### PR TITLE
docs: v1.6.0 user guides + marketing site refresh

### DIFF
--- a/docs/GUIDA_UTENTE.md
+++ b/docs/GUIDA_UTENTE.md
@@ -1777,6 +1777,40 @@ La Chat Community è una funzionalità di messaggistica in tempo reale integrata
 - **Widget chat** in basso a destra con drawer espandibile
 - **i18n**: traduzioni chat in tutte le 11 lingue supportate
 
+## Novità v1.6.0
+
+### Patcher Bethesda Engine
+- **Giochi supportati**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Formati archivio**: BSA v103/v104/v105 e BA2 (GNRL + DX10)
+- **Plugin**: parsing ESP/ESM con estrazione record traducibili
+- **Stringhe localizzate**: STRINGS, DLSTRINGS, ILSTRINGS
+- **Workflow**: estrazione → traduzione AI → re-pack con backup automatico
+
+### Patcher CRI Middleware
+- **Giochi supportati**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball e tutti i titoli CRI
+- **Archivi**: CPK con decompressione CRILAYLA
+- **Formati messaggi**: MSG, BMD, FTD
+- **Workflow**: unpack CPK → decode messaggi → traduzione → repack
+
+### Unity Localization Package
+- Pipeline per il package ufficiale Unity Localization (Unity 2021.3+)
+- Supporto StringTable + SharedTableData, Addressables, Smart Strings
+- Validator dedicato per placeholder e plural forms
+
+### Export PO Universale
+- Export gettext PO con metadata completi da ogni patcher
+- Compatibile con Poedit, Weblate, Crowdin e qualsiasi CAT tool
+
+### Accessibilità WCAG 2.1 AA
+- aria-label su icon button, heading semantici, focus-visible
+- Skip link "Salta al contenuto", prefers-reduced-motion
+- Compatibilità Windows High Contrast (forced-colors)
+
+### Design System e OCR
+- Card variants via cva, Button xs/icon-sm, utilities text-micro/text-2xs
+- Backend Tauri Tesseract reale al posto dello stub OCR
+- Fix: console flash loop Windows quando l'app è in tray
+
 ---
 
-GameStringer v1.5.0 - Guida aggiornata al 24/03/2026
+GameStringer v1.6.0 - Guida aggiornata al 04/04/2026

--- a/docs/USER_GUIDE_DE.md
+++ b/docs/USER_GUIDE_DE.md
@@ -413,6 +413,37 @@ Echtzeit-Community-Chat im Community Hub, betrieben mit Supabase Realtime.
 - **Eigene Räume erstellen**: dedizierte Räume für Projekte oder Spiele
 - **Auto-Login**: automatische Verbindung über GameStringer-Profil
 
