### PR TITLE
feat: Unity Localization Package pipeline

### DIFF
--- a/app/unity-localization/page.tsx
+++ b/app/unity-localization/page.tsx
@@ -1,0 +1,1107 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Virtuoso } from "react-virtuoso";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  FolderOpen, Globe, Languages, CheckCircle2, XCircle, AlertCircle,
+  Loader2, Download, ArrowRight, Sparkles, Package, Search,
+  FileText, BookOpen, Braces, Shield, RefreshCw, Copy, ChevronRight
+} from "lucide-react";
+// import { useTranslation } from "@/lib/i18n";
+import {
+  type StringTableEntry,
+  type StringTableInfo,
+  type AddressablesCatalog,
+  type TranslatedEntry,
+  SUPPORTED_LOCALES,
+  getLocaleDisplayName,
+  detectStringTables,
+  loadAddressablesCatalog,
+  extractStringTable,
+  buildPatchedBundle,
+  translateStringTable,
+  validateAllTranslations,
+  exportTableToCSV,
+  exportTableToJSON,
+} from "@/lib/unity-localization";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+}
+
+/** Lightweight table summary for Step 2 (no entries loaded yet) */
+interface TableSummary {
+  tableName: string;
+  locale: string;
+  localeName: string;
+  entryCount: number;
+  smartCount: number;
+  bundlePath: string;
+  sizeBytes: number;
+}
+
+function tableToSummary(t: StringTableInfo): TableSummary {
+  return {
+    tableName: t.tableName,
+    locale: t.locale,
+    localeName: t.localeName,
+    entryCount: t.entries.length,
+    smartCount: t.entries.filter((e) => e.isSmart).length,
+    bundlePath: t.bundlePath,
+    sizeBytes: 0,
+  };
+}
+
+const ALL_LOCALE_CODES = Object.keys(SUPPORTED_LOCALES);
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function UnityLocalizationPage() {
+  // const { t } = useTranslation();
+
+  // Wizard state
+  const [step, setStep] = useState(1);
+  const [folderPath, setFolderPath] = useState("");
+  const [catalog, setCatalog] = useState<AddressablesCatalog | null>(null);
+  const [tableSummaries, setTableSummaries] = useState<TableSummary[]>([]);
+  const [loadedTable, setLoadedTable] = useState<StringTableInfo | null>(null);
+  const [entries, setEntries] = useState<StringTableEntry[]>([]);
+  const [sourceLocale, setSourceLocale] = useState("en");
+  const [targetLocale, setTargetLocale] = useState("it");
+  const [searchFilter, setSearchFilter] = useState("");
+  const [translating, setTranslating] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState("");
+  const [analyzing, setAnalyzing] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportResult, setExportResult] = useState("");
+  const [activeTab, setActiveTab] = useState("all");
+  const [validating, setValidating] = useState(false);
+  const [copiedFeedback, setCopiedFeedback] = useState(false);
+
+  // Ref for batch-update optimisation during translation
+  const entriesRef = useRef<StringTableEntry[]>([]);
+  entriesRef.current = entries;
+
+  // Load settings from localStorage
+  useEffect(() => {
+    const loadSettings = () => {
+      const saved = localStorage.getItem("gameStringerSettings");
+      if (saved) {
+        try {
+          const s = JSON.parse(saved);
+          if (s.translation?.defaultTargetLang) setTargetLocale(s.translation.defaultTargetLang);
+        } catch { /* ignore */ }
+      }
+    };
+    loadSettings();
+    window.addEventListener("focus", loadSettings);
+    return () => window.removeEventListener("focus", loadSettings);
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Step 1: Folder selection & analysis
+  // -----------------------------------------------------------------------
+
+  const handleSelectFolder = async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: "Seleziona cartella Unity Localization",
+      });
+      if (selected) {
+        setFolderPath(selected as string);
+        setTableSummaries([]);
+        setCatalog(null);
+        setLoadedTable(null);
+        setEntries([]);
+        setError("");
+        setStep(1);
+      }
+    } catch (e) {
+      console.error("Errore selezione cartella:", e);
+    }
+  };
+
+  const handleAnalyzeFolder = async () => {
+    if (!folderPath) return;
+    setAnalyzing(true);
+    setError("");
+
+    try {
+      // Detect string tables
+      const detected = await detectStringTables(folderPath);
+      setTableSummaries(detected.map(tableToSummary));
+
+      // Try loading addressables catalog (optional)
+      try {
+        const cat = await loadAddressablesCatalog(folderPath);
+        setCatalog(cat);
+        if (cat.locales.length > 0 && !cat.locales.includes(sourceLocale)) {
+          setSourceLocale(cat.locales[0]);
+        }
+      } catch {
+        // Catalog is not mandatory
+      }
+
+      if (detected.length > 0) {
+        setStep(2);
+      } else {
+        setError("Nessuna StringTable trovata nella cartella selezionata.");
+      }
+    } catch (e) {
+      setError(`Errore analisi: ${e}`);
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // Step 2: Select table & load entries
+  // -----------------------------------------------------------------------
+
+  const handleSelectTable = async (summary: TableSummary) => {
+    setError("");
+    try {
+      const tables = await extractStringTable(summary.bundlePath);
+      const match = tables.find((t) => t.tableName === summary.tableName) ?? tables[0];
+      if (!match) {
+        setError("Nessuna entry trovata nel bundle selezionato.");
+        return;
+      }
+      setLoadedTable(match);
+      setEntries(match.entries.map((e) => ({ ...e })));
+      setStep(3);
+    } catch (e) {
+      setError(`Errore caricamento tabella: ${e}`);
+    }
+  };
+
+  const availableLocales = useMemo(() => {
+    if (catalog && catalog.locales.length > 0) return catalog.locales;
+    const locales = new Set(tableSummaries.map((t) => t.locale));
+    return Array.from(locales);
+  }, [catalog, tableSummaries]);
+
+  // -----------------------------------------------------------------------
+  // Step 3: Translation editor
+  // -----------------------------------------------------------------------
+
+  const handleTranslateAll = async () => {
+    if (!loadedTable || entries.length === 0) return;
+    setTranslating(true);
+    setProgress(0);
+    setError("");
+
+    try {
+      // Build a temporary table with current entries for the service
+      const tableForTranslation: StringTableInfo = {
+        ...loadedTable,
+        entries: entries.map((e) => ({ ...e })),
+      };
+
+      const result = await translateStringTable(tableForTranslation, targetLocale, {
+        preserveSmartStrings: true,
+        batchSize: 20,
+      });
+
+      setEntries(result.entries);
+      setProgress(100);
+    } catch (e) {
+      setError(`Errore traduzione: ${e}`);
+    } finally {
+      setTranslating(false);
+    }
+  };
+
+  const handleEntryChange = useCallback((keyId: number, value: string) => {
+    setEntries((prev) =>
+      prev.map((e) =>
+        e.keyId === keyId
+          ? { ...e, translated: value, translationStatus: "pending" as const }
+          : e
+      )
+    );
+  }, []);
+
+  const handleValidateAll = async () => {
+    if (!loadedTable) return;
+    setValidating(true);
+    setError("");
+
+    try {
+      const tableForValidation: StringTableInfo = { ...loadedTable, entries };
+      const validations = await validateAllTranslations(tableForValidation);
+
+      setEntries((prev) =>
+        prev.map((entry, idx) => {
+          const v = validations[idx];
+          if (!v) return entry;
+          if (!v.valid) {
+            return {
+              ...entry,
+              translationStatus: "error" as const,
+              validationErrors: [
+                ...v.missingTokens.map((tk) => `Token mancante: ${tk}`),
+                ...v.extraTokens.map((tk) => `Token extra: ${tk}`),
+                ...v.warnings,
+              ],
+            };
+          }
+          if (v.warnings.length > 0) {
+            return { ...entry, translationStatus: "validated" as const, validationErrors: v.warnings };
+          }
+          return { ...entry, translationStatus: "validated" as const, validationErrors: [] };
+        })
+      );
+    } catch (e) {
+      setError(`Errore validazione: ${e}`);
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  // --- Filtering & stats (memoized) ---
+
+  const tabCounts = useMemo(() => {
+    let smart = 0, untranslated = 0, validated = 0;
+    for (const e of entries) {
+      if (e.isSmart) smart++;
+      if (!e.translated) untranslated++;
+      if (e.translationStatus === "validated" || e.translationStatus === "error") validated++;
+    }
+    return { all: entries.length, smart, untranslated, validated };
+  }, [entries]);
+
+  const stats = useMemo(() => {
+    let translated = 0, valid = 0, warnings = 0;
+    for (const e of entries) {
+      if (e.translated) translated++;
+      if (e.translationStatus === "validated") valid++;
+      if (e.translationStatus === "error") warnings++;
+    }
+    return { translated, valid, warnings };
+  }, [entries]);
+
+  const filteredEntries = useMemo(() => {
+    let filtered = entries;
+
+    if (activeTab === "smart") {
+      filtered = filtered.filter((e) => e.isSmart);
+    } else if (activeTab === "untranslated") {
+      filtered = filtered.filter((e) => !e.translated);
+    } else if (activeTab === "validated") {
+      filtered = filtered.filter(
+        (e) => e.translationStatus === "validated" || e.translationStatus === "error"
+      );
+    }
+
+    if (searchFilter.trim()) {
+      const q = searchFilter.toLowerCase();
+      filtered = filtered.filter(
+        (e) =>
+          e.keyName.toLowerCase().includes(q) ||
+          e.value.toLowerCase().includes(q) ||
+          (e.translated && e.translated.toLowerCase().includes(q))
+      );
+    }
+
+    return filtered;
+  }, [entries, activeTab, searchFilter]);
+
+  // -----------------------------------------------------------------------
+  // Step 4: Export & patch
+  // -----------------------------------------------------------------------
+
+  const handleExportPatchedBundle = async () => {
+    if (!loadedTable) return;
+    setExporting(true);
+    setError("");
+    try {
+      const translations: TranslatedEntry[] = entries
+        .filter((e) => e.translated)
+        .map((e) => ({ keyId: e.keyId, translated: e.translated! }));
+
+      const outputPath = loadedTable.bundlePath.replace(/(\.\w+)$/, `_${targetLocale}$1`);
+      const result = await buildPatchedBundle(loadedTable.bundlePath, translations, outputPath);
+
+      if (result.success) {
+        setExportResult(result.outputPath);
+        setStep(4);
+      } else {
+        setError(result.message);
+      }
+    } catch (e) {
+      setError(`Errore creazione bundle: ${e}`);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleExportCSV = () => {
+    if (!loadedTable) return;
+    const tableForExport: StringTableInfo = { ...loadedTable, entries };
+    const csv = exportTableToCSV(tableForExport);
+    downloadFile(csv, `${loadedTable.tableName}_${targetLocale}.csv`, "text/csv");
+    setExportResult(`CSV esportato: ${loadedTable.tableName}_${targetLocale}.csv`);
+    setStep(4);
+  };
+
+  const handleExportJSON = () => {
+    if (!loadedTable) return;
+    const tableForExport: StringTableInfo = { ...loadedTable, entries };
+    const json = exportTableToJSON(tableForExport);
+    downloadFile(json, `${loadedTable.tableName}_${targetLocale}.json`, "application/json");
+    setExportResult(`JSON esportato: ${loadedTable.tableName}_${targetLocale}.json`);
+    setStep(4);
+  };
+
+  const handleCopyAll = async () => {
+    const text = entries
+      .map((e) => `${e.keyName}\t${e.value}\t${e.translated ?? ""}`)
+      .join("\n");
+    await navigator.clipboard.writeText(text);
+    setCopiedFeedback(true);
+    setTimeout(() => setCopiedFeedback(false), 2000);
+  };
+
+  // -----------------------------------------------------------------------
+  // UI helpers
+  // -----------------------------------------------------------------------
+
+  const validationIcon = (entry: StringTableEntry) => {
+    switch (entry.translationStatus) {
+      case "validated":
+        return <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />;
+      case "error":
+        return (
+          <span title={entry.validationErrors?.join("\n")}>
+            <XCircle className="h-4 w-4 text-red-400 shrink-0" />
+          </span>
+        );
+      default:
+        return entry.translated ? (
+          <AlertCircle className="h-4 w-4 text-yellow-400/60 shrink-0" />
+        ) : null;
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-120px)] px-4 gap-4 overflow-y-auto">
+      {/* ── Hero Header ─────────────────────────────────────────── */}
+      <div className="relative overflow-hidden rounded-xl bg-gradient-to-br from-cyan-700 via-teal-600 to-emerald-700 p-4 shrink-0">
+        <div className="absolute inset-0 bg-[url('/grid.svg')] opacity-10" />
+        <div className="absolute top-0 right-0 w-32 h-32 bg-white/10 rounded-full blur-2xl -translate-y-1/2 translate-x-1/2" />
+
+        <div className="relative flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 bg-black/30 rounded-lg shadow-lg shadow-black/40 border border-white/10">
+              <Globe className="h-6 w-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-lg font-bold text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.7)]">
+                Unity Localization Package
+              </h1>
+              <p className="text-white/70 text-xs drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
+                StringTable, Smart Strings e cataloghi Addressables
+              </p>
+            </div>
+          </div>
+
+          <div className="hidden md:flex items-center gap-3">
+            <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/30 shadow-lg shadow-black/40 border border-white/10">
+              <Braces className="h-3.5 w-3.5 text-white" />
+              <span className="text-sm font-bold text-white">Smart</span>
+              <span className="text-xs text-white/70">Strings</span>
+            </div>
+            <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/30 shadow-lg shadow-black/40 border border-white/10">
+              <Languages className="h-3.5 w-3.5 text-white" />
+              <span className="text-sm font-bold text-white">AI</span>
+              <span className="text-xs text-white/70">Traduzione</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Error banner ────────────────────────────────────────── */}
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-400 p-3 rounded-lg text-sm flex items-center gap-2 shrink-0">
+          <XCircle className="h-4 w-4 shrink-0" />
+          <span className="min-w-0 break-words">{error}</span>
+          <button onClick={() => setError("")} className="ml-auto text-red-400/60 hover:text-red-300">
+            <XCircle className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+
+      {/* ── Stepper ─────────────────────────────────────────────── */}
+      <div className="flex items-center justify-center gap-1 py-2 shrink-0">
+        {[
+          { num: 1, label: "Seleziona" },
+          { num: 2, label: "Catalogo" },
+          { num: 3, label: "Traduci" },
+          { num: 4, label: "Esporta" },
+        ].map((s, idx) => (
+          <div key={s.num} className="flex items-center">
+            <button
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs transition-all focus:outline-none focus:ring-2 focus:ring-cyan-400/50 ${
+                step >= s.num
+                  ? "bg-cyan-600 text-white"
+                  : "bg-slate-800/50 text-slate-500 border border-slate-700/50"
+              } ${s.num < step ? "cursor-pointer hover:bg-cyan-500" : s.num > step ? "cursor-default" : ""}`}
+              onClick={() => { if (s.num < step) setStep(s.num); }}
+              tabIndex={s.num < step ? 0 : -1}
+              aria-label={`Passo ${s.num}: ${s.label}`}
+            >
+              <span className="font-bold">{s.num}</span>
+              <span>{s.label}</span>
+            </button>
+            {idx < 3 && <ArrowRight className="h-3 w-3 mx-1 text-slate-600" />}
+          </div>
+        ))}
+      </div>
+
+      {/* ================================================================= */}
+      {/* STEP 1: Folder Selection                                          */}
+      {/* ================================================================= */}
+      {step === 1 && (
+        <div className="space-y-4">
+          {/* Feature cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            {[
+              {
+                icon: FileText,
+                title: "StringTable",
+                desc: "Rileva e carica automaticamente tutte le StringTable (.asset) del progetto Unity, con supporto chiavi e valori multilingua.",
+              },
+              {
+                icon: Braces,
+                title: "Smart Strings",
+                desc: "Supporto completo per Smart Strings: parsing dei token, validazione dei placeholder e traduzione intelligente.",
+              },
+              {
+                icon: Package,
+                title: "Addressables",
+                desc: "Analisi del catalogo Addressables per individuare bundle di localizzazione e statistiche di copertura.",
+              },
+            ].map((card) => (
+              <Card key={card.title} variant="muted">
+                <CardHeader className="py-3 px-4">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <card.icon className="h-4 w-4 text-cyan-400" />
+                    {card.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-4 pb-4">
+                  <p className="text-xs text-slate-400 leading-relaxed">{card.desc}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {/* Folder picker */}
+          <Card variant="muted">
+            <CardHeader className="py-3 px-4">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <FolderOpen className="h-4 w-4 text-cyan-400" />
+                Seleziona Cartella Progetto
+              </CardTitle>
+              <CardDescription className="text-xs">
+                Scegli la cartella contenente i file di localizzazione Unity (StreamingAssets, Localization, ecc.)
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="px-4 pb-4 space-y-3">
+              <div className="flex gap-2">
+                <Button onClick={handleSelectFolder} variant="outline" size="sm" className="h-9 text-xs">
+                  <FolderOpen className="mr-1.5 h-3.5 w-3.5" />
+                  Sfoglia...
+                </Button>
+                <Button
+                  onClick={handleAnalyzeFolder}
+                  disabled={!folderPath || analyzing}
+                  size="sm"
+                  className="h-9 bg-cyan-600 hover:bg-cyan-500 text-xs"
+                >
+                  {analyzing ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Search className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  Analizza
+                </Button>
+              </div>
+
+              {folderPath && (
+                <p
+                  className="text-xs text-slate-400 font-mono bg-slate-950/50 p-2 rounded truncate border border-slate-800/50"
+                  title={folderPath}
+                >
+                  {folderPath}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ================================================================= */}
+      {/* STEP 2: Catalog Overview                                          */}
+      {/* ================================================================= */}
+      {step === 2 && (
+        <div className="space-y-4">
+          {/* Locale badges + selectors */}
+          <Card variant="muted">
+            <CardHeader className="py-3 px-4">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <Globe className="h-4 w-4 text-cyan-400" />
+                Locale Rilevati
+                {catalog && (
+                  <Badge variant="outline" className="ml-auto text-xs">
+                    {catalog.tables.length} tabelle
+                  </Badge>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="px-4 pb-4 space-y-3">
+              {/* Locale badges */}
+              <div className="flex flex-wrap gap-1.5">
+                {availableLocales.map((loc) => (
+                  <Badge
+                    key={loc}
+                    className="text-xs bg-cyan-500/20 text-cyan-400 border-cyan-500/30 hover:bg-cyan-500/30"
+                  >
+                    {getLocaleDisplayName(loc)} ({loc})
+                  </Badge>
+                ))}
+              </div>
+
+              {/* Source / Target selectors */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-400 font-medium uppercase tracking-wider">
+                    Lingua sorgente
+                  </label>
+                  <Select value={sourceLocale} onValueChange={setSourceLocale}>
+                    <SelectTrigger className="h-9 text-xs bg-slate-950/50 border-slate-700/50">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableLocales.map((loc) => (
+                        <SelectItem key={loc} value={loc} className="text-xs">
+                          {getLocaleDisplayName(loc)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-400 font-medium uppercase tracking-wider">
+                    Lingua target
+                  </label>
+                  <Select value={targetLocale} onValueChange={setTargetLocale}>
+                    <SelectTrigger className="h-9 text-xs bg-slate-950/50 border-slate-700/50">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ALL_LOCALE_CODES.map((loc) => (
+                        <SelectItem key={loc} value={loc} className="text-xs">
+                          {getLocaleDisplayName(loc)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Table list */}
+          <Card variant="muted">
+            <CardHeader className="py-3 px-4">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <BookOpen className="h-4 w-4 text-cyan-400" />
+                  StringTable ({tableSummaries.length})
+                </CardTitle>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 text-xs"
+                  onClick={handleAnalyzeFolder}
+                  disabled={analyzing}
+                >
+                  {analyzing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                  <span className="ml-1.5">Ricarica</span>
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              <div className="space-y-2 max-h-[400px] overflow-y-auto pr-1">
+                {tableSummaries.map((table, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => handleSelectTable(table)}
+                    className="group w-full text-left p-3 rounded-lg border transition-all hover:bg-slate-800/50 border-slate-800/30 hover:border-slate-700/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/50"
+                    tabIndex={0}
+                  >
+                    <div className="flex items-center justify-between mb-1.5">
+                      <div className="flex items-center gap-2">
+                        <FileText className="h-4 w-4 text-cyan-400" />
+                        <span className="text-sm font-medium text-slate-200">{table.tableName}</span>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-slate-600 group-hover:text-slate-400 transition-colors" />
+                    </div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant="outline" className="text-xs px-1.5 py-0.5">
+                        {table.locale.toUpperCase()}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs px-1.5 py-0.5">
+                        {table.entryCount} chiavi
+                      </Badge>
+                      {table.smartCount > 0 && (
+                        <Badge className="text-xs px-1.5 py-0.5 bg-cyan-500/20 text-cyan-400 border-cyan-500/30">
+                          <Braces className="h-3 w-3 mr-0.5" />
+                          {table.smartCount} smart
+                        </Badge>
+                      )}
+                      {table.sizeBytes > 0 && (
+                        <span className="text-xs text-slate-500 ml-auto">{formatBytes(table.sizeBytes)}</span>
+                      )}
+                    </div>
+                  </button>
+                ))}
+
+                {tableSummaries.length === 0 && (
+                  <p className="text-sm text-slate-500 text-center py-8">
+                    Nessuna StringTable trovata
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ================================================================= */}
+      {/* STEP 3: Translation Editor                                        */}
+      {/* ================================================================= */}
+      {step === 3 && loadedTable && (
+        <div className="flex flex-col gap-3 flex-1 min-h-0">
+          {/* Top bar */}
+          <Card variant="muted" className="shrink-0">
+            <CardContent className="px-4 py-3">
+              <div className="flex items-center gap-3 flex-wrap">
+                <div className="flex items-center gap-2">
+                  <FileText className="h-4 w-4 text-cyan-400" />
+                  <span className="text-sm font-semibold text-slate-200">{loadedTable.tableName}</span>
+                </div>
+
+                <div className="flex items-center gap-1.5">
+                  <Badge className="text-xs bg-slate-700/50 text-slate-300">
+                    {sourceLocale.toUpperCase()}
+                  </Badge>
+                  <ArrowRight className="h-3 w-3 text-slate-500" />
+                  <Badge className="text-xs bg-cyan-500/20 text-cyan-400 border-cyan-500/30">
+                    {targetLocale.toUpperCase()}
+                  </Badge>
+                </div>
+
+                <div className="relative ml-auto flex-1 max-w-xs">
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-slate-500" />
+                  <Input
+                    value={searchFilter}
+                    onChange={(e) => setSearchFilter(e.target.value)}
+                    aria-label="Cerca" placeholder="Cerca chiave o valore..."
+                    className="h-9 text-xs pl-8 bg-slate-950/50 border-slate-700/50"
+                  />
+                </div>
+
+                <Button
+                  onClick={handleTranslateAll}
+                  disabled={translating || entries.length === 0}
+                  size="sm"
+                  className="h-9 text-xs bg-emerald-600 hover:bg-emerald-500"
+                >
+                  {translating ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  Traduci Tutto
+                </Button>
+              </div>
+
+              {translating && (
+                <div className="mt-2 space-y-1">
+                  <Progress value={progress} className="h-1.5" />
+                  <p className="text-xs text-center text-slate-400">{progress}%</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Tabs + Virtualized entry list */}
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-col flex-1 min-h-0">
+            <TabsList className="bg-slate-900/50 border border-slate-800/50 shrink-0">
+              <TabsTrigger value="all" className="text-xs">
+                Tutte ({tabCounts.all})
+              </TabsTrigger>
+              <TabsTrigger value="smart" className="text-xs">
+                <Braces className="h-3 w-3 mr-1" />
+                Smart ({tabCounts.smart})
+              </TabsTrigger>
+              <TabsTrigger value="untranslated" className="text-xs">
+                Da tradurre ({tabCounts.untranslated})
+              </TabsTrigger>
+              <TabsTrigger value="validated" className="text-xs">
+                <Shield className="h-3 w-3 mr-1" />
+                Validati ({tabCounts.validated})
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value={activeTab} className="flex-1 min-h-0 mt-2">
+              <div className="h-[calc(100vh-440px)] rounded-lg border border-slate-800/50 bg-slate-950/30 overflow-hidden">
+                {filteredEntries.length > 0 ? (
+                  <Virtuoso
+                    data={filteredEntries}
+                    overscan={200}
+                    itemContent={(index, entry) => (
+                      <EntryRow
+                        key={entry.keyId}
+                        entry={entry}
+                        onChange={handleEntryChange}
+                        validationIcon={validationIcon}
+                      />
+                    )}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-full text-sm text-slate-500">
+                    Nessun risultato trovato
+                  </div>
+                )}
+              </div>
+            </TabsContent>
+          </Tabs>
+
+          {/* Bottom bar */}
+          <Card variant="muted" className="shrink-0">
+            <CardContent className="px-4 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4 text-xs text-slate-400">
+                  <span>
+                    <span className="text-emerald-400 font-semibold">{stats.translated}</span>
+                    /{entries.length} tradotte
+                  </span>
+                  {stats.valid > 0 && (
+                    <span className="flex items-center gap-1">
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" />
+                      {stats.valid} valide
+                    </span>
+                  )}
+                  {stats.warnings > 0 && (
+                    <span className="flex items-center gap-1">
+                      <AlertCircle className="h-3.5 w-3.5 text-yellow-400" />
+                      {stats.warnings} avvisi
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-9 text-xs"
+                    onClick={handleValidateAll}
+                    disabled={validating || stats.translated === 0}
+                  >
+                    {validating ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Shield className="mr-1.5 h-3.5 w-3.5" />
+                    )}
+                    Valida Tutto
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="h-9 text-xs bg-cyan-600 hover:bg-cyan-500"
+                    onClick={() => setStep(4)}
+                    disabled={stats.translated === 0}
+                  >
+                    Esporta
+                    <ChevronRight className="ml-1.5 h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* ================================================================= */}
+      {/* STEP 4: Export & Patch                                             */}
+      {/* ================================================================= */}
+      {step === 4 && (
+        <div className="space-y-4">
+          {/* Summary */}
+          <Card variant="muted">
+            <CardHeader className="py-3 px-4">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                Riepilogo Traduzione
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              <div className="grid grid-cols-3 gap-3">
+                <div className="p-3 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-center">
+                  <p className="text-2xl font-bold text-emerald-400">{stats.translated}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">Entries tradotte</p>
+                </div>
+                <div className="p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
+                  <p className="text-2xl font-bold text-cyan-400">{stats.valid}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">Validate</p>
+                </div>
+                <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+                  <p className="text-2xl font-bold text-yellow-400">{stats.warnings}</p>
+                  <p className="text-xs text-slate-400 mt-0.5">Avvisi</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Export options */}
+          <Card variant="muted">
+            <CardHeader className="py-3 px-4">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <Download className="h-4 w-4 text-cyan-400" />
+                Opzioni di Esportazione
+              </CardTitle>
+              {loadedTable && (
+                <CardDescription className="text-xs">
+                  {loadedTable.tableName} &mdash; {getLocaleDisplayName(sourceLocale)} &rarr; {getLocaleDisplayName(targetLocale)}
+                </CardDescription>
+              )}
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                <Button
+                  onClick={handleExportPatchedBundle}
+                  disabled={exporting}
+                  className="h-auto py-3 flex flex-col items-center gap-1.5 bg-cyan-600 hover:bg-cyan-500 text-xs"
+                >
+                  {exporting ? <Loader2 className="h-5 w-5 animate-spin" /> : <Package className="h-5 w-5" />}
+                  <span className="font-medium">Bundle Patchato</span>
+                  <span className="text-2xs text-cyan-200/70">Pronto per Unity</span>
+                </Button>
+
+                <Button
+                  onClick={handleExportCSV}
+                  disabled={exporting}
+                  variant="outline"
+                  className="h-auto py-3 flex flex-col items-center gap-1.5 text-xs"
+                >
+                  <FileText className="h-5 w-5" />
+                  <span className="font-medium">Esporta CSV</span>
+                  <span className="text-2xs text-slate-400">Foglio di calcolo</span>
+                </Button>
+
+                <Button
+                  onClick={handleExportJSON}
+                  disabled={exporting}
+                  variant="outline"
+                  className="h-auto py-3 flex flex-col items-center gap-1.5 text-xs"
+                >
+                  <Braces className="h-5 w-5" />
+                  <span className="font-medium">Esporta JSON</span>
+                  <span className="text-2xs text-slate-400">Strutturato</span>
+                </Button>
+
+                <Button
+                  onClick={handleCopyAll}
+                  variant="outline"
+                  className="h-auto py-3 flex flex-col items-center gap-1.5 text-xs"
+                >
+                  {copiedFeedback ? <CheckCircle2 className="h-5 w-5 text-emerald-400" /> : <Copy className="h-5 w-5" />}
+                  <span className="font-medium">{copiedFeedback ? "Copiato!" : "Copia Tutto"}</span>
+                  <span className="text-2xs text-slate-400">Negli appunti</span>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Export result */}
+          {exportResult && (
+            <Card className="border-emerald-500/30 bg-emerald-500/5">
+              <CardContent className="px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-emerald-400">Esportazione completata</p>
+                    <p className="text-xs text-slate-400 font-mono truncate mt-0.5" title={exportResult}>
+                      {exportResult}
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Back button */}
+          <div className="flex justify-center">
+            <Button variant="outline" size="sm" className="h-9 text-xs" onClick={() => setStep(3)}>
+              <ArrowRight className="h-3.5 w-3.5 mr-1.5 rotate-180" />
+              Torna all&apos;Editor
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EntryRow — memoized row component for Virtuoso
+// ---------------------------------------------------------------------------
+
+import React from "react";
+
+const EntryRow = React.memo(function EntryRow({
+  entry,
+  onChange,
+  validationIcon,
+}: {
+  entry: StringTableEntry;
+  onChange: (keyId: number, value: string) => void;
+  validationIcon: (entry: StringTableEntry) => React.ReactNode;
+}) {
+  const isLong = entry.value.length > 80;
+
+  return (
+    <div className="flex flex-col gap-1.5 px-4 py-3 border-b border-slate-800/40 hover:bg-slate-800/20 transition-colors">
+      {/* Key name + smart badge */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-500 font-mono truncate max-w-[280px]" title={entry.keyName}>
+          {entry.keyName}
+        </span>
+        {entry.isSmart && (
+          <Badge className="text-2xs px-1.5 py-0 bg-cyan-500/20 text-cyan-400 border-cyan-500/30">
+            <Braces className="h-2.5 w-2.5 mr-0.5" />
+            smart
+          </Badge>
+        )}
+        <span className="ml-auto">{validationIcon(entry)}</span>
+      </div>
+
+      {/* Content: stacked for long text, side-by-side for short */}
+      <div className={isLong ? "flex flex-col gap-1.5" : "flex items-start gap-3"}>
+        {/* Original value */}
+        <div className={`${isLong ? "w-full" : "flex-1"} min-w-0`}>
+          <p className="text-xs text-slate-300 leading-relaxed break-words">
+            {entry.isSmart ? renderSmartTokens(entry.value, entry.smartTokens) : entry.value}
+          </p>
+        </div>
+
+        {/* Translation input */}
+        <div className={`${isLong ? "w-full" : "flex-1"} min-w-0`}>
+          <Input
+            value={entry.translated ?? ""}
+            onChange={(e) => onChange(entry.keyId, e.target.value)}
+            placeholder="Traduzione..."
+            className="h-8 text-xs bg-slate-950/50 border-slate-700/50 w-full"
+          />
+        </div>
+      </div>
+
+      {/* Validation errors */}
+      {entry.validationErrors && entry.validationErrors.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {entry.validationErrors.map((err, i) => (
+            <span key={i} className="text-2xs text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded">
+              {err}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Smart String renderer: literal text + token badges
+// ---------------------------------------------------------------------------
+
+function renderSmartTokens(
+  value: string,
+  tokens: { tokenType: string; raw: string; inner?: string }[]
+): React.ReactNode {
+  if (!tokens || tokens.length === 0) return value;
+
+  const parts: React.ReactNode[] = [];
+  let remaining = value;
+  let keyIdx = 0;
+
+  for (const token of tokens) {
+    if (token.tokenType === "literal") continue; // skip literals, they're the surrounding text
+
+    const idx = remaining.indexOf(token.raw);
+    if (idx === -1) continue;
+
+    if (idx > 0) {
+      parts.push(<span key={`t-${keyIdx++}`}>{remaining.slice(0, idx)}</span>);
+    }
+
+    parts.push(
+      <span
+        key={`tk-${keyIdx++}`}
+        className="inline-flex items-center bg-cyan-500/20 text-cyan-400 rounded px-1 font-mono text-2xs mx-0.5 align-middle"
+        title={`${token.tokenType}: ${token.inner ?? token.raw}`}
+      >
+        {token.raw}
+      </span>
+    );
+
+    remaining = remaining.slice(idx + token.raw.length);
+  }
+
+  if (remaining) {
+    parts.push(<span key={`t-${keyIdx}`}>{remaining}</span>);
+  }
+
+  return <>{parts}</>;
+}
+
+// ---------------------------------------------------------------------------
+// File download helper
+// ---------------------------------------------------------------------------
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -176,6 +176,7 @@ const getNavGroups = (t: (key: string) => string) => [
         icon: Wand2,
         subItems: [
           { name: 'Unity', href: '/unity-patcher', icon: Wand2 },
+          { name: 'Unity Localization', href: '/unity-localization', icon: Globe },
           { name: 'Unreal Engine', href: '/unreal-translator', icon: Cpu },
           { name: 'Godot', href: '/godot-translator', icon: Globe },
           { name: 'RPG Maker', href: '/rpgmaker-patcher', icon: Gamepad2 },

--- a/lib/tools-registry.ts
+++ b/lib/tools-registry.ts
@@ -388,6 +388,23 @@ export function getToolsRegistry(): ToolDefinition[] {
       ],
     },
     {
+      id: 'unity-localization',
+      href: '/unity-localization',
+      name: 'Unity Localization',
+      icon: Globe,
+      color: 'emerald',
+      category: 'tools',
+      subcategory: 'patcher',
+      features: [
+        'Supporto nativo Unity Localization Package',
+        'Parsing StringTable e SharedTableData',
+        'Preservazione Smart Strings ({variabili})',
+        'Lettura catalogo Addressables',
+      ],
+      addedInVersion: '1.6.0',
+      isNew: true,
+    },
+    {
       id: 'bethesda-patcher',
       href: '/bethesda-patcher',
       name: 'Bethesda Patcher',

--- a/lib/unity-localization.ts
+++ b/lib/unity-localization.ts
@@ -1,0 +1,665 @@
+// Unity Localization Package Support
+// Native parsing di StringTable, Addressables catalog e Smart Strings
+
+// ═══════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════
+
+export interface SmartToken {
+  tokenType: string;  // "literal" | "variable" | "formatter" | "plural" | "nested"
+  raw: string;
+  inner?: string;
+}
+
+export interface StringTableEntry {
+  keyId: number;
+  keyName: string;
+  value: string;
+  isSmart: boolean;
+  smartTokens: SmartToken[];
+  metadata?: string;
+  // Frontend-only fields
+  translated?: string;
+  translationStatus?: 'pending' | 'translated' | 'validated' | 'error';
+  validationErrors?: string[];
+}
+
+export interface StringTableInfo {
+  tableName: string;
+  tableId: string;
+  locale: string;
+  localeName: string;
+  entries: StringTableEntry[];
+  bundlePath: string;
+  assetPath: string;
+}
+
+export interface AddressablesCatalog {
+  locales: string[];
+  tables: CatalogTableRef[];
+  bundles: CatalogBundleRef[];
+}
+
+export interface CatalogTableRef {
+  tableName: string;
+  locale: string;
+  bundleFilename: string;
+  internalId: string;
+}
+
+export interface CatalogBundleRef {
+  internalId: string;
+  bundlePath: string;
+  dependencies: string[];
+}
+
+export interface SmartStringValidation {
+  valid: boolean;
+  missingTokens: string[];
+  extraTokens: string[];
+  warnings: string[];
+}
+
+export interface TranslatedEntry {
+  keyId: number;
+  translated: string;
+}
+
+export interface PatchResult {
+  success: boolean;
+  outputPath: string;
+  entriesPatched: number;
+  message: string;
+}
+
+export interface TranslateOptions {
+  provider?: string;
+  model?: string;
+  preserveSmartStrings?: boolean;
+  batchSize?: number;
+  context?: string;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// LOCALE MAP
+// ═══════════════════════════════════════════════════════════════════
+
+/** Full locale code → display name map */
+export const SUPPORTED_LOCALES: Record<string, string> = {
+  en: 'English',
+  it: 'Italiano',
+  fr: 'Français',
+  de: 'Deutsch',
+  es: 'Español',
+  pt: 'Português',
+  'pt-BR': 'Português (Brasil)',
+  ru: 'Русский',
+  ja: '日本語',
+  ko: '한국어',
+  'zh-CN': '中文(简体)',
+  'zh-TW': '中文(繁體)',
+  ar: 'العربية',
+  pl: 'Polski',
+  nl: 'Nederlands',
+  sv: 'Svenska',
+  da: 'Dansk',
+  fi: 'Suomi',
+  nb: 'Norsk Bokmål',
+  tr: 'Türkçe',
+  cs: 'Čeština',
+  hu: 'Magyar',
+  ro: 'Română',
+  el: 'Ελληνικά',
+  th: 'ไทย',
+  vi: 'Tiếng Việt',
+  id: 'Bahasa Indonesia',
+  uk: 'Українська',
+  hi: 'हिन्दी',
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// TAURI COMMAND WRAPPER
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Invoke a Tauri backend command.
+ * Uses dynamic import so this module can be loaded in SSR / test contexts
+ * without crashing when `@tauri-apps/api` is unavailable.
+ */
+async function invokeCommand<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<T>(cmd, args);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// TAURI COMMAND WRAPPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Parse an Addressables catalog.json to discover locales, table refs and bundles.
+ */
+export async function loadAddressablesCatalog(catalogPath: string): Promise<AddressablesCatalog> {
+  return invokeCommand<AddressablesCatalog>('parse_addressables_catalog', { catalogPath });
+}
+
+/**
+ * Detect all StringTable bundles in a folder (recursive).
+ * Useful when the user points at a StreamingAssets or build output folder.
+ */
+export async function detectStringTables(folderPath: string): Promise<StringTableInfo[]> {
+  return invokeCommand<StringTableInfo[]>('detect_string_tables_in_folder', { folderPath });
+}
+
+/**
+ * Extract entries from a single AssetBundle that contains a StringTable.
+ * Returns one StringTableInfo per locale table found in the bundle.
+ */
+export async function extractStringTable(bundlePath: string): Promise<StringTableInfo[]> {
+  return invokeCommand<StringTableInfo[]>('extract_string_table', { bundlePath });
+}
+
+/**
+ * Build a patched AssetBundle by replacing translated entries.
+ * The Rust side copies the original bundle, swaps serialized values and writes outputPath.
+ */
+export async function buildPatchedBundle(
+  originalBundle: string,
+  translations: TranslatedEntry[],
+  outputPath: string,
+): Promise<PatchResult> {
+  return invokeCommand<PatchResult>('build_patched_bundle', {
+    originalBundle,
+    translations,
+    outputPath,
+  });
+}
+
+/**
+ * Validate that a translated Smart String preserves all variable/formatter tokens.
+ * Delegates to the Rust parser for an authoritative check.
+ */
+export async function validateSmartTranslation(
+  original: string,
+  translated: string,
+): Promise<SmartStringValidation> {
+  return invokeCommand<SmartStringValidation>('validate_smart_string_translation', {
+    original,
+    translated,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CLIENT-SIDE SMART STRING HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Quick check: does the text contain un-escaped `{...}` patterns?
+ * Escaped braces `\{` are ignored.
+ */
+export function isSmartString(text: string): boolean {
+  // Match `{` that is NOT preceded by `\`
+  return /(?<!\\)\{[^}]+\}/.test(text);
+}
+
+/**
+ * Client-side tokenizer that mirrors the Rust smart-string parser.
+ *
+ * Token types:
+ *   literal    – plain translatable text between tokens
+ *   variable   – {variableName}
+ *   formatter  – {variableName:FormatterName(...)}
+ *   plural     – {variableName:plural:...}
+ *   nested     – {variableName:{nestedRef}}
+ */
+export function extractSmartTokens(text: string): SmartToken[] {
+  const tokens: SmartToken[] = [];
+  let pos = 0;
+
+  while (pos < text.length) {
+    // Find next un-escaped opening brace
+    const braceIdx = findUnescapedBrace(text, pos);
+
+    // Everything before the brace is a literal
+    if (braceIdx === -1) {
+      const literal = text.slice(pos);
+      if (literal.length > 0) {
+        tokens.push({ tokenType: 'literal', raw: literal });
+      }
+      break;
+    }
+
+    if (braceIdx > pos) {
+      tokens.push({ tokenType: 'literal', raw: text.slice(pos, braceIdx) });
+    }
+
+    // Find matching closing brace (respects nesting)
+    const closeIdx = findMatchingClose(text, braceIdx);
+    if (closeIdx === -1) {
+      // Unbalanced brace – treat rest as literal
+      tokens.push({ tokenType: 'literal', raw: text.slice(braceIdx) });
+      break;
+    }
+
+    const raw = text.slice(braceIdx, closeIdx + 1);
+    const inner = text.slice(braceIdx + 1, closeIdx);
+
+    tokens.push({ tokenType: classifyToken(inner), raw, inner });
+    pos = closeIdx + 1;
+  }
+
+  return tokens;
+}
+
+/** Find index of next `{` that is not escaped with `\`. Returns -1 if none. */
+function findUnescapedBrace(text: string, from: number): number {
+  for (let i = from; i < text.length; i++) {
+    if (text[i] === '{' && (i === 0 || text[i - 1] !== '\\')) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Find matching `}` respecting nested `{...}`. */
+function findMatchingClose(text: string, openIdx: number): number {
+  let depth = 0;
+  for (let i = openIdx; i < text.length; i++) {
+    if (text[i] === '\\') {
+      i++; // skip escaped char
+      continue;
+    }
+    if (text[i] === '{') depth++;
+    if (text[i] === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Classify the content between braces into a token type. */
+function classifyToken(inner: string): string {
+  if (inner.includes('{')) return 'nested';
+  if (/:plural:/i.test(inner)) return 'plural';
+  if (inner.includes(':')) return 'formatter';
+  return 'variable';
+}
+
+/**
+ * Reconstruct a Smart String: keeps variable/formatter/plural/nested tokens
+ * in place, replaces literal tokens with translated text.
+ *
+ * @param tokens   – original token list from extractSmartTokens
+ * @param translatedLiterals – translations for the literal tokens, in order
+ */
+export function rebuildSmartString(tokens: SmartToken[], translatedLiterals: string[]): string {
+  let litIdx = 0;
+  return tokens
+    .map((t) => {
+      if (t.tokenType === 'literal') {
+        return litIdx < translatedLiterals.length ? translatedLiterals[litIdx++] : t.raw;
+      }
+      // Non-literal tokens are preserved verbatim
+      return t.raw;
+    })
+    .join('');
+}
+
+/**
+ * Extract only the translatable literal portions from a Smart String.
+ * Useful for sending just the prose to the translation engine.
+ */
+export function getSmartStringLiterals(text: string): string[] {
+  return extractSmartTokens(text)
+    .filter((t) => t.tokenType === 'literal')
+    .map((t) => t.raw);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// TRANSLATION ORCHESTRATION
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Translate an entire StringTable into the target locale.
+ *
+ * Strategy:
+ *  - Plain entries are batched together for efficient bulk translation.
+ *  - Smart-string entries are decomposed: only literal fragments are sent
+ *    to the translation engine, then reassembled preserving tokens.
+ *  - All smart translations are validated against the original token set.
+ *
+ * Returns a new StringTableInfo with `translated` and `translationStatus`
+ * fields populated on each entry.
+ */
+export async function translateStringTable(
+  table: StringTableInfo,
+  targetLocale: string,
+  options?: TranslateOptions,
+): Promise<StringTableInfo> {
+  const { translateWithFallback } = await import('@/lib/ai-translate-direct');
+
+  const batchSize = options?.batchSize ?? 20;
+  const preserveSmart = options?.preserveSmartStrings ?? true;
+
+  // Deep-clone entries so we don't mutate the original
+  const entries: StringTableEntry[] = table.entries.map((e) => ({ ...e }));
+
+  // Split into plain vs smart
+  const plainEntries = entries.filter((e) => !e.isSmart);
+  const smartEntries = entries.filter((e) => e.isSmart);
+
+  // ── Plain entries: batch translate ──────────────────────────
+  for (let i = 0; i < plainEntries.length; i += batchSize) {
+    const batch = plainEntries.slice(i, i + batchSize);
+    const texts = batch.map((e) => e.value);
+
+    try {
+      const result = await translateWithFallback({
+        texts,
+        sourceLanguage: table.locale,
+        targetLanguage: targetLocale,
+        context: options?.context,
+        provider: options?.provider,
+        model: options?.model,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const translated = result.translations ?? result.results ?? [];
+      batch.forEach((entry, idx) => {
+        entry.translated = translated[idx] ?? '';
+        entry.translationStatus = translated[idx] ? 'translated' : 'error';
+      });
+    } catch (err) {
+      batch.forEach((entry) => {
+        entry.translationStatus = 'error';
+        entry.validationErrors = [(err as Error).message];
+      });
+    }
+  }
+
+  // ── Smart entries: decompose, translate literals, reassemble ─
+  if (preserveSmart) {
+    for (let i = 0; i < smartEntries.length; i += batchSize) {
+      const batch = smartEntries.slice(i, i + batchSize);
+
+      // Collect all literal fragments across the batch
+      const batchTokens = batch.map((e) => extractSmartTokens(e.value));
+      const allLiterals: string[] = [];
+      const literalCounts: number[] = [];
+
+      batchTokens.forEach((tokens) => {
+        const lits = tokens.filter((t) => t.tokenType === 'literal').map((t) => t.raw);
+        allLiterals.push(...lits);
+        literalCounts.push(lits.length);
+      });
+
+      // Translate all literals in one batch call
+      let translatedLiterals: string[] = [];
+      try {
+        if (allLiterals.length > 0) {
+          const result = await translateWithFallback({
+            texts: allLiterals,
+            sourceLanguage: table.locale,
+            targetLanguage: targetLocale,
+            context: options?.context,
+            provider: options?.provider,
+            model: options?.model,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+          translatedLiterals = result.translations ?? result.results ?? [];
+        }
+      } catch (err) {
+        batch.forEach((entry) => {
+          entry.translationStatus = 'error';
+          entry.validationErrors = [(err as Error).message];
+        });
+        continue;
+      }
+
+      // Reassemble each entry with its translated literals
+      let litOffset = 0;
+      batch.forEach((entry, batchIdx) => {
+        const count = literalCounts[batchIdx];
+        const entryLiterals = translatedLiterals.slice(litOffset, litOffset + count);
+        litOffset += count;
+
+        entry.translated = rebuildSmartString(batchTokens[batchIdx], entryLiterals);
+        entry.translationStatus = 'translated';
+      });
+
+      // Validate smart translations
+      for (const entry of batch) {
+        if (entry.translated && entry.translationStatus === 'translated') {
+          try {
+            const validation = await validateSmartTranslation(entry.value, entry.translated);
+            if (!validation.valid) {
+              entry.translationStatus = 'error';
+              entry.validationErrors = [
+                ...validation.missingTokens.map((t) => `Missing token: ${t}`),
+                ...validation.extraTokens.map((t) => `Extra token: ${t}`),
+                ...validation.warnings,
+              ];
+            } else if (validation.warnings.length > 0) {
+              entry.translationStatus = 'validated';
+              entry.validationErrors = validation.warnings;
+            } else {
+              entry.translationStatus = 'validated';
+            }
+          } catch {
+            // Validation backend unavailable – keep as 'translated'
+          }
+        }
+      }
+    }
+  } else {
+    // No smart-string preservation – translate as plain text
+    for (let i = 0; i < smartEntries.length; i += batchSize) {
+      const batch = smartEntries.slice(i, i + batchSize);
+      const texts = batch.map((e) => e.value);
+      try {
+        const result = await translateWithFallback({
+          texts,
+          sourceLanguage: table.locale,
+          targetLanguage: targetLocale,
+          context: options?.context,
+          provider: options?.provider,
+          model: options?.model,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+        const translated = result.translations ?? result.results ?? [];
+        batch.forEach((entry, idx) => {
+          entry.translated = translated[idx] ?? '';
+          entry.translationStatus = translated[idx] ? 'translated' : 'error';
+        });
+      } catch (err) {
+        batch.forEach((entry) => {
+          entry.translationStatus = 'error';
+          entry.validationErrors = [(err as Error).message];
+        });
+      }
+    }
+  }
+
+  return { ...table, entries };
+}
+
+/**
+ * Validate all translated Smart Strings in a table.
+ * Returns one SmartStringValidation per entry (in order).
+ */
+export async function validateAllTranslations(
+  table: StringTableInfo,
+): Promise<SmartStringValidation[]> {
+  const results: SmartStringValidation[] = [];
+
+  for (const entry of table.entries) {
+    if (!entry.isSmart || !entry.translated) {
+      results.push({ valid: true, missingTokens: [], extraTokens: [], warnings: [] });
+      continue;
+    }
+    try {
+      results.push(await validateSmartTranslation(entry.value, entry.translated));
+    } catch {
+      results.push({
+        valid: false,
+        missingTokens: [],
+        extraTokens: [],
+        warnings: ['Validation backend unavailable'],
+      });
+    }
+  }
+
+  return results;
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// EXPORT / IMPORT HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Export a StringTable as CSV: key, original, translated.
+ * Handles quoting for fields that contain commas or newlines.
+ */
+export function exportTableToCSV(table: StringTableInfo): string {
+  const rows: string[] = ['key,original,translated'];
+
+  for (const entry of table.entries) {
+    rows.push(
+      [
+        csvEscape(entry.keyName),
+        csvEscape(entry.value),
+        csvEscape(entry.translated ?? ''),
+      ].join(','),
+    );
+  }
+
+  return rows.join('\n');
+}
+
+/** Escape a CSV field: wrap in quotes if it contains comma, quote or newline. */
+function csvEscape(field: string): string {
+  if (/[",\n\r]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+/**
+ * Import translations from a CSV string.
+ * Matches rows to entries by key name and populates `translated` + `translationStatus`.
+ * Unmatched CSV rows are silently skipped.
+ */
+export function importTranslationsFromCSV(csv: string, table: StringTableInfo): StringTableInfo {
+  const lines = parseCSVLines(csv);
+  if (lines.length === 0) return table;
+
+  // Build lookup by keyName
+  const entryMap = new Map<string, StringTableEntry>();
+  const entries = table.entries.map((e) => ({ ...e }));
+  entries.forEach((e) => entryMap.set(e.keyName, e));
+
+  // Skip header if present
+  const startIdx = lines[0]?.[0]?.toLowerCase() === 'key' ? 1 : 0;
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const [key, , translated] = lines[i];
+    const entry = entryMap.get(key);
+    if (entry && translated != null && translated.length > 0) {
+      entry.translated = translated;
+      entry.translationStatus = 'translated';
+    }
+  }
+
+  return { ...table, entries };
+}
+
+/** Minimal CSV line parser that handles quoted fields with commas/newlines. */
+function parseCSVLines(csv: string): string[][] {
+  const results: string[][] = [];
+  let current: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < csv.length; i++) {
+    const ch = csv[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < csv.length && csv[i + 1] === '"') {
+          field += '"';
+          i++; // skip escaped quote
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ',') {
+        current.push(field);
+        field = '';
+      } else if (ch === '\n' || (ch === '\r' && csv[i + 1] === '\n')) {
+        current.push(field);
+        field = '';
+        results.push(current);
+        current = [];
+        if (ch === '\r') i++; // skip \n of \r\n
+      } else {
+        field += ch;
+      }
+    }
+  }
+
+  // Push last field/row
+  if (field.length > 0 || current.length > 0) {
+    current.push(field);
+    results.push(current);
+  }
+
+  return results;
+}
+
+/**
+ * Export a StringTable as JSON with full metadata.
+ * Useful for backup / external tool integration.
+ */
+export function exportTableToJSON(table: StringTableInfo): string {
+  return JSON.stringify(
+    {
+      tableName: table.tableName,
+      tableId: table.tableId,
+      locale: table.locale,
+      localeName: table.localeName,
+      bundlePath: table.bundlePath,
+      assetPath: table.assetPath,
+      exportedAt: new Date().toISOString(),
+      entryCount: table.entries.length,
+      entries: table.entries.map((e) => ({
+        keyId: e.keyId,
+        keyName: e.keyName,
+        value: e.value,
+        translated: e.translated ?? null,
+        isSmart: e.isSmart,
+        translationStatus: e.translationStatus ?? null,
+        metadata: e.metadata ?? null,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// LOCALE HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Map a locale code to its human-readable display name.
+ * Falls back to the code itself if not found in SUPPORTED_LOCALES.
+ */
+export function getLocaleDisplayName(code: string): string {
+  return SUPPORTED_LOCALES[code] ?? SUPPORTED_LOCALES[code.split('-')[0]] ?? code;
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -73,6 +73,7 @@ pub mod unity_patcher;
 pub mod unity_bundle;
 pub mod unity_csv;
 pub mod unity_asset_injector;
+pub mod unity_localization;
 pub mod unreal_patcher;
 pub mod unreal_localization;
 pub mod unreal_iostore;

--- a/src-tauri/src/commands/unity_localization.rs
+++ b/src-tauri/src/commands/unity_localization.rs
@@ -1,0 +1,1904 @@
+//! Unity Localization Package Pipeline
+//!
+//! Estrae, analizza e ricostruisce testi di localizzazione da giochi Unity
+//! che usano il pacchetto Unity Localization (StringTable + Addressables).
+//! Supporta UnityFS bundles, Smart Strings e catalog.json.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use serde::{Deserialize, Serialize};
+
+// ═══════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SmartToken {
+    pub token_type: String,
+    pub raw: String,
+    pub inner: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StringTableEntry {
+    pub key_id: i64,
+    pub key_name: String,
+    pub value: String,
+    pub is_smart: bool,
+    pub smart_tokens: Vec<SmartToken>,
+    pub metadata: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StringTableInfo {
+    pub table_name: String,
+    pub table_id: String,
+    pub locale: String,
+    pub locale_name: String,
+    pub entries: Vec<StringTableEntry>,
+    pub bundle_path: String,
+    pub asset_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddressablesCatalog {
+    pub locales: Vec<String>,
+    pub tables: Vec<CatalogTableRef>,
+    pub bundles: Vec<CatalogBundleRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogTableRef {
+    pub table_name: String,
+    pub locale: String,
+    pub bundle_filename: String,
+    pub internal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogBundleRef {
+    pub internal_id: String,
+    pub bundle_path: String,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SmartStringValidation {
+    pub valid: bool,
+    pub missing_tokens: Vec<String>,
+    pub extra_tokens: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranslatedStringTableEntry {
+    pub key_id: i64,
+    pub translated: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchResult {
+    pub success: bool,
+    pub output_path: String,
+    pub entries_patched: usize,
+    pub message: String,
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// BINARY READ HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+#[allow(dead_code)]
+fn read_u8(data: &[u8], offset: &mut usize) -> Result<u8, String> {
+    if *offset >= data.len() {
+        return Err(format!("EOF reading u8 at offset {}", offset));
+    }
+    let v = data[*offset];
+    *offset += 1;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_u16(data: &[u8], offset: &mut usize) -> Result<u16, String> {
+    if *offset + 2 > data.len() {
+        return Err(format!("EOF reading u16 at offset {}", offset));
+    }
+    let v = u16::from_le_bytes([data[*offset], data[*offset + 1]]);
+    *offset += 2;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_i32(data: &[u8], offset: &mut usize) -> Result<i32, String> {
+    if *offset + 4 > data.len() {
+        return Err(format!("EOF reading i32 at offset {}", offset));
+    }
+    let v = i32::from_le_bytes([
+        data[*offset], data[*offset + 1], data[*offset + 2], data[*offset + 3],
+    ]);
+    *offset += 4;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_u32(data: &[u8], offset: &mut usize) -> Result<u32, String> {
+    if *offset + 4 > data.len() {
+        return Err(format!("EOF reading u32 at offset {}", offset));
+    }
+    let v = u32::from_le_bytes([
+        data[*offset], data[*offset + 1], data[*offset + 2], data[*offset + 3],
+    ]);
+    *offset += 4;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_i64(data: &[u8], offset: &mut usize) -> Result<i64, String> {
+    if *offset + 8 > data.len() {
+        return Err(format!("EOF reading i64 at offset {}", offset));
+    }
+    let v = i64::from_le_bytes([
+        data[*offset], data[*offset + 1], data[*offset + 2], data[*offset + 3],
+        data[*offset + 4], data[*offset + 5], data[*offset + 6], data[*offset + 7],
+    ]);
+    *offset += 8;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_u64(data: &[u8], offset: &mut usize) -> Result<u64, String> {
+    if *offset + 8 > data.len() {
+        return Err(format!("EOF reading u64 at offset {}", offset));
+    }
+    let v = u64::from_le_bytes([
+        data[*offset], data[*offset + 1], data[*offset + 2], data[*offset + 3],
+        data[*offset + 4], data[*offset + 5], data[*offset + 6], data[*offset + 7],
+    ]);
+    *offset += 8;
+    Ok(v)
+}
+
+#[allow(dead_code)]
+fn read_bytes(data: &[u8], offset: &mut usize, count: usize) -> Result<Vec<u8>, String> {
+    if *offset + count > data.len() {
+        return Err(format!("EOF reading {} bytes at offset {}", count, offset));
+    }
+    let v = data[*offset..*offset + count].to_vec();
+    *offset += count;
+    Ok(v)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// BINARY WRITE HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+#[allow(dead_code)]
+fn write_i32(buf: &mut Vec<u8>, v: i32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+#[allow(dead_code)]
+fn write_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+#[allow(dead_code)]
+fn write_i64(buf: &mut Vec<u8>, v: i64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+#[allow(dead_code)]
+fn write_bytes(buf: &mut Vec<u8>, data: &[u8]) {
+    buf.extend_from_slice(data);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// UNITY-SPECIFIC HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/// Allinea un offset al prossimo multiplo di 4
+#[allow(dead_code)]
+fn align4(offset: usize) -> usize {
+    (offset + 3) & !3
+}
+
+/// Legge una stringa serializzata Unity (i32 length + bytes + padding a 4 byte)
+#[allow(dead_code)]
+fn read_unity_string(data: &[u8], offset: &mut usize) -> Result<String, String> {
+    let length = read_i32(data, offset)?;
+
+    if length < 0 {
+        return Err(format!("Lunghezza stringa negativa ({}) a offset {}", length, *offset - 4));
+    }
+    if length == 0 {
+        return Ok(String::new());
+    }
+
+    let len = length as usize;
+    if *offset + len > data.len() {
+        return Err(format!("EOF reading unity string ({} bytes) at offset {}", len, *offset));
+    }
+
+    let bytes = &data[*offset..*offset + len];
+    *offset += len;
+
+    // Padding a 4-byte alignment
+    *offset = align4(*offset);
+
+    // Prova UTF-8, fallback a lossy
+    Ok(String::from_utf8_lossy(bytes).to_string())
+}
+
+/// Scrive una stringa serializzata Unity con alignment a 4 byte
+#[allow(dead_code)]
+fn write_unity_string(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    write_i32(buf, bytes.len() as i32);
+    buf.extend_from_slice(bytes);
+
+    // Padding a 4-byte alignment
+    let padded = align4(bytes.len());
+    for _ in bytes.len()..padded {
+        buf.push(0u8);
+    }
+}
+
+/// Legge una stringa null-terminated dai dati
+#[allow(dead_code)]
+fn read_null_terminated_string(data: &[u8], offset: &mut usize) -> Result<String, String> {
+    let start = *offset;
+    while *offset < data.len() {
+        if data[*offset] == 0 {
+            let s = String::from_utf8_lossy(&data[start..*offset]).to_string();
+            *offset += 1; // skip null terminator
+            return Ok(s);
+        }
+        *offset += 1;
+    }
+    Err(format!("EOF cercando null terminator da offset {}", start))
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// LOCALE DETECTION
+// ═══════════════════════════════════════════════════════════════════
+
+/// Mappa di codici locale comuni usati da Unity Localization
+fn locale_code_to_name(code: &str) -> String {
+    match code.to_lowercase().as_str() {
+        "en" => "English".to_string(),
+        "it" => "Italian".to_string(),
+        "fr" => "French".to_string(),
+        "de" => "German".to_string(),
+        "es" => "Spanish".to_string(),
+        "pt" | "pt-br" => "Portuguese".to_string(),
+        "ja" => "Japanese".to_string(),
+        "ko" => "Korean".to_string(),
+        "zh" | "zh-cn" => "Chinese (Simplified)".to_string(),
+        "zh-tw" | "zh-hant" => "Chinese (Traditional)".to_string(),
+        "ru" => "Russian".to_string(),
+        "pl" => "Polish".to_string(),
+        "nl" => "Dutch".to_string(),
+        "sv" => "Swedish".to_string(),
+        "da" => "Danish".to_string(),
+        "fi" => "Finnish".to_string(),
+        "no" | "nb" => "Norwegian".to_string(),
+        "tr" => "Turkish".to_string(),
+        "ar" => "Arabic".to_string(),
+        "th" => "Thai".to_string(),
+        "vi" => "Vietnamese".to_string(),
+        "uk" => "Ukrainian".to_string(),
+        "cs" => "Czech".to_string(),
+        "hu" => "Hungarian".to_string(),
+        "ro" => "Romanian".to_string(),
+        "el" => "Greek".to_string(),
+        "id" => "Indonesian".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Estrae il codice locale da un nome file o internal_id di Unity
+/// Pattern: "_en.asset", "_it.asset", "english(en)", "StringTable_ja", ecc.
+fn detect_locale_from_name(name: &str) -> Option<String> {
+    let lower = name.to_lowercase();
+
+    // Pattern 1: "english(en)", "italian(it)" ecc.
+    if let Some(start) = lower.find('(') {
+        if let Some(end) = lower[start..].find(')') {
+            let code = &lower[start + 1..start + end];
+            if code.len() >= 2 && code.len() <= 5 && code.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                return Some(code.to_string());
+            }
+        }
+    }
+
+    // Pattern 2: "_en.asset", "_ja.asset", "_pt-br.asset"
+    let name_no_ext = if let Some(dot_pos) = lower.rfind('.') {
+        &lower[..dot_pos]
+    } else {
+        &lower
+    };
+
+    if let Some(underscore_pos) = name_no_ext.rfind('_') {
+        let candidate = &name_no_ext[underscore_pos + 1..];
+        if candidate.len() >= 2 && candidate.len() <= 5
+            && candidate.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        {
+            // Verifica che sia un codice locale noto
+            let known = locale_code_to_name(candidate);
+            if known != candidate {
+                return Some(candidate.to_string());
+            }
+        }
+    }
+
+    // Pattern 3: path contiene /en/ o /english/ ecc.
+    let locale_dirs = [
+        ("english", "en"), ("italian", "it"), ("french", "fr"),
+        ("german", "de"), ("spanish", "es"), ("japanese", "ja"),
+        ("korean", "ko"), ("chinese", "zh"), ("russian", "ru"),
+        ("portuguese", "pt"), ("polish", "pl"), ("dutch", "nl"),
+        ("turkish", "tr"), ("arabic", "ar"), ("thai", "th"),
+    ];
+
+    for (long, short) in &locale_dirs {
+        if lower.contains(&format!("/{}/", long)) || lower.contains(&format!("\\{}\\", long)) {
+            return Some(short.to_string());
+        }
+        // Solo se è un segmento di path isolato (es. /en/)
+        if lower.contains(&format!("/{}/", short)) || lower.contains(&format!("\\{}\\", short)) {
+            return Some(short.to_string());
+        }
+    }
+
+    None
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// UNITYFS BUNDLE PARSER
+// ═══════════════════════════════════════════════════════════════════
+
+/// Header di un UnityFS bundle
+#[derive(Debug)]
+struct UnityFSHeader {
+    #[allow(dead_code)]
+    format_version: u32,
+    #[allow(dead_code)]
+    unity_version: String,
+    #[allow(dead_code)]
+    generator_version: String,
+    file_size: i64,
+    compressed_block_info_size: u32,
+    uncompressed_block_info_size: u32,
+    flags: u32,
+}
+
+/// Informazioni su un blocco di dati nel bundle
+#[derive(Debug)]
+struct BlockInfo {
+    uncompressed_size: u32,
+    compressed_size: u32,
+    flags: u16,
+}
+
+/// Entry di un file dentro il bundle
+#[derive(Debug)]
+struct NodeEntry {
+    offset: i64,
+    size: i64,
+    #[allow(dead_code)]
+    flags: u32,
+    name: String,
+}
+
+/// Parsa l'header UnityFS da un buffer
+fn parse_unityfs_header(data: &[u8]) -> Result<(UnityFSHeader, usize), String> {
+    // Magic: "UnityFS\0"
+    if data.len() < 16 {
+        return Err("File troppo piccolo per essere un bundle Unity".into());
+    }
+
+    let magic = &data[0..8];
+    if magic != b"UnityFS\0" {
+        return Err(format!(
+            "Magic non valido: atteso 'UnityFS\\0', trovato {:?}",
+            String::from_utf8_lossy(&data[0..8])
+        ));
+    }
+
+    let mut offset = 8usize;
+
+    // Format version (u32 big-endian)
+    let format_version = u32::from_be_bytes([
+        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+    ]);
+    offset += 4;
+
+    // Unity version (null-terminated string)
+    let unity_version = read_null_terminated_string(data, &mut offset)?;
+
+    // Generator version (null-terminated string)
+    let generator_version = read_null_terminated_string(data, &mut offset)?;
+
+    // File size (i64 big-endian)
+    let file_size = i64::from_be_bytes([
+        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+        data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7],
+    ]);
+    offset += 8;
+
+    // Compressed block info size (u32 big-endian)
+    let compressed_block_info_size = u32::from_be_bytes([
+        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+    ]);
+    offset += 4;
+
+    // Uncompressed block info size (u32 big-endian)
+    let uncompressed_block_info_size = u32::from_be_bytes([
+        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+    ]);
+    offset += 4;
+
+    // Flags (u32 big-endian)
+    let flags = u32::from_be_bytes([
+        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+    ]);
+    offset += 4;
+
+    log::info!(
+        "UnityFS header: v{}, unity={}, size={}, block_info={}(compressed)/{}(uncompressed), flags=0x{:X}",
+        format_version, unity_version, file_size,
+        compressed_block_info_size, uncompressed_block_info_size, flags
+    );
+
+    Ok((UnityFSHeader {
+        format_version,
+        unity_version,
+        generator_version,
+        file_size,
+        compressed_block_info_size,
+        uncompressed_block_info_size,
+        flags,
+    }, offset))
+}
+
+/// Decomprime i block info e ottiene i blocchi + nodi
+fn parse_block_info(
+    data: &[u8],
+    header: &UnityFSHeader,
+    header_end: usize,
+) -> Result<(Vec<BlockInfo>, Vec<NodeEntry>, usize), String> {
+    let flags = header.flags;
+    let compression = flags & 0x3F;
+
+    // Determina dove si trovano i block info
+    let block_info_at_end = (flags & 0x80) != 0;
+    let block_info_offset = if block_info_at_end {
+        // Block info alla fine del file
+        (header.file_size as usize) - header.compressed_block_info_size as usize
+    } else {
+        header_end
+    };
+
+    let compressed_size = header.compressed_block_info_size as usize;
+    if block_info_offset + compressed_size > data.len() {
+        return Err(format!(
+            "Block info fuori dal file: offset={}, size={}, file_len={}",
+            block_info_offset, compressed_size, data.len()
+        ));
+    }
+
+    let block_info_data = &data[block_info_offset..block_info_offset + compressed_size];
+
+    // Decomprimi block info se necessario
+    let uncompressed_info = match compression {
+        0 => {
+            // Nessuna compressione
+            block_info_data.to_vec()
+        }
+        1 => {
+            // LZMA — non supportato per ora
+            return Err("Compressione LZMA per block info non supportata".into());
+        }
+        2 | 3 => {
+            // LZ4 / LZ4HC
+            let uncompressed_size = header.uncompressed_block_info_size as usize;
+            lz4_flex::decompress(block_info_data, uncompressed_size)
+                .map_err(|e| format!("Errore decompressione LZ4 block info: {}", e))?
+        }
+        _ => {
+            return Err(format!("Tipo compressione block info sconosciuto: {}", compression));
+        }
+    };
+
+    // Parsa block info decompresso
+    let mut off = 0usize;
+    let info_data = &uncompressed_info;
+
+    // Skip uncompressed data hash (16 bytes)
+    if off + 16 > info_data.len() {
+        return Err("Block info troppo corto per hash".into());
+    }
+    off += 16;
+
+    // Block count (i32 big-endian)
+    if off + 4 > info_data.len() {
+        return Err("Block info troppo corto per block count".into());
+    }
+    let block_count = i32::from_be_bytes([
+        info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+    ]);
+    off += 4;
+
+    if block_count < 0 || block_count > 100_000 {
+        return Err(format!("Numero blocchi sospetto: {}", block_count));
+    }
+
+    let mut blocks = Vec::with_capacity(block_count as usize);
+    for _ in 0..block_count {
+        if off + 10 > info_data.len() {
+            return Err("Block info troppo corto per blocco".into());
+        }
+        let uncompressed_size = u32::from_be_bytes([
+            info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+        ]);
+        off += 4;
+        let compressed_size = u32::from_be_bytes([
+            info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+        ]);
+        off += 4;
+        let block_flags = u16::from_be_bytes([info_data[off], info_data[off + 1]]);
+        off += 2;
+
+        blocks.push(BlockInfo {
+            uncompressed_size,
+            compressed_size,
+            flags: block_flags,
+        });
+    }
+
+    // Node count (i32 big-endian)
+    if off + 4 > info_data.len() {
+        return Err("Block info troppo corto per node count".into());
+    }
+    let node_count = i32::from_be_bytes([
+        info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+    ]);
+    off += 4;
+
+    if node_count < 0 || node_count > 100_000 {
+        return Err(format!("Numero nodi sospetto: {}", node_count));
+    }
+
+    let mut nodes = Vec::with_capacity(node_count as usize);
+    for _ in 0..node_count {
+        if off + 20 > info_data.len() {
+            return Err("Block info troppo corto per nodo".into());
+        }
+        let node_offset = i64::from_be_bytes([
+            info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+            info_data[off + 4], info_data[off + 5], info_data[off + 6], info_data[off + 7],
+        ]);
+        off += 8;
+        let node_size = i64::from_be_bytes([
+            info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+            info_data[off + 4], info_data[off + 5], info_data[off + 6], info_data[off + 7],
+        ]);
+        off += 8;
+        let node_flags = u32::from_be_bytes([
+            info_data[off], info_data[off + 1], info_data[off + 2], info_data[off + 3],
+        ]);
+        off += 4;
+
+        // Node name is a null-terminated string
+        let name = {
+            let start = off;
+            while off < info_data.len() && info_data[off] != 0 {
+                off += 1;
+            }
+            let s = String::from_utf8_lossy(&info_data[start..off]).to_string();
+            if off < info_data.len() {
+                off += 1; // skip null
+            }
+            s
+        };
+
+        nodes.push(NodeEntry {
+            offset: node_offset,
+            size: node_size,
+            flags: node_flags,
+            name,
+        });
+    }
+
+    // Calcola dove iniziano i dati dei blocchi
+    let data_offset = if block_info_at_end {
+        header_end
+    } else {
+        block_info_offset + compressed_size
+    };
+
+    log::info!(
+        "UnityFS: {} blocchi, {} nodi, data_offset={}",
+        blocks.len(), nodes.len(), data_offset
+    );
+
+    Ok((blocks, nodes, data_offset))
+}
+
+/// Decomprime tutti i blocchi dati del bundle in un singolo buffer
+fn decompress_blocks(data: &[u8], blocks: &[BlockInfo], data_offset: usize) -> Result<Vec<u8>, String> {
+    let mut result = Vec::new();
+    let mut current_offset = data_offset;
+
+    for (i, block) in blocks.iter().enumerate() {
+        let comp_size = block.compressed_size as usize;
+        let uncomp_size = block.uncompressed_size as usize;
+        let compression = block.flags & 0x3F;
+
+        if current_offset + comp_size > data.len() {
+            return Err(format!(
+                "Blocco {} fuori dal file: offset={}, size={}, file_len={}",
+                i, current_offset, comp_size, data.len()
+            ));
+        }
+
+        let block_data = &data[current_offset..current_offset + comp_size];
+
+        match compression {
+            0 => {
+                // Nessuna compressione
+                result.extend_from_slice(block_data);
+            }
+            1 => {
+                // LZMA
+                return Err(format!("Blocco {} usa LZMA, non supportato", i));
+            }
+            2 | 3 => {
+                // LZ4 / LZ4HC
+                let decompressed = lz4_flex::decompress(block_data, uncomp_size)
+                    .map_err(|e| format!("Errore LZ4 blocco {}: {}", i, e))?;
+                result.extend_from_slice(&decompressed);
+            }
+            _ => {
+                return Err(format!("Blocco {} compressione sconosciuta: {}", i, compression));
+            }
+        }
+
+        current_offset += comp_size;
+    }
+
+    log::info!("Decompresso {} bytes totali dai blocchi", result.len());
+    Ok(result)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// STRING TABLE EXTRACTION (PATTERN SCANNING)
+// ═══════════════════════════════════════════════════════════════════
+
+/// Cerca una sequenza di byte in un buffer. Restituisce tutte le posizioni trovate.
+fn find_all_occurrences(data: &[u8], pattern: &[u8]) -> Vec<usize> {
+    let mut positions = Vec::new();
+    if pattern.is_empty() || data.len() < pattern.len() {
+        return positions;
+    }
+    for i in 0..=data.len() - pattern.len() {
+        if data[i..i + pattern.len()] == *pattern {
+            positions.push(i);
+        }
+    }
+    positions
+}
+
+/// Verifica se una sequenza di byte è una stringa UTF-8 ragionevole
+fn is_reasonable_utf8(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(s) => {
+            // Deve avere almeno un carattere stampabile
+            s.chars().any(|c| !c.is_control()) &&
+            // Non deve essere tutta punteggiatura/spazi
+            s.chars().any(|c| c.is_alphanumeric())
+        }
+        Err(_) => false,
+    }
+}
+
+/// Cerca coppie (i64 key, string value) nel buffer decompresso.
+/// Questo è il formato serializzato di m_TableEntries in Unity.
+fn scan_for_string_table_entries(data: &[u8]) -> Vec<StringTableEntry> {
+    let mut entries = Vec::new();
+
+    // Strategia 1: Cerca "m_TableCollectionName" per localizzare l'asset
+    let marker = b"m_TableCollectionName";
+    let marker_positions = find_all_occurrences(data, marker);
+
+    if !marker_positions.is_empty() {
+        log::info!("Trovati {} marker m_TableCollectionName", marker_positions.len());
+    }
+
+    // Strategia 2: Cerca pattern di array serializzati
+    // Unity serializza m_TableEntries come:
+    //   i32 array_size (numero di entry)
+    //   per ogni entry:
+    //     i64 key_id
+    //     i32 string_length
+    //     bytes string_data
+    //     (alignment padding)
+    //     ... metadata opzionale
+
+    // Scansione euristica: cerca sequenze di (i64, i32 len, utf8 string)
+    let mut off = 0usize;
+    let min_entries_for_table = 3; // Minimo entry per considerarlo una tabella valida
+    let mut candidate_entries: Vec<StringTableEntry> = Vec::new();
+
+    while off + 12 < data.len() {
+        // Prova a leggere un i64 (potenziale key_id)
+        let key_id = i64::from_le_bytes([
+            data[off], data[off + 1], data[off + 2], data[off + 3],
+            data[off + 4], data[off + 5], data[off + 6], data[off + 7],
+        ]);
+
+        // I key ID di Unity sono tipicamente hash a 64 bit o sequenziali piccoli
+        // Filtriamo valori ragionevoli
+        if key_id == 0 || (key_id > 0 && key_id < 0x7FFF_FFFF_FFFF_FFFF) {
+            let str_off = off + 8;
+            if str_off + 4 <= data.len() {
+                let str_len = i32::from_le_bytes([
+                    data[str_off], data[str_off + 1], data[str_off + 2], data[str_off + 3],
+                ]);
+
+                // Lunghezza ragionevole per una stringa di localizzazione
+                if str_len > 0 && str_len < 10_000 {
+                    let str_start = str_off + 4;
+                    let str_end = str_start + str_len as usize;
+
+                    if str_end <= data.len() && is_reasonable_utf8(&data[str_start..str_end]) {
+                        let value = String::from_utf8_lossy(&data[str_start..str_end]).to_string();
+                        let is_smart = value.contains('{') && value.contains('}');
+
+                        let smart_tokens = if is_smart {
+                            tokenize_smart_string(&value).unwrap_or_default()
+                        } else {
+                            Vec::new()
+                        };
+
+                        candidate_entries.push(StringTableEntry {
+                            key_id,
+                            key_name: format!("key_{}", key_id),
+                            value,
+                            is_smart,
+                            smart_tokens,
+                            metadata: None,
+                        });
+
+                        // Avanza oltre questa stringa + alignment
+                        off = align4(str_end);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        off += 1;
+    }
+
+    // Se abbiamo trovato abbastanza entry consecutive, considerala una tabella
+    if candidate_entries.len() >= min_entries_for_table {
+        log::info!(
+            "Scansione euristica: trovate {} entry candidate",
+            candidate_entries.len()
+        );
+        entries.extend(candidate_entries);
+    }
+
+    // Strategia 3: Cerca stringhe con pattern di chiave/valore Unity
+    // Formato alternativo: m_TableEntries con array di SharedTableData.SharedTableEntry
+    // che ha Key (i64) + Id (string) + Metadata
+    let table_entries_marker = b"m_TableEntries";
+    let te_positions = find_all_occurrences(data, table_entries_marker);
+
+    for pos in te_positions {
+        log::info!("Trovato m_TableEntries a offset {}", pos);
+
+        // Cerca l'array serializzato dopo il marker
+        // Salta marker + possibile type info + i32 array_count
+        let search_start = pos + table_entries_marker.len();
+        let search_end = std::cmp::min(search_start + 256, data.len());
+
+        for scan_off in search_start..search_end.saturating_sub(4) {
+            let potential_count = i32::from_le_bytes([
+                data[scan_off], data[scan_off + 1], data[scan_off + 2], data[scan_off + 3],
+            ]);
+
+            if potential_count > 0 && potential_count < 100_000 {
+                let mut entry_off = scan_off + 4;
+                let mut found_entries = Vec::new();
+
+                for _ in 0..potential_count {
+                    if entry_off + 12 > data.len() {
+                        break;
+                    }
+
+                    let kid = i64::from_le_bytes([
+                        data[entry_off], data[entry_off + 1], data[entry_off + 2], data[entry_off + 3],
+                        data[entry_off + 4], data[entry_off + 5], data[entry_off + 6], data[entry_off + 7],
+                    ]);
+                    entry_off += 8;
+
+                    // Prova a leggere una Unity string (valore)
+                    let mut temp_off = entry_off;
+                    match read_unity_string(data, &mut temp_off) {
+                        Ok(val) if !val.is_empty() && is_reasonable_utf8(val.as_bytes()) => {
+                            let is_smart = val.contains('{') && val.contains('}');
+                            let smart_tokens = if is_smart {
+                                tokenize_smart_string(&val).unwrap_or_default()
+                            } else {
+                                Vec::new()
+                            };
+
+                            found_entries.push(StringTableEntry {
+                                key_id: kid,
+                                key_name: format!("key_{}", kid),
+                                value: val,
+                                is_smart,
+                                smart_tokens,
+                                metadata: None,
+                            });
+                            entry_off = temp_off;
+                        }
+                        _ => break,
+                    }
+                }
+
+                if found_entries.len() >= min_entries_for_table {
+                    log::info!(
+                        "m_TableEntries array: {} entry estratte a offset {}",
+                        found_entries.len(), scan_off
+                    );
+                    // Deduplicazione: non aggiungere se i key_id sono già presenti
+                    let existing_keys: std::collections::HashSet<i64> =
+                        entries.iter().map(|e| e.key_id).collect();
+                    for fe in found_entries {
+                        if !existing_keys.contains(&fe.key_id) {
+                            entries.push(fe);
+                        }
+                    }
+                    break; // Trovato l'array, stop scan per questo marker
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+/// Estrae il nome della tabella dal buffer decompresso
+fn extract_table_name(data: &[u8]) -> Option<String> {
+    // Cerca m_TableCollectionName seguito da una stringa
+    let marker = b"m_TableCollectionName";
+    for pos in find_all_occurrences(data, marker) {
+        let after = pos + marker.len();
+        // Cerca la prossima stringa serializzata Unity
+        // Potrebbe esserci type info tra il marker e il valore
+        let search_end = std::cmp::min(after + 128, data.len());
+        for off in after..search_end.saturating_sub(4) {
+            let len = i32::from_le_bytes([
+                data[off], data[off + 1], data[off + 2], data[off + 3],
+            ]);
+            if len > 0 && len < 256 {
+                let str_start = off + 4;
+                let str_end = str_start + len as usize;
+                if str_end <= data.len() {
+                    if let Ok(s) = std::str::from_utf8(&data[str_start..str_end]) {
+                        if s.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == ' ') {
+                            return Some(s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: cerca m_Name
+    let name_marker = b"m_Name";
+    for pos in find_all_occurrences(data, name_marker) {
+        let after = pos + name_marker.len();
+        let search_end = std::cmp::min(after + 128, data.len());
+        for off in after..search_end.saturating_sub(4) {
+            let len = i32::from_le_bytes([
+                data[off], data[off + 1], data[off + 2], data[off + 3],
+            ]);
+            if len > 2 && len < 256 {
+                let str_start = off + 4;
+                let str_end = str_start + len as usize;
+                if str_end <= data.len() {
+                    if let Ok(s) = std::str::from_utf8(&data[str_start..str_end]) {
+                        if s.contains("StringTable") || s.contains("Localization") {
+                            return Some(s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Estrae il table ID (GUID) dal buffer decompresso
+fn extract_table_id(data: &[u8]) -> Option<String> {
+    // Cerca m_TableCollectionNameGuid
+    let marker = b"m_TableCollectionNameGuid";
+    for pos in find_all_occurrences(data, marker) {
+        let after = pos + marker.len();
+        let search_end = std::cmp::min(after + 128, data.len());
+        for off in after..search_end.saturating_sub(4) {
+            let len = i32::from_le_bytes([
+                data[off], data[off + 1], data[off + 2], data[off + 3],
+            ]);
+            // GUID tipicamente 32-36 caratteri
+            if len >= 32 && len <= 40 {
+                let str_start = off + 4;
+                let str_end = str_start + len as usize;
+                if str_end <= data.len() {
+                    if let Ok(s) = std::str::from_utf8(&data[str_start..str_end]) {
+                        if s.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+                            return Some(s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SMART STRING TOKENIZER
+// ═══════════════════════════════════════════════════════════════════
+
+/// Tokenizza una Smart String di Unity in segmenti
+fn tokenize_smart_string(input: &str) -> Result<Vec<SmartToken>, String> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut literal_buf = String::new();
+
+    while i < len {
+        // Escaped brace
+        if chars[i] == '\\' && i + 1 < len && (chars[i + 1] == '{' || chars[i + 1] == '}') {
+            literal_buf.push(chars[i + 1]);
+            i += 2;
+            continue;
+        }
+
+        if chars[i] == '{' {
+            // Flush literal
+            if !literal_buf.is_empty() {
+                tokens.push(SmartToken {
+                    token_type: "literal".to_string(),
+                    raw: literal_buf.clone(),
+                    inner: None,
+                });
+                literal_buf.clear();
+            }
+
+            // Trova la fine del token, gestendo braces annidati
+            let start = i;
+            let mut depth = 0;
+            let mut end = i;
+
+            while end < len {
+                if chars[end] == '\\' && end + 1 < len {
+                    end += 2; // skip escaped
+                    continue;
+                }
+                if chars[end] == '{' {
+                    depth += 1;
+                } else if chars[end] == '}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        end += 1;
+                        break;
+                    }
+                }
+                end += 1;
+            }
+
+            let raw: String = chars[start..end].iter().collect();
+            let inner_str: String = if end > start + 2 {
+                chars[start + 1..end - 1].iter().collect()
+            } else {
+                String::new()
+            };
+
+            // Classifica il token
+            let token_type = classify_smart_token(&inner_str);
+
+            tokens.push(SmartToken {
+                token_type,
+                raw,
+                inner: Some(inner_str),
+            });
+
+            i = end;
+        } else {
+            literal_buf.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    // Flush ultimo literal
+    if !literal_buf.is_empty() {
+        tokens.push(SmartToken {
+            token_type: "literal".to_string(),
+            raw: literal_buf,
+            inner: None,
+        });
+    }
+
+    Ok(tokens)
+}
+
+/// Classifica il tipo di un token Smart String dal suo contenuto interno
+fn classify_smart_token(inner: &str) -> String {
+    if inner.is_empty() {
+        return "variable".to_string();
+    }
+
+    // Controlla per plural: contiene "plural:" e sotto-braces
+    if inner.contains(":plural:") || inner.contains(":p:") {
+        return "plural".to_string();
+    }
+
+    // Controlla per braces annidati (nested)
+    if inner.contains('{') {
+        return "nested".to_string();
+    }
+
+    // Controlla per formatter: contiene ":"
+    if inner.contains(':') {
+        return "formatter".to_string();
+    }
+
+    // Semplice variabile
+    "variable".to_string()
+}
+
+/// Estrae tutti i token `{...}` da una stringa (per confronto traduzioni)
+fn extract_brace_tokens(s: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        if chars[i] == '\\' && i + 1 < len {
+            i += 2;
+            continue;
+        }
+        if chars[i] == '{' {
+            let start = i;
+            let mut depth = 0;
+            while i < len {
+                if chars[i] == '\\' && i + 1 < len {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '{' {
+                    depth += 1;
+                } else if chars[i] == '}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        i += 1;
+                        break;
+                    }
+                }
+                i += 1;
+            }
+            let token: String = chars[start..i].iter().collect();
+            tokens.push(token);
+        } else {
+            i += 1;
+        }
+    }
+
+    tokens
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// FILESYSTEM HELPERS
+// ═══════════════════════════════════════════════════════════════════
+
+/// Walk directory fino a max_depth
+fn walkdir(dir: &Path, max_depth: usize) -> Result<Vec<PathBuf>, String> {
+    let mut results = Vec::new();
+    walkdir_inner(dir, max_depth, 0, &mut results)?;
+    Ok(results)
+}
+
+fn walkdir_inner(
+    dir: &Path,
+    max_depth: usize,
+    depth: usize,
+    results: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    if depth > max_depth {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("Errore lettura dir {}: {}", dir.display(), e))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            results.push(path);
+        } else if path.is_dir() {
+            walkdir_inner(&path, max_depth, depth + 1, results)?;
+        }
+    }
+
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// TAURI COMMANDS
+// ═══════════════════════════════════════════════════════════════════
+
+/// Parsa il catalog.json di Unity Addressables per estrarre info su tabelle e bundle
+#[tauri::command]
+pub async fn parse_addressables_catalog(catalog_path: String) -> Result<AddressablesCatalog, String> {
+    let path = Path::new(&catalog_path);
+
+    if !path.exists() {
+        return Err(format!("File catalogo non trovato: {}", catalog_path));
+    }
+
+    log::info!("Parsing catalogo Addressables: {}", catalog_path);
+
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Errore lettura catalogo: {}", e))?;
+
+    let catalog: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Errore parsing JSON catalogo: {}", e))?;
+
+    // Estrai m_InternalIds
+    let internal_ids: Vec<String> = catalog
+        .get("m_InternalIds")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    log::info!("Catalogo: {} internal IDs trovati", internal_ids.len());
+
+    // Trova tabelle StringTable e bundle
+    let mut locales = std::collections::HashSet::new();
+    let mut tables = Vec::new();
+    let mut bundles = Vec::new();
+    let mut bundle_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+
+    // Prima passata: identifica i bundle (path che finiscono con estensione bundle o senza estensione)
+    for id in &internal_ids {
+        let lower = id.to_lowercase();
+        if lower.ends_with(".bundle") || lower.contains("_assets_") || lower.contains("_scenes_") {
+            let filename = Path::new(id)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            bundle_map.insert(id.clone(), filename);
+        }
+    }
+
+    // Seconda passata: identifica le StringTable
+    for id in &internal_ids {
+        let lower = id.to_lowercase();
+        if lower.contains("stringtable") || lower.contains("localization") || lower.contains("localiz") {
+            if lower.ends_with(".asset") {
+                // Questo è un riferimento a una StringTable
+                let table_name = Path::new(id)
+                    .file_stem()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                let locale = detect_locale_from_name(id).unwrap_or_else(|| "unknown".to_string());
+                locales.insert(locale.clone());
+
+                // Trova il bundle associato (euristica: stesso prefisso o vicino nell'array)
+                let bundle_filename = find_associated_bundle(id, &internal_ids, &bundle_map);
+
+                tables.push(CatalogTableRef {
+                    table_name: table_name.clone(),
+                    locale: locale.clone(),
+                    bundle_filename: bundle_filename.clone(),
+                    internal_id: id.clone(),
+                });
+            }
+        }
+    }
+
+    // Costruisci lista bundle
+    for (internal_id, filename) in &bundle_map {
+        bundles.push(CatalogBundleRef {
+            internal_id: internal_id.clone(),
+            bundle_path: filename.clone(),
+            dependencies: Vec::new(), // Le dipendenze richiederebbero parsing più complesso di EntryData
+        });
+    }
+
+    let mut locale_list: Vec<String> = locales.into_iter().collect();
+    locale_list.sort();
+
+    log::info!(
+        "Catalogo parsato: {} locali, {} tabelle, {} bundle",
+        locale_list.len(), tables.len(), bundles.len()
+    );
+
+    Ok(AddressablesCatalog {
+        locales: locale_list,
+        tables,
+        bundles,
+    })
+}
+
+/// Euristica per trovare il bundle associato a un asset di StringTable
+fn find_associated_bundle(
+    asset_id: &str,
+    internal_ids: &[String],
+    bundle_map: &std::collections::HashMap<String, String>,
+) -> String {
+    let asset_lower = asset_id.to_lowercase();
+
+    // Estrai nome base della tabella (prima di _locale)
+    let stem = Path::new(asset_id)
+        .file_stem()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+
+    // Cerca bundle con nome simile
+    for (bid, bname) in bundle_map {
+        let blower = bid.to_lowercase();
+        if blower.contains(&stem) || bname.to_lowercase().contains(&stem) {
+            return bname.clone();
+        }
+    }
+
+    // Fallback: cerca bundle "vicino" nell'array di internal_ids
+    if let Some(asset_idx) = internal_ids.iter().position(|id| id == asset_id) {
+        // Cerca il bundle più vicino prima o dopo nell'array
+        for distance in 1..20 {
+            if asset_idx >= distance {
+                let candidate = &internal_ids[asset_idx - distance];
+                if bundle_map.contains_key(candidate) {
+                    return bundle_map[candidate].clone();
+                }
+            }
+            if asset_idx + distance < internal_ids.len() {
+                let candidate = &internal_ids[asset_idx + distance];
+                if bundle_map.contains_key(candidate) {
+                    return bundle_map[candidate].clone();
+                }
+            }
+        }
+    }
+
+    let _ = asset_lower; // suppress warning
+    String::new()
+}
+
+/// Scansiona una cartella (tipicamente StreamingAssets/aa/StandaloneWindows64/)
+/// alla ricerca di StringTable, bundle e catalog.json
+#[tauri::command]
+pub async fn detect_string_tables_in_folder(folder_path: String) -> Result<Vec<StringTableInfo>, String> {
+    let dir = Path::new(&folder_path);
+
+    if !dir.exists() || !dir.is_dir() {
+        return Err(format!("Directory non trovata: {}", folder_path));
+    }
+
+    log::info!("Scansione cartella per StringTable: {}", folder_path);
+
+    let files = walkdir(dir, 4)
+        .map_err(|e| format!("Errore scansione cartella: {}", e))?;
+
+    let mut results = Vec::new();
+
+    // 1. Cerca catalog.json
+    let catalogs: Vec<&PathBuf> = files.iter()
+        .filter(|f| {
+            f.file_name()
+                .map(|n| n.to_string_lossy().to_lowercase().contains("catalog") &&
+                         n.to_string_lossy().to_lowercase().ends_with(".json"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if !catalogs.is_empty() {
+        log::info!("Trovati {} file catalog.json", catalogs.len());
+        for cat_path in &catalogs {
+            match parse_addressables_catalog(cat_path.to_string_lossy().to_string()).await {
+                Ok(catalog) => {
+                    for table_ref in &catalog.tables {
+                        results.push(StringTableInfo {
+                            table_name: table_ref.table_name.clone(),
+                            table_id: String::new(),
+                            locale: table_ref.locale.clone(),
+                            locale_name: locale_code_to_name(&table_ref.locale),
+                            entries: Vec::new(), // Non estratte ancora, solo detection
+                            bundle_path: table_ref.bundle_filename.clone(),
+                            asset_path: table_ref.internal_id.clone(),
+                        });
+                    }
+                }
+                Err(e) => {
+                    log::warn!("Errore parsing catalogo {}: {}", cat_path.display(), e);
+                }
+            }
+        }
+    }
+
+    // 2. Cerca file .bundle con nomi localizzazione
+    let bundle_files: Vec<&PathBuf> = files.iter()
+        .filter(|f| {
+            let name = f.to_string_lossy().to_lowercase();
+            (name.ends_with(".bundle") || name.contains("_assets_all_")) &&
+            (name.contains("local") || name.contains("string") || name.contains("text"))
+        })
+        .collect();
+
+    for bundle_path in &bundle_files {
+        let name = bundle_path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let locale = detect_locale_from_name(&name).unwrap_or_else(|| "unknown".to_string());
+
+        // Controlla se non è già stato trovato dal catalogo
+        let already_found = results.iter().any(|r| {
+            r.bundle_path == name || r.bundle_path == bundle_path.to_string_lossy().to_string()
+        });
+
+        if !already_found {
+            results.push(StringTableInfo {
+                table_name: name.clone(),
+                table_id: String::new(),
+                locale: locale.clone(),
+                locale_name: locale_code_to_name(&locale),
+                entries: Vec::new(),
+                bundle_path: bundle_path.to_string_lossy().to_string(),
+                asset_path: String::new(),
+            });
+        }
+    }
+
+    // 3. Cerca file .asset diretti che potrebbero essere StringTable
+    let asset_files: Vec<&PathBuf> = files.iter()
+        .filter(|f| {
+            let name = f.to_string_lossy().to_lowercase();
+            name.ends_with(".asset") &&
+            (name.contains("stringtable") || name.contains("localization"))
+        })
+        .collect();
+
+    for asset_path in &asset_files {
+        let name = asset_path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let locale = detect_locale_from_name(&name).unwrap_or_else(|| "unknown".to_string());
+
+        results.push(StringTableInfo {
+            table_name: name.clone(),
+            table_id: String::new(),
+            locale: locale.clone(),
+            locale_name: locale_code_to_name(&locale),
+            entries: Vec::new(),
+            bundle_path: String::new(),
+            asset_path: asset_path.to_string_lossy().to_string(),
+        });
+    }
+
+    log::info!("Scansione completata: {} tabelle trovate", results.len());
+    Ok(results)
+}
+
+/// Estrae le StringTable da un Unity Asset Bundle.
+/// Parser ibrido: prova type tree, poi scansione a pattern.
+#[tauri::command]
+pub async fn extract_string_table(bundle_path: String) -> Result<Vec<StringTableInfo>, String> {
+    let path = Path::new(&bundle_path);
+
+    if !path.exists() {
+        return Err(format!("File bundle non trovato: {}", bundle_path));
+    }
+
+    log::info!("Estrazione StringTable da bundle: {}", bundle_path);
+
+    let data = fs::read(path)
+        .map_err(|e| format!("Errore lettura bundle: {}", e))?;
+
+    // 1. Parsa header UnityFS
+    let (header, header_end) = parse_unityfs_header(&data)?;
+
+    // 2. Parsa block info
+    let (blocks, nodes, data_offset) = parse_block_info(&data, &header, header_end)?;
+
+    // 3. Decomprimi tutti i blocchi
+    let decompressed = decompress_blocks(&data, &blocks, data_offset)?;
+
+    log::info!(
+        "Bundle decompresso: {} bytes, {} nodi",
+        decompressed.len(), nodes.len()
+    );
+
+    // 4. Per ogni nodo, estrai i dati dell'asset e cerca StringTable
+    let mut tables = Vec::new();
+
+    for node in &nodes {
+        let node_start = node.offset as usize;
+        let node_end = node_start + node.size as usize;
+
+        if node_end > decompressed.len() {
+            log::warn!(
+                "Nodo '{}' fuori dal buffer: offset={}, size={}, buffer={}",
+                node.name, node.offset, node.size, decompressed.len()
+            );
+            continue;
+        }
+
+        let node_data = &decompressed[node_start..node_end];
+
+        log::info!(
+            "Analisi nodo '{}': {} bytes (offset {})",
+            node.name, node.size, node.offset
+        );
+
+        // Cerca le entry della StringTable
+        let entries = scan_for_string_table_entries(node_data);
+
+        if entries.is_empty() {
+            log::info!("Nodo '{}': nessuna entry StringTable trovata", node.name);
+            continue;
+        }
+
+        // Estrai metadati
+        let table_name = extract_table_name(node_data)
+            .unwrap_or_else(|| node.name.clone());
+        let table_id = extract_table_id(node_data)
+            .unwrap_or_default();
+
+        let locale = detect_locale_from_name(&bundle_path)
+            .or_else(|| detect_locale_from_name(&node.name))
+            .or_else(|| detect_locale_from_name(&table_name))
+            .unwrap_or_else(|| "unknown".to_string());
+
+        log::info!(
+            "Tabella '{}' (locale: {}): {} entry estratte",
+            table_name, locale, entries.len()
+        );
+
+        tables.push(StringTableInfo {
+            table_name,
+            table_id,
+            locale: locale.clone(),
+            locale_name: locale_code_to_name(&locale),
+            entries,
+            bundle_path: bundle_path.clone(),
+            asset_path: node.name.clone(),
+        });
+    }
+
+    // Se nessun nodo ha prodotto risultati, prova scansione globale
+    if tables.is_empty() && !decompressed.is_empty() {
+        log::info!("Nessuna tabella trovata nei nodi, provo scansione globale...");
+
+        let entries = scan_for_string_table_entries(&decompressed);
+
+        if !entries.is_empty() {
+            let table_name = extract_table_name(&decompressed)
+                .unwrap_or_else(|| {
+                    Path::new(&bundle_path)
+                        .file_stem()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "UnknownTable".to_string())
+                });
+
+            let table_id = extract_table_id(&decompressed).unwrap_or_default();
+            let locale = detect_locale_from_name(&bundle_path)
+                .unwrap_or_else(|| "unknown".to_string());
+
+            log::info!(
+                "Scansione globale: '{}' (locale: {}): {} entry",
+                table_name, locale, entries.len()
+            );
+
+            tables.push(StringTableInfo {
+                table_name,
+                table_id,
+                locale: locale.clone(),
+                locale_name: locale_code_to_name(&locale),
+                entries,
+                bundle_path: bundle_path.clone(),
+                asset_path: String::new(),
+            });
+        }
+    }
+
+    if tables.is_empty() {
+        log::warn!("Nessuna StringTable trovata nel bundle {}", bundle_path);
+    }
+
+    Ok(tables)
+}
+
+/// Tokenizza una Smart String di Unity in segmenti
+#[tauri::command]
+pub async fn parse_smart_string(input: String) -> Result<Vec<SmartToken>, String> {
+    log::info!("Parsing Smart String: '{}'", &input[..std::cmp::min(input.len(), 80)]);
+    tokenize_smart_string(&input)
+}
+
+/// Valida una traduzione rispetto all'originale verificando i token Smart String
+#[tauri::command]
+pub async fn validate_smart_string_translation(
+    original: String,
+    translated: String,
+) -> Result<SmartStringValidation, String> {
+    let original_tokens = extract_brace_tokens(&original);
+    let translated_tokens = extract_brace_tokens(&translated);
+
+    let mut missing_tokens = Vec::new();
+    let mut extra_tokens = Vec::new();
+    let mut warnings = Vec::new();
+
+    // Confronta token originali vs tradotti
+    let mut translated_remaining: Vec<String> = translated_tokens.clone();
+
+    for orig_token in &original_tokens {
+        if let Some(pos) = translated_remaining.iter().position(|t| t == orig_token) {
+            translated_remaining.remove(pos);
+        } else {
+            missing_tokens.push(orig_token.clone());
+        }
+    }
+
+    // Token in più nella traduzione
+    for extra in &translated_remaining {
+        extra_tokens.push(extra.clone());
+    }
+
+    // Warning aggiuntivi
+    if original_tokens.is_empty() && translated_tokens.is_empty() {
+        // Nessun token, tutto OK
+    } else if original_tokens.is_empty() && !translated_tokens.is_empty() {
+        warnings.push(format!(
+            "L'originale non contiene token Smart String, ma la traduzione ne ha {}",
+            translated_tokens.len()
+        ));
+    }
+
+    // Controlla ordine dei token (warning, non errore)
+    if missing_tokens.is_empty() && extra_tokens.is_empty() {
+        let orig_order: Vec<&str> = original_tokens.iter().map(|s| s.as_str()).collect();
+        let trans_order: Vec<&str> = translated_tokens.iter().map(|s| s.as_str()).collect();
+        if orig_order != trans_order {
+            warnings.push(
+                "I token sono presenti ma in ordine diverso. Questo potrebbe essere intenzionale per la lingua target.".to_string()
+            );
+        }
+    }
+
+    // Controlla braces non bilanciate nella traduzione
+    let open_count = translated.chars().filter(|&c| c == '{').count();
+    let close_count = translated.chars().filter(|&c| c == '}').count();
+    if open_count != close_count {
+        warnings.push(format!(
+            "Braces non bilanciate nella traduzione: {} aperture, {} chiusure",
+            open_count, close_count
+        ));
+    }
+
+    let valid = missing_tokens.is_empty() && extra_tokens.is_empty() &&
+        warnings.iter().all(|w| !w.contains("non bilanciate"));
+
+    Ok(SmartStringValidation {
+        valid,
+        missing_tokens,
+        extra_tokens,
+        warnings,
+    })
+}
+
+/// Costruisce un bundle patchato con le traduzioni fornite.
+/// Strategia iniziale: sostituzione diretta per stringhe di uguale o minore lunghezza,
+/// con padding a null per riempire lo spazio rimanente.
+#[tauri::command]
+pub async fn build_patched_bundle(
+    original_bundle: String,
+    translations: Vec<TranslatedStringTableEntry>,
+    output_path: String,
+) -> Result<PatchResult, String> {
+    let path = Path::new(&original_bundle);
+
+    if !path.exists() {
+        return Err(format!("Bundle originale non trovato: {}", original_bundle));
+    }
+
+    log::info!(
+        "Patching bundle: {} con {} traduzioni -> {}",
+        original_bundle, translations.len(), output_path
+    );
+
+    let data = fs::read(path)
+        .map_err(|e| format!("Errore lettura bundle: {}", e))?;
+
+    // 1. Parsa header e decomprimi
+    let (header, header_end) = parse_unityfs_header(&data)?;
+    let (blocks, _nodes, data_offset) = parse_block_info(&data, &header, header_end)?;
+    let mut decompressed = decompress_blocks(&data, &blocks, data_offset)?;
+
+    // 2. Costruisci mappa traduzioni per key_id
+    let translation_map: std::collections::HashMap<i64, &str> = translations.iter()
+        .map(|t| (t.key_id, t.translated.as_str()))
+        .collect();
+
+    // 3. Estrai le entry originali per trovare le posizioni delle stringhe
+    let original_entries = scan_for_string_table_entries(&decompressed);
+
+    let mut patched_count = 0usize;
+    let mut skipped_longer = 0usize;
+
+    // 4. Per ogni entry, cerca e sostituisci la stringa nel buffer decompresso
+    for entry in &original_entries {
+        if let Some(&translated) = translation_map.get(&entry.key_id) {
+            // Trova la stringa originale nel buffer
+            let original_bytes = entry.value.as_bytes();
+            let translated_bytes = translated.as_bytes();
+
+            // Cerca la stringa originale preceduta dalla sua lunghezza (i32)
+            let original_len = original_bytes.len() as i32;
+            let len_bytes = original_len.to_le_bytes();
+
+            let mut found = false;
+            for i in 0..decompressed.len().saturating_sub(4 + original_bytes.len()) {
+                if decompressed[i..i + 4] == len_bytes
+                    && i + 4 + original_bytes.len() <= decompressed.len()
+                    && decompressed[i + 4..i + 4 + original_bytes.len()] == *original_bytes
+                {
+                    // Trovata la stringa. Controlla se la traduzione ci sta
+                    let available_space = original_bytes.len();
+                    let aligned_end = align4(i + 4 + available_space);
+                    let total_available = aligned_end - (i + 4);
+
+                    if translated_bytes.len() <= total_available {
+                        // Scrivi la nuova lunghezza
+                        let new_len_bytes = (translated_bytes.len() as i32).to_le_bytes();
+                        decompressed[i..i + 4].copy_from_slice(&new_len_bytes);
+
+                        // Scrivi la traduzione
+                        let write_start = i + 4;
+                        decompressed[write_start..write_start + translated_bytes.len()]
+                            .copy_from_slice(translated_bytes);
+
+                        // Padding con null
+                        for j in write_start + translated_bytes.len()..aligned_end {
+                            if j < decompressed.len() {
+                                decompressed[j] = 0;
+                            }
+                        }
+
+                        patched_count += 1;
+                        found = true;
+                        break;
+                    } else {
+                        log::warn!(
+                            "Traduzione troppo lunga per key {}: {} bytes > {} disponibili",
+                            entry.key_id, translated_bytes.len(), total_available
+                        );
+                        skipped_longer += 1;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if !found {
+                log::warn!(
+                    "Stringa originale non trovata nel buffer per key {}: '{}'",
+                    entry.key_id, &entry.value[..std::cmp::min(entry.value.len(), 50)]
+                );
+            }
+        }
+    }
+
+    // 5. Ricomprimi e scrivi il file di output
+    let output = rebuild_bundle(&data, &header, header_end, &blocks, data_offset, &decompressed)?;
+
+    // Crea directory di output se necessario
+    if let Some(parent) = Path::new(&output_path).parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Errore creazione directory output: {}", e))?;
+    }
+
+    fs::write(&output_path, &output)
+        .map_err(|e| format!("Errore scrittura bundle patchato: {}", e))?;
+
+    let message = if skipped_longer > 0 {
+        format!(
+            "Patchate {} entry su {} ({} saltate: traduzione troppo lunga)",
+            patched_count, translations.len(), skipped_longer
+        )
+    } else {
+        format!("Patchate {} entry su {}", patched_count, translations.len())
+    };
+
+    log::info!("Patching completato: {}", message);
+
+    Ok(PatchResult {
+        success: patched_count > 0,
+        output_path: output_path.clone(),
+        entries_patched: patched_count,
+        message,
+    })
+}
+
+/// Ricostruisce un bundle Unity dai dati decompessi modificati.
+/// Per compressione LZ4 ricomprime i blocchi; per nessuna compressione copia direttamente.
+fn rebuild_bundle(
+    original_data: &[u8],
+    header: &UnityFSHeader,
+    header_end: usize,
+    original_blocks: &[BlockInfo],
+    original_data_offset: usize,
+    decompressed: &[u8],
+) -> Result<Vec<u8>, String> {
+    let flags = header.flags;
+    let block_info_at_end = (flags & 0x80) != 0;
+
+    // Ricostruisci i blocchi dati
+    let mut new_block_data = Vec::new();
+    let mut new_blocks_info: Vec<(u32, u32, u16)> = Vec::new(); // (uncomp, comp, flags)
+    let mut decomp_offset = 0usize;
+
+    for block in original_blocks {
+        let uncomp_size = block.uncompressed_size as usize;
+        let block_compression = block.flags & 0x3F;
+
+        let block_end = std::cmp::min(decomp_offset + uncomp_size, decompressed.len());
+        let block_slice = &decompressed[decomp_offset..block_end];
+
+        match block_compression {
+            0 => {
+                // Nessuna compressione: copia direttamente
+                new_block_data.extend_from_slice(block_slice);
+                new_blocks_info.push((block_slice.len() as u32, block_slice.len() as u32, 0));
+            }
+            2 | 3 => {
+                // LZ4/LZ4HC: ricomprimi con LZ4
+                let compressed = lz4_flex::compress(block_slice);
+                new_block_data.extend_from_slice(&compressed);
+                new_blocks_info.push((
+                    block_slice.len() as u32,
+                    compressed.len() as u32,
+                    block.flags,
+                ));
+            }
+            _ => {
+                return Err(format!(
+                    "Impossibile ricostruire blocco con compressione {}",
+                    block_compression
+                ));
+            }
+        }
+
+        decomp_offset += uncomp_size;
+    }
+
+    // Ricostruisci il block info
+    let mut new_block_info_buf = Vec::new();
+
+    // Hash dei dati non compressi (16 bytes, usiamo zeri per semplicità)
+    new_block_info_buf.extend_from_slice(&[0u8; 16]);
+
+    // Block count (i32 big-endian)
+    let block_count = new_blocks_info.len() as i32;
+    new_block_info_buf.extend_from_slice(&block_count.to_be_bytes());
+
+    for (uncomp, comp, bflags) in &new_blocks_info {
+        new_block_info_buf.extend_from_slice(&uncomp.to_be_bytes());
+        new_block_info_buf.extend_from_slice(&comp.to_be_bytes());
+        new_block_info_buf.extend_from_slice(&bflags.to_be_bytes());
+    }
+
+    // Node info (copia dall'originale)
+    // Dobbiamo ricostruire la sezione nodi dal block info originale
+    let original_compression = flags & 0x3F;
+    let original_block_info_offset = if block_info_at_end {
+        (header.file_size as usize) - header.compressed_block_info_size as usize
+    } else {
+        header_end
+    };
+
+    let original_compressed_info = &original_data[
+        original_block_info_offset..original_block_info_offset + header.compressed_block_info_size as usize
+    ];
+
+    let original_uncompressed_info = match original_compression {
+        0 => original_compressed_info.to_vec(),
+        2 | 3 => {
+            lz4_flex::decompress(original_compressed_info, header.uncompressed_block_info_size as usize)
+                .map_err(|e| format!("Errore decompressione block info per rebuild: {}", e))?
+        }
+        _ => return Err("Compressione block info non supportata per rebuild".into()),
+    };
+
+    // Estrai la sezione nodi dall'info originale (tutto dopo i blocchi)
+    // Skip: hash(16) + block_count(4) + blocks(10*n)
+    let original_blocks_section_size = 16 + 4 + (original_blocks.len() * 10);
+    if original_blocks_section_size < original_uncompressed_info.len() {
+        let nodes_section = &original_uncompressed_info[original_blocks_section_size..];
+        new_block_info_buf.extend_from_slice(nodes_section);
+    }
+
+    // Comprimi il nuovo block info
+    let compressed_block_info = match original_compression {
+        0 => new_block_info_buf.clone(),
+        2 | 3 => lz4_flex::compress(&new_block_info_buf),
+        _ => return Err("Compressione non supportata".into()),
+    };
+
+    // Assembla il file finale
+    let mut result = Vec::new();
+
+    // Copia header fino alla fine (prima dei campi variabili)
+    // Ricostruiamo l'header da zero per aggiornare le dimensioni
+    result.extend_from_slice(b"UnityFS\0");
+
+    // Format version (big-endian)
+    result.extend_from_slice(&header.format_version.to_be_bytes());
+
+    // Unity version (null-terminated)
+    result.extend_from_slice(header.unity_version.as_bytes());
+    result.push(0);
+
+    // Generator version (null-terminated)
+    result.extend_from_slice(header.generator_version.as_bytes());
+    result.push(0);
+
+    // Placeholder per file_size (aggiornato dopo)
+    let file_size_offset = result.len();
+    result.extend_from_slice(&[0u8; 8]);
+
+    // Compressed block info size
+    result.extend_from_slice(&(compressed_block_info.len() as u32).to_be_bytes());
+
+    // Uncompressed block info size
+    result.extend_from_slice(&(new_block_info_buf.len() as u32).to_be_bytes());
+
+    // Flags (conserva gli originali)
+    result.extend_from_slice(&flags.to_be_bytes());
+
+    if block_info_at_end {
+        // Dati prima, block info alla fine
+        result.extend_from_slice(&new_block_data);
+        result.extend_from_slice(&compressed_block_info);
+    } else {
+        // Block info prima, poi dati
+        result.extend_from_slice(&compressed_block_info);
+        result.extend_from_slice(&new_block_data);
+    }
+
+    // Aggiorna file_size nell'header
+    let file_size = result.len() as i64;
+    let file_size_bytes = file_size.to_be_bytes();
+    result[file_size_offset..file_size_offset + 8].copy_from_slice(&file_size_bytes);
+
+    let _ = original_data_offset; // suppress warning
+
+    Ok(result)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -560,6 +560,14 @@ fn main() {
             commands::unity_asset_injector::restore_unity_assets,
             commands::unity_asset_injector::scan_unity_ink_strings,
 
+            // Unity Localization Package (StringTable + Addressables + Smart Strings)
+            commands::unity_localization::parse_addressables_catalog,
+            commands::unity_localization::detect_string_tables_in_folder,
+            commands::unity_localization::extract_string_table,
+            commands::unity_localization::parse_smart_string,
+            commands::unity_localization::validate_smart_string_translation,
+            commands::unity_localization::build_patched_bundle,
+
             // Unity Direct Injection (bypassa BepInEx)
             commands::unity_injector::inject_unity_translator,
             commands::unity_injector::start_unity_translation_server,


### PR DESCRIPTION
## Summary
- Rust backend `commands::unity_localization` (6 Tauri commands): Addressables catalog parsing, StringTable detection/extraction from UnityFS bundles, Smart Strings tokenizer + translation validator, patched bundle rebuild.
- TypeScript client (`lib/unity-localization.ts`) and UI page (`app/unity-localization/page.tsx`) with multi-step wizard, Smart Strings validation and translation preview.
- Registered in `commands/mod.rs`, `main.rs` invoke_handler, `lib/tools-registry.ts`, and the sidebar.

## Test plan
- [x] `cargo check` clean (only the pre-existing `translation_bridge` warnings)
- [ ] Smoke-test on a Unity game shipping with the Unity Localization Package (parse catalog, extract a StringTable, translate, rebuild bundle, validate Smart Strings preserved)
- [ ] Regression: existing Unity patcher / Unity Bundle flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)