### PR TITLE
fix: tray console flash loop — CREATE_NO_WINDOW in system_monitor

### DIFF
--- a/src-tauri/src/commands/system_monitor.rs
+++ b/src-tauri/src/commands/system_monitor.rs
@@ -1,6 +1,26 @@
 use serde::Serialize;
 use std::process::Command;
 
+// Su Windows, evita il flash della console nera per ogni spawn di processo figlio.
+// Senza questo flag, il polling periodico di get_system_stats() genera un loop
+// di finestre cmd che appaiono e scompaiono (bug tray icon).
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Costruisce un Command che su Windows non mostra la console figlia.
+fn no_window_command(program: &str) -> Command {
+    let cmd = Command::new(program);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        let mut cmd = cmd;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        return cmd;
+    }
+    #[cfg(not(target_os = "windows"))]
+    cmd
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct SystemStats {
     pub cpu_usage_percent: f64,
@@ -20,7 +40,7 @@ pub struct SystemStats {
 /// Ottieni statistiche GPU via nvidia-smi (NVIDIA) o fallback
 fn get_gpu_stats() -> (String, u64, u64, u64, f64, Option<f64>, bool) {
     // Prova nvidia-smi
-    if let Ok(output) = Command::new("nvidia-smi")
+    if let Ok(output) = no_window_command("nvidia-smi")
         .args(["--query-gpu=name,memory.total,memory.used,memory.free,utilization.gpu,temperature.gpu", "--format=csv,noheader,nounits"])
         .output()
     {
@@ -49,7 +69,7 @@ fn get_gpu_stats() -> (String, u64, u64, u64, f64, Option<f64>, bool) {
 fn get_ram_stats() -> (u64, u64) {
     #[cfg(target_os = "windows")]
     {
-        if let Ok(output) = Command::new("wmic")
+        if let Ok(output) = no_window_command("wmic")
             .args(["OS", "get", "TotalVisibleMemorySize,FreePhysicalMemory", "/format:csv"])
             .output()
         {
@@ -68,7 +88,7 @@ fn get_ram_stats() -> (u64, u64) {
             }
         }
         // Fallback PowerShell
-        if let Ok(output) = Command::new("powershell")
+        if let Ok(output) = no_window_command("powershell")
             .args(["-NoProfile", "-Command", "(Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize,FreePhysicalMemory | ConvertTo-Json)"])
             .output()
         {


### PR DESCRIPTION
## Summary
- `get_system_stats()` spawnava `nvidia-smi`, `wmic` e `powershell` senza il flag `CREATE_NO_WINDOW`, causando un flash di console nera ad ogni chiamata su Windows
- Il frontend invoca `get_system_stats` in polling continuo (`VramManager` ogni 10s, `components/tools/system-monitor.tsx` ogni 5s), producendo un loop di finestre cmd mentre l'app è minimizzata in tray
- Introduce un helper `no_window_command()` che applica `creation_flags(0x08000000)` su Windows; Linux/macOS invariati

## Root cause
Polling cronico lato frontend × `std::process::Command::new` senza il flag di nascondimento console.

Uscire dall'app dal menu della tray spegneva il processo Tauri → polling morto → flash fermo. Questo spiegava perché il bug "spariva" alla chiusura.

## Test plan
- [x] `cargo check` pulito (solo 4 warning preesistenti in `translation_bridge`)
- [x] `npm run tauri:dev` avvio dell'app desktop OK
- [x] Verificato manualmente che il flash loop è sparito con app minimizzata in tray

## Note
Altri 12 file in `src-tauri/src/commands/` usano ancora `Command::new` senza `CREATE_NO_WINDOW`. Non sono in polling quindi flashano solo durante azioni esplicite; verranno affrontati in un PR separato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)