+## Neu in v1.6.0
+
+### Bethesda Engine Patcher
+- **Unterstützte Spiele**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Archivformate**: BSA v103/v104/v105 und BA2 (GNRL + DX10)
+- **Plugins**: ESP/ESM-Parsing mit Extraktion übersetzbarer Datensätze
+- **Lokalisierte Strings**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### CRI Middleware Patcher
+- **Unterstützte Spiele**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball und alle CRI-Titel
+- **Archive**: CPK mit CRILAYLA-Dekompression
+- **Nachrichtenformate**: MSG, BMD, FTD
+
+### Unity Localization Package
+- Pipeline für das offizielle Unity Localization Package (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Dedizierter Validator für Platzhalter und Pluralformen
+
+### Universal PO Export
+- gettext PO-Export mit vollständigen Metadaten aus jedem Patcher
+- Kompatibel mit Poedit, Weblate, Crowdin
+
+### Barrierefreiheit WCAG 2.1 AA
+- aria-label, semantische Überschriften, focus-visible
+- Skip-Link, prefers-reduced-motion, Windows High Contrast
+
+### Design System und OCR
+- Card-Varianten via cva, Button xs/icon-sm
+- Echtes Tauri Tesseract OCR-Backend statt Stub
+- Fix: Konsolen-Flash-Loop unter Windows beim Tray-Betrieb
+
 ---
 
-GameStringer v1.5.0 - Anleitung aktualisiert am 24.03.2026
+GameStringer v1.6.0 - Anleitung aktualisiert am 04.04.2026

--- a/docs/USER_GUIDE_EN.md
+++ b/docs/USER_GUIDE_EN.md
@@ -410,6 +410,40 @@ Real-time community chat integrated into the Community Hub, powered by Supabase 
 - Active internet connection
 - Supabase backend configured (for self-hosting)
 
+## What's New v1.6.0
+
+### Bethesda Engine Patcher
+- **Supported games**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Archive formats**: BSA v103/v104/v105 and BA2 (GNRL + DX10)
+- **Plugins**: ESP/ESM parsing with translatable record extraction
+- **Localized strings**: STRINGS, DLSTRINGS, ILSTRINGS
+- **Workflow**: extract → AI translate → repack with automatic backup
+
+### CRI Middleware Patcher
+- **Supported games**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball and every CRI title
+- **Archives**: CPK with CRILAYLA decompression
+- **Message formats**: MSG, BMD, FTD
+- **Workflow**: unpack CPK → decode messages → translate → repack
+
+### Unity Localization Package
+- Pipeline for the official Unity Localization package (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings support
+- Dedicated validator for placeholders and plural forms
+
+### Universal PO Export
+- gettext PO export with full metadata from every patcher
+- Compatible with Poedit, Weblate, Crowdin and any CAT tool
+
+### Accessibility WCAG 2.1 AA
+- aria-label on icon buttons, semantic headings, focus-visible
+- "Skip to content" skip link, prefers-reduced-motion
+- Windows High Contrast compatibility (forced-colors)
+
+### Design System and OCR
+- Card variants via cva, Button xs/icon-sm, text-micro/text-2xs utilities
+- Real Tauri Tesseract backend replacing the OCR stub
+- Fix: Windows console flash loop when the app runs in tray
+
 ---
 
-GameStringer v1.5.0 - Guide updated 24/03/2026
+GameStringer v1.6.0 - Guide updated 04/04/2026

--- a/docs/USER_GUIDE_ES.md
+++ b/docs/USER_GUIDE_ES.md
@@ -413,6 +413,37 @@ Chat en tiempo real integrado en el Community Hub, impulsado por Supabase Realti
 - **Crear salas personalizadas**: salas dedicadas para proyectos o juegos
 - **Auto-login**: conexión automática vía perfil GameStringer
 
+## Novedades v1.6.0
+
+### Parcheador Bethesda Engine
+- **Juegos compatibles**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Formatos de archivo**: BSA v103/v104/v105 y BA2 (GNRL + DX10)
+- **Plugins**: análisis ESP/ESM con extracción de registros traducibles
+- **Cadenas localizadas**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### Parcheador CRI Middleware
+- **Juegos compatibles**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball y todos los títulos CRI
+- **Archivos**: CPK con descompresión CRILAYLA
+- **Formatos de mensaje**: MSG, BMD, FTD
+
+### Unity Localization Package
+- Pipeline para el paquete oficial Unity Localization (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Validador dedicado para placeholders y formas plurales
+
+### Exportación PO universal
+- Exportación gettext PO con metadatos completos desde cada parcheador
+- Compatible con Poedit, Weblate, Crowdin
+
+### Accesibilidad WCAG 2.1 AA
+- aria-label, encabezados semánticos, focus-visible
+- Enlace de salto, prefers-reduced-motion, Windows High Contrast
+
+### Sistema de diseño y OCR
+- Variantes de Card vía cva, Button xs/icon-sm
+- Backend Tauri Tesseract real en lugar del stub OCR
+- Fix: bucle de flash de consola en Windows con la app en la bandeja
+
 ---
 
-GameStringer v1.5.0 - Guía actualizada 24/03/2026
+GameStringer v1.6.0 - Guía actualizada 04/04/2026

--- a/docs/USER_GUIDE_FR.md
+++ b/docs/USER_GUIDE_FR.md
@@ -413,6 +413,37 @@ Chat en temps réel intégré au Community Hub, propulsé par Supabase Realtime.
 - **Créer des salons personnalisés** : salons dédiés pour projets ou jeux
 - **Auto-login** : connexion automatique via profil GameStringer
 
+## Nouveautés v1.6.0
+
+### Patcheur Bethesda Engine
+- **Jeux pris en charge** : Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Formats d'archive** : BSA v103/v104/v105 et BA2 (GNRL + DX10)
+- **Plugins** : analyse ESP/ESM avec extraction des enregistrements traduisibles
+- **Chaînes localisées** : STRINGS, DLSTRINGS, ILSTRINGS
+
+### Patcheur CRI Middleware
+- **Jeux pris en charge** : Persona 5 Royal, Yakuza, Tales of, Dragon Ball et tous les titres CRI
+- **Archives** : CPK avec décompression CRILAYLA
+- **Formats de messages** : MSG, BMD, FTD
+
+### Unity Localization Package
+- Pipeline pour le package officiel Unity Localization (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Validator dédié pour les placeholders et les formes plurielles
+
+### Export PO universel
+- Export gettext PO avec métadonnées complètes depuis chaque patcheur
+- Compatible avec Poedit, Weblate, Crowdin
+
+### Accessibilité WCAG 2.1 AA
+- aria-label, titres sémantiques, focus-visible
+- Lien d'évitement, prefers-reduced-motion, Windows High Contrast
+
+### Design System et OCR
+- Variantes de Card via cva, Button xs/icon-sm
+- Vrai backend Tauri Tesseract OCR à la place du stub
+- Correction : boucle de flash console Windows en mode tray
+
 ---
 
-GameStringer v1.5.0 - Guide mise à jour le 24/03/2026
+GameStringer v1.6.0 - Guide mise à jour le 04/04/2026

--- a/docs/USER_GUIDE_JA.md
+++ b/docs/USER_GUIDE_JA.md
@@ -413,6 +413,37 @@ Community Hubに統合されたリアルタイムチャット。Supabase Realtim
 - **カスタムルーム作成**：プロジェクトやゲーム専用ルーム
 - **自動ログイン**：GameStringerプロフィールで自動接続
 
+## v1.6.0の新機能
+
+### Bethesdaエンジン パッチャー
+- **対応ゲーム**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **アーカイブ形式**: BSA v103/v104/v105 および BA2 (GNRL + DX10)
+- **プラグイン**: ESP/ESM 解析と翻訳可能レコードの抽出
+- **ローカライズ文字列**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### CRIミドルウェア パッチャー
+- **対応ゲーム**: ペルソナ5 ザ・ロイヤル、龍が如く、テイルズ オブ、ドラゴンボール等
+- **アーカイブ**: CPK + CRILAYLA 解凍
+- **メッセージ形式**: MSG, BMD, FTD
+
+### Unity Localization パッケージ
+- 公式 Unity Localization パッケージ用のパイプライン (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- プレースホルダと複数形のバリデーター
+
+### 汎用PO エクスポート
+- 各パッチャーからの gettext PO エクスポート（メタデータ完備）
+- Poedit、Weblate、Crowdin と互換
+
+### アクセシビリティ WCAG 2.1 AA
+- aria-label、セマンティック見出し、focus-visible
+- スキップリンク、prefers-reduced-motion、Windows ハイコントラスト
+
+### デザインシステムとOCR
+- cva による Card バリアント、Button xs/icon-sm
+- OCR スタブを置き換える実 Tauri Tesseract バックエンド
+- 修正: タスクトレイ時のコンソールフラッシュ ループ
+
 ---
 
-GameStringer v1.5.0 - ガイド更新日 2026/03/24
+GameStringer v1.6.0 - ガイド更新日 2026/04/04

--- a/docs/USER_GUIDE_KO.md
+++ b/docs/USER_GUIDE_KO.md
@@ -413,6 +413,37 @@ Community Hub에 통합된 실시간 채팅. Supabase Realtime으로 구동.
 - **사용자 정의 채팅방 생성**: 프로젝트 또는 게임 전용 채팅방
 - **자동 로그인**: GameStringer 프로필로 자동 연결
 
+## v1.6.0 새 기능
+
+### Bethesda 엔진 패처
+- **지원 게임**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **아카이브 형식**: BSA v103/v104/v105 및 BA2 (GNRL + DX10)
+- **플러그인**: ESP/ESM 파싱 및 번역 가능 레코드 추출
+- **로컬라이즈 문자열**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### CRI 미들웨어 패처
+- **지원 게임**: 페르소나 5 더 로열, 용과 같이, 테일즈 오브, 드래곤볼 등
+- **아카이브**: CPK 및 CRILAYLA 압축 해제
+- **메시지 형식**: MSG, BMD, FTD
+
+### Unity Localization 패키지
+- 공식 Unity Localization 패키지 파이프라인 (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- 자리 표시자와 복수형 전용 검증기
+
+### 범용 PO 내보내기
+- 각 패처에서 전체 메타데이터와 함께 gettext PO 내보내기
+- Poedit, Weblate, Crowdin 호환
+
+### 접근성 WCAG 2.1 AA
+- aria-label, 시맨틱 헤딩, focus-visible
+- 건너뛰기 링크, prefers-reduced-motion, Windows 고대비
+
+### 디자인 시스템 및 OCR
+- cva 기반 Card 변형, Button xs/icon-sm
+- OCR 스텁 대신 실제 Tauri Tesseract 백엔드
+- 수정: 트레이 상태에서 Windows 콘솔 플래시 루프
+
 ---
 
-GameStringer v1.5.0 - 가이드 업데이트 2026/03/24
+GameStringer v1.6.0 - 가이드 업데이트 2026/04/04

--- a/docs/USER_GUIDE_PL.md
+++ b/docs/USER_GUIDE_PL.md
@@ -413,6 +413,37 @@ Czat w czasie rzeczywistym zintegrowany z Community Hub, oparty na Supabase Real
 - **Tworzenie własnych pokojów**: dedykowane pokoje dla projektów lub gier
 - **Auto-login**: automatyczne połączenie przez profil GameStringer
 
+## Nowości v1.6.0
+
+### Patcher Bethesda Engine
+- **Obsługiwane gry**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Formaty archiwów**: BSA v103/v104/v105 oraz BA2 (GNRL + DX10)
+- **Wtyczki**: parsowanie ESP/ESM z ekstrakcją rekordów do tłumaczenia
+- **Zlokalizowane ciągi**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### Patcher CRI Middleware
+- **Obsługiwane gry**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball i wszystkie tytuły CRI
+- **Archiwa**: CPK z dekompresją CRILAYLA
+- **Formaty wiadomości**: MSG, BMD, FTD
+
+### Unity Localization Package
+- Pełny potok dla oficjalnego pakietu Unity Localization (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Dedykowany walidator placeholderów i form mnogich
+
+### Uniwersalny eksport PO
+- Eksport gettext PO z pełnymi metadanymi z każdego patchera
+- Kompatybilny z Poedit, Weblate, Crowdin
+
+### Dostępność WCAG 2.1 AA
+- aria-label, semantyczne nagłówki, focus-visible
+- Link pomijający, prefers-reduced-motion, Windows High Contrast
+
+### System projektowy i OCR
+- Warianty Card przez cva, Button xs/icon-sm
+- Prawdziwy backend Tauri Tesseract zamiast zaślepki OCR
+- Poprawka: pętla migania konsoli Windows w trybie tray
+
 ---
 
-GameStringer v1.5.0 - Przewodnik zaktualizowany 24.03.2026
+GameStringer v1.6.0 - Przewodnik zaktualizowany 04.04.2026

--- a/docs/USER_GUIDE_PT.md
+++ b/docs/USER_GUIDE_PT.md
@@ -413,6 +413,37 @@ Chat em tempo real integrado ao Community Hub, alimentado por Supabase Realtime.
 - **Criar salas personalizadas**: salas dedicadas para projetos ou jogos
 - **Auto-login**: conexão automática via perfil GameStringer
 
+## Novidades v1.6.0
+
+### Patcher Bethesda Engine
+- **Jogos suportados**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Formatos de arquivo**: BSA v103/v104/v105 e BA2 (GNRL + DX10)
+- **Plugins**: análise ESP/ESM com extração de registros traduzíveis
+- **Strings localizadas**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### Patcher CRI Middleware
+- **Jogos suportados**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball e todos os títulos CRI
+- **Arquivos**: CPK com descompressão CRILAYLA
+- **Formatos de mensagem**: MSG, BMD, FTD
+
+### Unity Localization Package
+- Pipeline para o pacote oficial Unity Localization (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Validador dedicado para placeholders e formas plurais
+
+### Exportação PO universal
+- Exportação gettext PO com metadados completos de cada patcher
+- Compatível com Poedit, Weblate, Crowdin
+
+### Acessibilidade WCAG 2.1 AA
+- aria-label, cabeçalhos semânticos, focus-visible
+- Skip link, prefers-reduced-motion, Windows High Contrast
+
+### Design System e OCR
+- Variantes de Card via cva, Button xs/icon-sm
+- Backend Tauri Tesseract real no lugar do stub OCR
+- Correção: console flash loop no Windows com app na bandeja
+
 ---
 
-GameStringer v1.5.0 - Guia atualizado 24/03/2026
+GameStringer v1.6.0 - Guia atualizado 04/04/2026

--- a/docs/USER_GUIDE_RU.md
+++ b/docs/USER_GUIDE_RU.md
@@ -413,6 +413,37 @@ Unity (Mono/IL2CPP), Unreal Engine, Godot, RPG Maker, Ren'Py, Source Engine, Cry
 - **Создание пользовательских комнат**: комнаты для проектов или игр
 - **Авто-вход**: автоматическое подключение через профиль GameStringer
 
+## Что нового в v1.6.0
+
+### Патчер Bethesda Engine
+- **Поддерживаемые игры**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield
+- **Форматы архивов**: BSA v103/v104/v105 и BA2 (GNRL + DX10)
+- **Плагины**: парсинг ESP/ESM с извлечением переводимых записей
+- **Локализованные строки**: STRINGS, DLSTRINGS, ILSTRINGS
+
+### Патчер CRI Middleware
+- **Поддерживаемые игры**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball и все CRI-тайтлы
+- **Архивы**: CPK с распаковкой CRILAYLA
+- **Форматы сообщений**: MSG, BMD, FTD
+
+### Unity Localization Package
+- Конвейер для официального пакета Unity Localization (Unity 2021.3+)
+- StringTable + SharedTableData, Addressables, Smart Strings
+- Выделенный валидатор для плейсхолдеров и форм множественного числа
+
+### Универсальный экспорт PO
+- Экспорт gettext PO с полными метаданными из каждого патчера
+- Совместимость с Poedit, Weblate, Crowdin
+
+### Доступность WCAG 2.1 AA
+- aria-label, семантические заголовки, focus-visible
+- Ссылка для перехода к контенту, prefers-reduced-motion, Windows High Contrast
+
+### Дизайн-система и OCR
+- Варианты Card через cva, Button xs/icon-sm
+- Реальный бэкенд Tauri Tesseract вместо заглушки OCR
+- Исправление: цикл мерцания консоли в Windows при работе в трее
+
 ---
 
-GameStringer v1.5.0 - Руководство обновлено 24.03.2026
+GameStringer v1.6.0 - Руководство обновлено 04.04.2026

--- a/docs/USER_GUIDE_ZH.md
+++ b/docs/USER_GUIDE_ZH.md
@@ -413,6 +413,37 @@ Unity游戏（Mono和IL2CPP）的**最佳方法**。
 - **创建自定义聊天室**：为项目或游戏创建专用聊天室
 - **自动登录**：通过GameStringer个人资料自动连接
 
+## v1.6.0 新功能
+
+### Bethesda 引擎补丁器
+- **支持游戏**: Skyrim LE/SE/AE、Fallout 3/NV/4、Oblivion、Starfield
+- **归档格式**: BSA v103/v104/v105 和 BA2 (GNRL + DX10)
+- **插件**: ESP/ESM 解析并提取可翻译记录
+- **本地化字符串**: STRINGS、DLSTRINGS、ILSTRINGS
+
+### CRI 中间件补丁器
+- **支持游戏**: 女神异闻录5皇家版、如龙、Tales of、七龙珠等 CRI 作品
+- **归档**: CPK 和 CRILAYLA 解压
+- **消息格式**: MSG、BMD、FTD
+
+### Unity Localization 包
+- 官方 Unity Localization 包的完整流水线 (Unity 2021.3+)
+- StringTable + SharedTableData、Addressables、Smart Strings
+- 占位符和复数形式验证器
+
+### 通用 PO 导出
+- 各补丁器的 gettext PO 导出（含完整元数据）
+- 兼容 Poedit、Weblate、Crowdin
+
+### 无障碍 WCAG 2.1 AA
+- aria-label、语义标题、focus-visible
+- 跳转链接、prefers-reduced-motion、Windows 高对比度
+
+### 设计系统和 OCR
+- 通过 cva 的 Card 变体、Button xs/icon-sm
+- 使用真实 Tauri Tesseract 后端替换 OCR 桩
+- 修复: 托盘模式下 Windows 控制台闪烁循环
+
 ---
 
-GameStringer v1.5.0 - 指南更新于 2026/03/24
+GameStringer v1.6.0 - 指南更新于 2026/04/04

--- a/docs/sito/index-en.html
+++ b/docs/sito/index-en.html
@@ -43,7 +43,7 @@
     
     <!-- HERO -->
     <div class="hero">
-      <span class="badge hero-badge"><span class="hero-badge-new">NEW</span> v1.4.2 — Vision LLM Translator, Advanced AI Tools, Translation Provider Fix</span>
+      <span class="badge hero-badge"><span class="hero-badge-new">NEW</span> v1.6.0 — Bethesda/CRI Patchers + Unity Localization + a11y</span>
       <h1>Translate <span class="hero-highlight">Any</span> Video Game<br>with Artificial Intelligence</h1>
       <p class="hero-subtitle">The ultimate open source suite for video game localization</p>
       <p class="hero-desc">Supports <strong>11+ engines</strong> (Unity, Unreal, Godot, RPG Maker, Ren'Py, Danganronpa...) and <strong>20+ AI providers</strong> (TranslateGemma, HY-MT, Ollama, GPT-4, Claude, Gemini, DeepSeek...). <strong>Quality Badges</strong> per-row (0-100), Auto-glossary AI, Translation Memory, Interactive Tutorial. <strong>500 free strings</strong>, then free donation.</p>
@@ -320,36 +320,48 @@
   </div>
 </section>
 
-<!-- WHAT'S NEW v1.4.2 -->
+<!-- WHAT'S NEW v1.6.0 -->
 <section id="whatsnew">
   <div class="container" style="text-align:center">
-    <span class="badge section-badge" style="background:rgba(6,182,212,.15);border-color:rgba(6,182,212,.3);color:#22d3ee">🆕 What's New in v1.4.2</span>
+    <span class="badge section-badge" style="background:rgba(6,182,212,.15);border-color:rgba(6,182,212,.3);color:#22d3ee">🆕 What's New in v1.6.0</span>
     <h2 class="section-title">Latest Release Highlights</h2>
-    <p class="section-desc">Vision LLM Translator, Advanced AI Tools, and critical Translation Provider fixes.</p>
+    <p class="section-desc">Bethesda/CRI Patchers, Unity Localization Package, Universal PO export and WCAG 2.1 AA accessibility sweep.</p>
     <div class="grid grid-2" style="margin-top:48px;text-align:left">
-      <div class="card feature-card" style="border-left:4px solid #06b6d4">
-        <div class="icon-box" style="background:linear-gradient(135deg,#06b6d4,#0891b2)">👁️</div>
-        <h3 class="feature-title">Vision LLM Translator</h3>
-        <p class="feature-desc">Context-aware translation using in-game screenshots. Upload an image or capture your screen to give visual context to the AI.</p>
-        <div class="feature-tags"><span class="feature-tag">Ollama</span><span class="feature-tag">Gemini 2.0 Flash</span><span class="feature-tag">GPT-4o</span><span class="feature-tag">/vision-translator</span></div>
-      </div>
-      <div class="card feature-card" style="border-left:4px solid #8b5cf6">
-        <div class="icon-box" style="background:linear-gradient(135deg,#8b5cf6,#7c3aed)">🧠</div>
-        <h3 class="feature-title">Advanced AI Tools</h3>
-        <p class="feature-desc">Lore Assistant (RAG chat), Auto-Hook Scanner (WinAPI), System Monitor VRAM/RAM (Rust), Ollama Setup Wizard, Debug Console, Plugin System.</p>
-        <div class="feature-tags"><span class="feature-tag">Lore RAG</span><span class="feature-tag">Memory Scan</span><span class="feature-tag">VRAM Monitor</span><span class="feature-tag">Debug Console</span></div>
-      </div>
-      <div class="card feature-card" style="border-left:4px solid #22c55e">
-        <div class="icon-box" style="background:linear-gradient(135deg,#22c55e,#16a34a)">🔧</div>
-        <h3 class="feature-title">Translation Provider Fix</h3>
-        <p class="feature-desc">Ollama: 30s cooldown instead of permanent block. Lingva: auto-truncate texts &gt;500 chars. New "Translate all untranslated" button with progress bar and stop.</p>
-        <div class="feature-tags"><span class="feature-tag">Ollama Cooldown</span><span class="feature-tag">Lingva Fix</span><span class="feature-tag">Auto-Translate Batch</span><span class="feature-tag">Tutorial Fix</span></div>
+      <div class="card feature-card" style="border-left:4px solid #dc2626">
+        <div class="icon-box" style="background:linear-gradient(135deg,#b91c1c,#dc2626)">🏰</div>
+        <h3 class="feature-title">Bethesda Engine Patcher</h3>
+        <p class="feature-desc">Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield. Supports BSA v103-105, BA2 GNRL/DX10, ESP/ESM and STRINGS/DLSTRINGS/ILSTRINGS.</p>
+        <div class="feature-tags"><span class="feature-tag">BSA/BA2</span><span class="feature-tag">ESP/ESM</span><span class="feature-tag">STRINGS</span><span class="feature-tag">Creation Engine</span></div>
       </div>
       <div class="card feature-card" style="border-left:4px solid #f59e0b">
-        <div class="icon-box" style="background:linear-gradient(135deg,#f59e0b,#d97706)">👥</div>
-        <h3 class="feature-title">Community & CI/CD</h3>
-        <p class="feature-desc">Community Hub with GitHub Discussions. Tauri Signing Key for signed auto-updates. Release workflow for Windows + Linux. 11 user guides updated.</p>
-        <div class="feature-tags"><span class="feature-tag">Discussions</span><span class="feature-tag">Signed Updates</span><span class="feature-tag">Win + Linux</span><span class="feature-tag">11 Guides</span></div>
+        <div class="icon-box" style="background:linear-gradient(135deg,#d97706,#f59e0b)">🎮</div>
+        <h3 class="feature-title">CRI Middleware Patcher</h3>
+        <p class="feature-desc">Persona 5 Royal, Yakuza, Tales of, Dragon Ball and all CRI titles. Decodes CPK + CRILAYLA and MSG/BMD/FTD formats.</p>
+        <div class="feature-tags"><span class="feature-tag">CPK</span><span class="feature-tag">CRILAYLA</span><span class="feature-tag">MSG/BMD/FTD</span><span class="feature-tag">Atlus/SEGA</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #0ea5e9">
+        <div class="icon-box" style="background:linear-gradient(135deg,#0891b2,#06b6d4)">🧩</div>
+        <h3 class="feature-title">Unity Localization Package</h3>
+        <p class="feature-desc">Full pipeline for the official Unity Localization package: StringTable + SharedTableData, Addressables and Smart Strings validator.</p>
+        <div class="feature-tags"><span class="feature-tag">StringTable</span><span class="feature-tag">Addressables</span><span class="feature-tag">Smart Strings</span><span class="feature-tag">Unity 2021+</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #22c55e">
+        <div class="icon-box" style="background:linear-gradient(135deg,#059669,#10b981)">📦</div>
+        <h3 class="feature-title">Universal PO Export</h3>
+        <p class="feature-desc">gettext PO export with full metadata from every patcher. Compatible with Poedit, Weblate, Crowdin and any CAT tool.</p>
+        <div class="feature-tags"><span class="feature-tag">gettext</span><span class="feature-tag">Poedit</span><span class="feature-tag">Weblate</span><span class="feature-tag">Metadata</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #8b5cf6">
+        <div class="icon-box" style="background:linear-gradient(135deg,#7c3aed,#8b5cf6)">♿</div>
+        <h3 class="feature-title">Accessibility WCAG 2.1 AA</h3>
+        <p class="feature-desc">aria-label, semantic headings, focus-visible, skip link, prefers-reduced-motion and Windows High Contrast support across the whole app.</p>
+        <div class="feature-tags"><span class="feature-tag">WCAG 2.1 AA</span><span class="feature-tag">Screen Reader</span><span class="feature-tag">Forced Colors</span><span class="feature-tag">Reduced Motion</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #ec4899">
+        <div class="icon-box" style="background:linear-gradient(135deg,#db2777,#ec4899)">🎨</div>
+        <h3 class="feature-title">Design System + Real OCR</h3>
+        <p class="feature-desc">Card variants via cva, Button xs/icon-sm, text-micro/text-2xs utilities. Real Tauri Tesseract OCR backend replacing the stub.</p>
+        <div class="feature-tags"><span class="feature-tag">cva</span><span class="feature-tag">Design Tokens</span><span class="feature-tag">Tesseract</span><span class="feature-tag">Tray Fix</span></div>
       </div>
     </div>
   </div>
@@ -478,7 +490,7 @@
     </div>
     <div class="footer-bottom">
       <p>© 2025-2026 GameStringer by <a href="https://github.com/rouges78" style="color: #7dd3fc;">rouges78</a>. Source-Available License.</p>
-      <p>Made with <span class="footer-heart">♥</span> in Italy 🇮🇹 — v1.4.2</p>
+      <p>Made with <span class="footer-heart">♥</span> in Italy 🇮🇹 — v1.6.0</p>
     </div>
   </div>
 </footer>

--- a/docs/sito/index.html
+++ b/docs/sito/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GameStringer - Traduci Qualsiasi Videogioco con l'AI</title>
-  <meta name="description" content="GameStringer v1.5.0 — Suite open source per tradurre videogiochi con AI. 11+ engine, 20+ provider AI, Community Chat Realtime, Quality Badges, Auto-glossario.">
-  <meta name="keywords" content="game translation, video game localization, AI translator, Unity, Unreal, RPG Maker, Danganronpa, Ollama, GPT-4, TranslateGemma">
-  <meta property="og:title" content="GameStringer v1.5.0 - Traduci Qualsiasi Videogioco con l'AI">
+  <meta name="description" content="GameStringer v1.6.0 — Suite open source per tradurre videogiochi con AI. 11+ engine, 20+ provider AI, Bethesda/CRI Patchers, Unity Localization, Quality Badges, Auto-glossario.">
+  <meta name="keywords" content="game translation, video game localization, AI translator, Unity, Unreal, RPG Maker, Bethesda, CRI, Danganronpa, Ollama, GPT-4, TranslateGemma">
+  <meta property="og:title" content="GameStringer v1.6.0 - Traduci Qualsiasi Videogioco con l'AI">
   <meta property="og:description" content="Suite open source: 11+ engine, 20+ AI, auto-glossario, TM, Quality Badges. Gratuito.">
   <meta property="og:image" content="images/og-image.svg">
   <meta property="og:type" content="website">
@@ -49,7 +49,7 @@
       </div>
     </nav>
     <div class="hero">
-      <span class="badge hero-badge"><span class="hero-badge-new">NEW</span> <span data-i18n="hero.badge">v1.5.0 — Community Chat Realtime, Auto-Bridge Auth, 11 Lingue</span></span>
+      <span class="badge hero-badge"><span class="hero-badge-new">NEW</span> <span data-i18n="hero.badge">v1.6.0 — Bethesda/CRI Patchers + Unity Localization + a11y</span></span>
       <h1 data-i18n="hero.title">GameStringer</h1>
       <p class="hero-subtitle" data-i18n="hero.subtitle">Localizza videogiochi con l'AI. Open source. Gratuito.</p>
       <p class="hero-desc" data-i18n="hero.desc">Supporta <strong>11+ engine</strong> (Unity, Unreal, Godot, RPG Maker, Ren'Py, <strong>Danganronpa</strong>...) e <strong>20+ provider AI</strong> (TranslateGemma, HY-MT, Ollama, GPT-4, Claude, Gemini, DeepSeek...). <strong>Quality Badges</strong> per-riga (0-100), Auto-glossario AI, Translation Memory persistente, Tutorial interattivo. <strong>500 stringhe gratuite</strong>, poi donazione libera.</p>
@@ -135,7 +135,7 @@
         <div style="position:absolute;bottom:0;left:0;right:0;padding:20px 24px;text-align:left">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
                         <h4 style="color:#e2e8f0;font-size:1rem;font-weight:700;margin:0">Community Chat</h4>
-            <span style="background:rgba(14,165,233,0.3);color:#7dd3fc;font-size:0.65rem;padding:2px 8px;border-radius:4px;font-weight:600">NEW v1.5.0</span>
+            <span style="background:rgba(14,165,233,0.3);color:#7dd3fc;font-size:0.65rem;padding:2px 8px;border-radius:4px;font-weight:600">v1.5.0</span>
           </div>
           <p style="color:#94a3b8;font-size:0.78rem;margin:0;line-height:1.4">Chat in tempo reale con Supabase Realtime. Stanze tematiche, presenza online, auto-login da profilo GS.</p>
         </div>
@@ -392,36 +392,48 @@
     </div>
   </div>
 </section>
-<!-- WHAT'S NEW v1.5.0 -->
+<!-- WHAT'S NEW v1.6.0 -->
 <section id="whatsnew">
   <div class="container" style="text-align:center">
-    <span class="badge section-badge">// v1.5.0</span>
-    <h2 class="section-title" data-i18n="whatsnew.title">Novità nella Versione 1.5.0</h2>
-    <p class="section-desc" data-i18n="whatsnew.desc">Community Chat Realtime, Auto-Bridge Authentication e documentazione in 11 lingue.</p>
+    <span class="badge section-badge">// v1.6.0</span>
+    <h2 class="section-title" data-i18n="whatsnew.title">Novità nella Versione 1.6.0</h2>
+    <p class="section-desc" data-i18n="whatsnew.desc">Bethesda/CRI Patchers, Unity Localization Package, Universal PO export e Accessibility WCAG 2.1 AA.</p>
     <div class="grid grid-2" style="margin-top:48px;text-align:left">
-      <div class="card feature-card" style="border-left:4px solid #0ea5e9">
-        <div class="icon-box" style="background:linear-gradient(135deg,#0891b2,#06b6d4)"><span style="color:#22d3ee;font-weight:800;font-size:14px">CHAT</span></div>
-        <h3 class="feature-title">Community Chat Realtime</h3>
-        <p class="feature-desc">Chat in tempo reale nel Community Hub via Supabase Realtime. 4 stanze predefinite (Generale, Traduzioni, Feedback & Bug, Annunci). Crea stanze personalizzate per giochi o progetti.</p>
-        <div class="feature-tags"><span class="feature-tag">Supabase Realtime</span><span class="feature-tag">4 Stanze</span><span class="feature-tag">Custom Rooms</span><span class="feature-tag">Presenza Online</span></div>
-      </div>
-      <div class="card feature-card" style="border-left:4px solid #8b5cf6">
-        <div class="icon-box" style="background:linear-gradient(135deg,#7c3aed,#8b5cf6)"><span style="color:#a78bfa;font-weight:800;font-size:14px">AUTH</span></div>
-        <h3 class="feature-title">Auto-Bridge Authentication</h3>
-        <p class="feature-desc">Il tuo profilo GameStringer si sincronizza automaticamente con Supabase Auth. Nessun login aggiuntivo. Client unificato, eliminati i warning "Multiple GoTrueClient".</p>
-        <div class="feature-tags"><span class="feature-tag">Zero Config</span><span class="feature-tag">Auto-Login</span><span class="feature-tag">Client Unificato</span><span class="feature-tag">Auto-Profile</span></div>
-      </div>
-      <div class="card feature-card" style="border-left:4px solid #22c55e">
-        <div class="icon-box" style="background:linear-gradient(135deg,#059669,#10b981)"><span style="color:#34d399;font-weight:800;font-size:14px">i18n</span></div>
-        <h3 class="feature-title">i18n & Documentazione</h3>
-        <p class="feature-desc">Traduzioni chat in tutte le 11 lingue supportate. Guide utente aggiornate con sezione Community Chat. Tutorial interattivo dedicato.</p>
-        <div class="feature-tags"><span class="feature-tag">11 Lingue</span><span class="feature-tag">Guide Aggiornate</span><span class="feature-tag">Tutorial Chat</span><span class="feature-tag">Locales</span></div>
+      <div class="card feature-card" style="border-left:4px solid #dc2626">
+        <div class="icon-box" style="background:linear-gradient(135deg,#b91c1c,#dc2626)"><span style="color:#f87171;font-weight:800;font-size:14px">BGS</span></div>
+        <h3 class="feature-title">Bethesda Engine Patcher</h3>
+        <p class="feature-desc">Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield. Supporta BSA v103-105, BA2 GNRL/DX10, ESP/ESM e STRINGS/DLSTRINGS/ILSTRINGS.</p>
+        <div class="feature-tags"><span class="feature-tag">BSA/BA2</span><span class="feature-tag">ESP/ESM</span><span class="feature-tag">STRINGS</span><span class="feature-tag">Creation Engine</span></div>
       </div>
       <div class="card feature-card" style="border-left:4px solid #f59e0b">
-        <div class="icon-box" style="background:linear-gradient(135deg,#d97706,#f59e0b)"><span style="color:#fbbf24;font-weight:800;font-size:16px">DB</span></div>
-        <h3 class="feature-title">Backend Supabase</h3>
-        <p class="feature-desc">PostgreSQL con RLS policies, trigger auto-profilo, RPC functions (SECURITY DEFINER). Realtime broadcasting per messaggi e presenza utenti.</p>
-        <div class="feature-tags"><span class="feature-tag">PostgreSQL</span><span class="feature-tag">RLS Policies</span><span class="feature-tag">RPC Functions</span><span class="feature-tag">Realtime</span></div>
+        <div class="icon-box" style="background:linear-gradient(135deg,#d97706,#f59e0b)"><span style="color:#fbbf24;font-weight:800;font-size:14px">CRI</span></div>
+        <h3 class="feature-title">CRI Middleware Patcher</h3>
+        <p class="feature-desc">Persona 5 Royal, Yakuza, Tales of, Dragon Ball e tutti i titoli CRI. Decodifica CPK + CRILAYLA e formati MSG/BMD/FTD.</p>
+        <div class="feature-tags"><span class="feature-tag">CPK</span><span class="feature-tag">CRILAYLA</span><span class="feature-tag">MSG/BMD/FTD</span><span class="feature-tag">Atlus/SEGA</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #0ea5e9">
+        <div class="icon-box" style="background:linear-gradient(135deg,#0891b2,#06b6d4)"><span style="color:#22d3ee;font-weight:800;font-size:14px">U-LOC</span></div>
+        <h3 class="feature-title">Unity Localization Package</h3>
+        <p class="feature-desc">Pipeline completa per il package ufficiale Unity Localization: StringTable + SharedTableData, Addressables e validator Smart Strings.</p>
+        <div class="feature-tags"><span class="feature-tag">StringTable</span><span class="feature-tag">Addressables</span><span class="feature-tag">Smart Strings</span><span class="feature-tag">Unity 2021+</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #22c55e">
+        <div class="icon-box" style="background:linear-gradient(135deg,#059669,#10b981)"><span style="color:#34d399;font-weight:800;font-size:14px">PO</span></div>
+        <h3 class="feature-title">Universal PO Export</h3>
+        <p class="feature-desc">Export gettext PO con metadata completi da ogni patcher. Compatibile con Poedit, Weblate, Crowdin e qualsiasi CAT tool.</p>
+        <div class="feature-tags"><span class="feature-tag">gettext</span><span class="feature-tag">Poedit</span><span class="feature-tag">Weblate</span><span class="feature-tag">Metadata</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #8b5cf6">
+        <div class="icon-box" style="background:linear-gradient(135deg,#7c3aed,#8b5cf6)"><span style="color:#a78bfa;font-weight:800;font-size:14px">A11Y</span></div>
+        <h3 class="feature-title">Accessibilità WCAG 2.1 AA</h3>
+        <p class="feature-desc">aria-label, heading semantici, focus-visible, skip link, prefers-reduced-motion e compatibilità Windows High Contrast su tutta l'app.</p>
+        <div class="feature-tags"><span class="feature-tag">WCAG 2.1 AA</span><span class="feature-tag">Screen Reader</span><span class="feature-tag">Forced Colors</span><span class="feature-tag">Reduced Motion</span></div>
+      </div>
+      <div class="card feature-card" style="border-left:4px solid #ec4899">
+        <div class="icon-box" style="background:linear-gradient(135deg,#db2777,#ec4899)"><span style="color:#f472b6;font-weight:800;font-size:14px">UI</span></div>
+        <h3 class="feature-title">Design System + OCR Reale</h3>
+        <p class="feature-desc">Card variants via cva, Button xs/icon-sm, utilities text-micro/text-2xs. Backend Tauri Tesseract reale al posto dello stub OCR.</p>
+        <div class="feature-tags"><span class="feature-tag">cva</span><span class="feature-tag">Design Tokens</span><span class="feature-tag">Tesseract</span><span class="feature-tag">Tray Fix</span></div>
       </div>
     </div>
   </div>
@@ -579,7 +591,7 @@
     </div>
     <div class="footer-bottom">
       <p>© 2025-2026 GameStringer by <span style="color:#7dd3fc">rouges78</span>. Source-Available License v1.1</p>
-      <p>Made with <span class="footer-heart">♥</span> in Italy 🇮🇹 — v1.5.0</p>
+      <p>Made with <span class="footer-heart">♥</span> in Italy 🇮🇹 — v1.6.0</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

Follow-up to #27 to bring docs and marketing site in sync with v1.6.0.

- **11 user guides** — append localized \"What's New v1.6.0\" sections covering Bethesda/CRI patchers, Unity Localization Package, Universal PO export, WCAG 2.1 AA accessibility, and design system / OCR updates. Footers bumped to v1.6.0 / 04-04-2026.
- **docs/sito/index.html** (Italian landing) — hero badge, meta tags, \"What's New\" feature cards rewritten with 6 v1.6.0 cards, footer to v1.6.0.
- **docs/sito/index-en.html** (English landing) — same refresh as Italian version.

Site-i18n.js hero badges were already updated in #27; this PR updates the static HTML that doesn't use i18n keys.

## Test plan

- [ ] Preview landing pages render the new v1.6.0 feature cards
- [ ] Each guide ends with \"GameStringer v1.6.0 - ... 04/04/2026\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)