### PR TITLE
feat: v1.6.0 follow-ups — P.T. smart gate, guide Advanced tab, untrack games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 🚀 v1.6.0 - 2026-04-04
 
+- Prediction Tool (P.T.): analisi traduzione per-gioco con difficulty score 0-100, DRM detection, encoding analysis, translation complexity, confidence score, LLM time estimates su 18 modelli, 5 chain Local/Cloud/Hybrid, export report
+- P.T.Rank / Classifica Rapida: ranking giochi per difficoltà con ordine suggerito di traduzione
+- Dry Run Scanner: scansione batch 800+ giochi senza modifica file (bottone + pannello nella library), categorizzazione ready/errori/unsupported, report JSON
+- Workflow Orchestrator: real execution engine con fast path universale per 6+ engine e progress real-time
+- "String it!" quick action: bottone one-click sulla game card (hover) per lanciare il Translation Wizard
+- "String it!" smart gate: nel dettaglio gioco controlla se il gioco è già stato analizzato da P.T. (cache 24h) e, se no, suggerisce di eseguire prima P.T. via toast con azioni "Esegui P.T. prima" / "String it! comunque"
+- Game Update Tracker: bottone "Smetti di monitorare" per disattivare il tracking di un gioco (comando backend `remove_tracked_game`), fix toast "patch danneggiata" ricorrente
+- P.T. upgrade: parsing reale stringhe, 20+ engine supportati, Gemma 4 (27B MoE A4B / E4B / E2B) nei time estimates e chains
+- Ollama Manager: auto-discovery modelli dal registry ollama.com + auto-refresh al focus/navigazione
 - Bethesda Engine Patcher: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield con parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
 - CRI Middleware Patcher: parser CPK + CRILAYLA + MSG/BMD/FTD (Persona 5 Royal, Yakuza, Tales of, Dragon Ball) con rilevamento Shift-JIS/UTF-8/UTF-16
 - Unity Localization Package pipeline: StringTable, SharedTableData, Addressables catalog, Smart Strings tokenizer + validator

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,453 @@
 # Contributing to GameStringer
 
-Thank you for your interest in contributing to GameStringer! We welcome contributions from the community.
+Thank you for your interest in contributing to **GameStringer**! This project is a community-driven effort to make video games playable in every language, and contributions of all kinds — code, translations, bug reports, documentation, engine research — are genuinely appreciated.
 
-## How to Contribute
+> **TL;DR** — Fork → branch → PR. For anything non-trivial, open an [Issue](https://github.com/rouges78/GameStringer/issues) or [Discussion](https://github.com/rouges78/GameStringer/discussions) first so we can align on the approach before you invest time.
 
-1. **Fork the repository** on GitHub.
-2. **Clone your fork** locally.
-3. **Create a new branch** for your feature or bugfix (`git checkout -b feature/amazing-feature`).
-4. **Commit your changes** (`git commit -m 'Add some amazing feature'`).
-5. **Push to the branch** (`git push origin feature/amazing-feature`).
-6. **Open a Pull Request**.
+---
 
-## Reporting Bugs
+## 📑 Table of Contents
 
-Please use the [Issues](https://github.com/rouges78/GameStringer/issues) page to report bugs. Include:
+- [Ways to Contribute](#-ways-to-contribute)
+- [Before You Start](#-before-you-start)
+- [Development Setup](#-development-setup)
+- [Project Structure](#-project-structure)
+- [Development Workflow](#-development-workflow)
+- [Coding Guidelines](#-coding-guidelines)
+- [Testing](#-testing)
+- [Commit & PR Conventions](#-commit--pr-conventions)
+- [Contributing Translations](#-contributing-translations)
+- [Adding a New Game Engine](#-adding-a-new-game-engine)
+- [Adding a New AI Provider](#-adding-a-new-ai-provider)
+- [Reporting Bugs](#-reporting-bugs)
+- [Suggesting Enhancements](#-suggesting-enhancements)
+- [Security Issues](#-security-issues)
+- [Community & Code of Conduct](#-community--code-of-conduct)
+- [License](#-license)
 
-* Version of GameStringer
-* Steps to reproduce
-* Expected behavior
-* Actual behavior
-* Screenshots (if applicable)
+---
 
-## Suggesting Enhancements
+## 🤝 Ways to Contribute
 
-We love hearing your ideas! Please submit them as issues with the "enhancement" label.
+You don't have to write Rust or TypeScript to help:
 
-## License
+| Type | Examples |
+|------|----------|
+| **Code** | New engine patchers, AI providers, bug fixes, performance work, P.T. improvements |
+| **Translations** | UI localization (11 languages currently), user guides in your language, README translations |
+| **Engine research** | Reverse-engineering game file formats, documenting text encoding quirks, finding string tables |
+| **Testing** | Report edge cases with specific games, verify releases on different hardware/OS |
+| **Documentation** | User guides, tutorials, fixing typos, explaining features in the in-app guide |
+| **Community** | Help other users in [Discussions](https://github.com/rouges78/GameStringer/discussions), answer questions in the Community Chat |
+| **Translation memories** | Share finished translations via the Community Hub |
 
-By contributing, you agree that your contributions will be licensed under the project's [Source Available License](../LICENSE).
+---
+
+## 🚦 Before You Start
+
+- **Check existing issues and PRs** to avoid duplicate work.
+- **For large changes** (new engine, new tool, refactor, API change) please [open a Discussion](https://github.com/rouges78/GameStringer/discussions) or Issue first to discuss the approach. This saves everyone time.
+- **For small fixes** (typos, one-line bugs, obvious improvements) go straight to a PR.
+- **Read the** [`LICENSE`](LICENSE) — GameStringer is **Source-Available**, not OSI open source. By contributing, you agree your contributions fall under the same license.
+- **Respect the** [anti-cheat warning](README.md#-supported-game-engines): GameStringer is for **single-player / offline** games. Contributions that weaken anti-cheat safeguards or target multiplayer titles will not be merged.
+
+---
+
+## 🛠️ Development Setup
+
+### Prerequisites
+
+- **Node.js 18+** and **npm**
+- **Rust 1.70+** (install via [rustup](https://rustup.rs))
+- **Git**
+- **Windows 10+** or **Linux** (Ubuntu 22.04+, Fedora 38+)
+- On Linux also install: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `build-essential`, `curl`, `wget`, `file`
+
+### Clone & Install
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+```
+
+### Run in Development
+
+```bash
+npm run dev           # Next.js dev server only (fast UI iteration)
+npm run tauri:dev     # Full Tauri desktop app (Rust + UI)
+```
+
+First `tauri:dev` will compile the Rust backend — expect 5-15 minutes on a fresh machine. Subsequent runs are incremental.
+
+### Build for Production
+
+```bash
+npm run tauri:build   # Produces signed installer in src-tauri/target/release/bundle/
+```
+
+### Useful Commands
+
+```bash
+npm run lint                    # ESLint on the frontend
+npm run typecheck               # TypeScript check (no emit)
+cd src-tauri && cargo check     # Rust compile check
+cd src-tauri && cargo clippy    # Rust linter
+cd src-tauri && cargo test      # Rust unit tests
+npm test                        # Frontend Jest tests (if any are relevant)
+```
+
+> **Tip:** Run `cargo check` before pushing Rust changes. CI runs it on both Linux and Windows and will block your PR if it fails.
+
+---
+
+## 🗂️ Project Structure
+
+```
+GameStringer/
+├── app/                      # Next.js 15 App Router pages
+│   ├── library/              # Game library + Dry Run Scanner
+│   ├── prediction-tool/      # P.T. analysis + P.T.Rank (/ranking)
+│   ├── translation-wizard/   # "String it!" wizard
+│   ├── guide/                # In-app user guide (Quickstart/Tools/Advanced/Shortcuts)
+│   ├── batch/                # Batch folder translation
+│   ├── community-hub/        # Community memories + GitHub Discussions
+│   ├── bethesda-patcher/     # (v1.6.0) Bethesda Engine patcher UI
+│   ├── cri-patcher/          # (v1.6.0) CRI Middleware patcher UI
+│   ├── unity-localization/   # (v1.6.0) Unity Localization Package pipeline
+│   └── settings/             # Providers, API keys, profiles
+├── components/               # Shared React components (game-detail-client, main-layout, …)
+│   └── ui/                   # shadcn/ui primitives + wizard-stepper
+├── lib/                      # Frontend helpers
+│   ├── i18n/                 # Translation strings (11 locales)
+│   ├── tools-registry.ts     # Registry used by the guide and navigation
+│   ├── bethesda-patcher.ts   # (v1.6.0) Bethesda frontend bindings
+│   ├── cri-patcher.ts        # (v1.6.0) CRI frontend bindings
+│   ├── unity-localization.ts # (v1.6.0) Unity Loc frontend bindings
+│   └── po-export.ts          # (v1.6.0) Universal PO (gettext) exporter
+├── src-tauri/                # Rust backend (Tauri 2)
+│   ├── src/
+│   │   ├── main.rs           # Tauri invoke_handler registration
+│   │   ├── commands/         # One file per feature area (~100 commands)
+│   │   │   ├── prediction_tool.rs     # P.T., P.T.Rank, Dry Run, Workflow Orchestrator
+│   │   │   ├── game_update_tracker.rs # Steam buildid + patch integrity
+│   │   │   ├── bethesda_patcher.rs    # (v1.6.0) BSA/BA2/ESP parser
+│   │   │   ├── cri_patcher.rs         # (v1.6.0) CPK/CRILAYLA/MSG
+│   │   │   ├── unity_localization.rs  # (v1.6.0) StringTable/Smart Strings
+│   │   │   ├── po_export.rs           # (v1.6.0) Universal .po exporter
+│   │   │   └── …
+│   │   └── engine_detector.rs         # Auto-detect 20+ engines from folder content
+│   └── Cargo.toml
+├── ue-translator-dll/        # Unreal Engine native DLL (MinHook)
+├── unity-translator-dll/     # Unity native DLL
+├── native/                   # Other native helpers
+├── docs/                     # User guides (11 languages), VERSIONING, PROJECT_STATUS
+│   └── sito/                 # Marketing website
+├── scripts/                  # One-shot utilities (version-manager.js, etc.)
+├── README.md                 # English master
+├── README_{IT,ES,FR,DE,PT,JA,ZH,KO,RU,PL}.md  # Localized READMEs
+├── CHANGELOG.md              # Version history
+├── CONTRIBUTING.md           # This file
+└── LICENSE                   # Source-Available License v1.1
+```
+
+---
+
+## 🔁 Development Workflow
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally and add the upstream remote:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/GameStringer.git
+   cd GameStringer
+   git remote add upstream https://github.com/rouges78/GameStringer.git
+   ```
+3. **Sync with upstream** before starting work:
+   ```bash
+   git fetch upstream
+   git checkout main
+   git merge upstream/main
+   ```
+4. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feat/short-description
+   # or: fix/bug-description, docs/topic, i18n/language-code
+   ```
+5. **Make focused commits** — see [Commit Conventions](#-commit--pr-conventions).
+6. **Run local checks** before pushing:
+   ```bash
+   npm run lint
+   npm run typecheck
+   cd src-tauri && cargo check && cargo clippy
+   ```
+7. **Push** and open a Pull Request against `main`.
+8. **Respond to review comments** — prefer new commits over force-pushes once the PR is open, unless you need to fix a CI failure in the latest commit.
+
+---
+
+## ✍️ Coding Guidelines
+
+### General
+
+- **Don't over-engineer.** Prefer the simplest code that solves the problem. Three similar lines of code is better than a premature abstraction.
+- **Don't add features beyond what the PR's title says.** A bug fix doesn't need a refactor; a feature doesn't need a design-system sweep.
+- **Don't add backwards-compatibility shims** for unused code paths. If it's dead, delete it.
+- **Trust internal callers.** Validate only at real boundaries (user input, external APIs, file parsing).
+- **Only add comments where the logic isn't self-evident.** Don't document trivial code.
+
+### TypeScript / React (frontend)
+
+- Follow the existing style — there is no `.prettierrc`, so match the surrounding file.
+- Use functional React components with hooks. No class components.
+- Server Components where possible (App Router default), Client Components only when needed (`'use client'`).
+- Prefer **shadcn/ui** + **Radix UI** primitives over custom components. Use `components/ui/*`.
+- Use **Tailwind CSS** with the existing design tokens. For custom sizes prefer the text-micro / text-2xs / xs / icon-sm utilities introduced in v1.6.0 before reaching for arbitrary values.
+- Call the Rust backend via `invoke<T>('command_name', { ... })` from `@tauri-apps/api/core`. Avoid duplicating that import path — check `lib/tauri-api.ts` first.
+- i18n strings go in `lib/i18n/locales/<lang>.json`. See [Contributing Translations](#-contributing-translations).
+
+### Rust (backend)
+
+- One file per feature area under `src-tauri/src/commands/`. Keep the `main.rs` `invoke_handler!` macro sorted by area.
+- Use `#[tauri::command]` (fully qualified) for Tauri commands — the file style is already consistent.
+- Return `Result<T, String>` for commands. Log with `log::info!` / `log::warn!` / `log::error!`, not `println!`.
+- Prefer `serde_json::Value` only at the boundary; use typed structs internally with `#[derive(Serialize, Deserialize)]`.
+- For new engine parsers: document the file format in a top-of-file comment, add the engine to `engine_detector.rs`, and wire the command in `main.rs`.
+- Run `cargo clippy -- -D warnings` before pushing. Fix or explicitly allow each warning.
+
+### Accessibility (v1.6.0 commitment)
+
+- **Every icon button** must have an `aria-label`.
+- **Interactive elements** must be focusable and have a visible `focus-visible` state.
+- Respect **`prefers-reduced-motion`** for animations.
+- Respect **`forced-colors`** for Windows High Contrast Mode.
+- Use **semantic HTML**: `<main>`, `<nav>`, `<h1>`-`<h6>`, `CardTitle` for card headings.
+
+---
+
+## 🧪 Testing
+
+### What to test
+
+- **Rust commands**: add unit tests in the same file with `#[cfg(test)] mod tests { ... }`. File parsers especially benefit from test fixtures — small binary samples under `src-tauri/tests/fixtures/`.
+- **Engine detection**: if you add or change `engine_detector.rs`, add at least one positive test case.
+- **File format parsers** (BSA, BA2, CPK, `.locres`, etc.): include a minimal byte-level test fixture and assert round-trip behavior (parse → modify → serialize → parse again).
+- **Frontend**: there is no strict unit-test requirement, but components with complex state (wizard steppers, P.T. report renderers) benefit from Jest/RTL coverage.
+
+### Manual testing checklist
+
+Before opening a PR that touches user-facing features, verify on at least one engine:
+
+- [ ] `npm run tauri:dev` launches without errors
+- [ ] Library loads and game detection works
+- [ ] P.T. analysis completes for a known game (e.g. a Unity or Unreal title you have installed)
+- [ ] Translation wizard ("String it!") runs to completion on a small game
+- [ ] No new TypeScript errors (`npm run typecheck`)
+- [ ] No new Rust warnings (`cargo clippy`)
+- [ ] CI passes: `check-linux` and `check-windows`
+
+---
+
+## 📝 Commit & PR Conventions
+
+### Language
+
+> **All Git/GitHub content must be in English**: commit messages, PR titles, PR bodies, issue comments, release notes. User-facing UI strings and in-app documentation can be in any of the 11 supported languages.
+
+### Commit Messages
+
+Follow a lightweight **Conventional Commits** style:
+
+```
+<type>: <short description>
+
+<optional body — what and why, not how>
+
+<optional footer — Co-Authored-By, Fixes #N>
+```
+
+**Types used in this repo:**
+
+| Type | Use for |
+|------|---------|
+| `feat` | New features |
+| `fix` | Bug fixes |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behavior change |
+| `perf` | Performance improvements |
+| `a11y` | Accessibility improvements |
+| `i18n` | Translation additions/updates |
+| `chore` | Build, tooling, dependencies, version bumps |
+| `ci` | CI/CD workflow changes |
+| `test` | Tests only |
+
+**Examples from the history:**
+
+```
+feat: Bethesda Engine Patcher — BSA v103-105 + BA2 + ESP parser
+fix: prevent console flash on child process spawns (Windows)
+a11y: aria-label on icon buttons + text-micro/text-2xs utilities
+chore: bump version to v1.6.0 across app, docs, and site
+```
+
+### Pull Requests
+
+- **Title**: same format as a commit message (`type: short description`).
+- **Body**: include a `## Summary` with 2–5 bullets and a `## Test plan` checklist.
+- **Scope**: one logical change per PR. A new engine patcher is one PR; "add engine + refactor wizard + bump deps" is three.
+- **Link issues**: use `Fixes #123` / `Closes #123` in the body if the PR closes an issue.
+- **Draft PRs are welcome** for early feedback. Mark them ready when green.
+- **Keep PRs small.** Reviews get slower and lower-quality as size grows. If a change must be large, explain why in the body and split it into logical commits.
+- **CI must be green** before review. Don't ask for review on a red PR unless you're explicitly requesting help.
+
+---
+
+## 🌐 Contributing Translations
+
+GameStringer ships with 11 UI languages. We'd love more.
+
+### Updating Existing Translations
+
+1. Edit the relevant file in `lib/i18n/locales/<lang>.json`.
+2. Keep the JSON structure identical to `it.json` or `en.json` (the reference locales).
+3. Don't translate technical terms that are brand names: `BepInEx`, `XUnity.AutoTranslator`, `UnrealLocres`, `Tauri`, `Steam`, `P.T.`, `String it!`, `Ollama`, etc.
+4. Test in-app: `npm run tauri:dev` → Settings → Language → your locale.
+
+### Adding a New UI Language
+
+1. Create `lib/i18n/locales/<lang>.json` by copying `en.json`.
+2. Add the locale to `lib/i18n/index.ts` (`SUPPORTED_LOCALES`, `Locale` type).
+3. Create a user guide: copy `docs/USER_GUIDE_EN.md` to `docs/USER_GUIDE_<LANG>.md` and translate it.
+4. Create a localized README: copy `README.md` to `README_<LANG>.md` and translate it.
+5. Add your language to the README switcher in all existing READMEs.
+6. Update `docs/sito/site-i18n.js` with the new locale.
+7. Open a PR with type `i18n: add <language> translation`.
+
+### Updating User Guides
+
+The user guides in `docs/USER_GUIDE_*.md` and `docs/GUIDA_UTENTE.md` have a "What's New" section at the bottom for each version. When a new feature ships, add a short description in the `## What's New vX.Y.Z` block.
+
+### Community Translations (not UI)
+
+If you've translated an entire game using GameStringer, share it via the **Community Hub** inside the app — not via PR. The Community Hub uses Supabase and has its own submission flow.
+
+---
+
+## 🎮 Adding a New Game Engine
+
+Adding support for a new engine is one of the most impactful contributions. Here's the typical flow:
+
+1. **Research the format**
+   - Document where strings live (loose files? archive? embedded in assets?)
+   - Identify the encoding (UTF-8, Shift-JIS, UTF-16, Big5, EUC-KR, custom?)
+   - Find existing open-source parsers or reverse-engineered documentation you can reference
+2. **Add engine detection**
+   - Edit `src-tauri/src/engine_detector.rs`
+   - Add a variant to the `GameEngine` enum
+   - Add detection logic (signature files, folder structure, magic bytes)
+   - Return the new variant from `detect_engine()` when matched
+3. **Create the parser module**
+   - New file under `src-tauri/src/commands/<engine>_patcher.rs`
+   - Public commands: `extract_strings`, `inject_strings`, optionally `backup`/`restore`
+   - Use `#[tauri::command]` (not `#[command]` — fully qualified)
+   - Return `Result<T, String>` with descriptive errors
+4. **Register the commands**
+   - Add them to the `invoke_handler![]` macro in `src-tauri/src/main.rs`
+5. **Add a frontend wrapper**
+   - `lib/<engine>-patcher.ts` — typed wrappers around `invoke()`
+6. **Add a UI page**
+   - `app/<engine>-patcher/page.tsx` using the shared `components/ui/wizard-stepper.tsx`
+7. **Wire into P.T.**
+   - Add the engine to the fast-path table in `prediction_tool.rs` so Dry Run and P.T. can analyze it
+8. **Test on a real game** — ship only if it works end-to-end on at least one title.
+9. **Document it** in the engine table in `README.md` and the user guides.
+
+Check the v1.6.0 additions (`bethesda_patcher.rs`, `cri_patcher.rs`, `unity_localization.rs`) for reference implementations.
+
+---
+
+## 🤖 Adding a New AI Provider
+
+1. **Backend**: add a function in `src-tauri/src/commands/providers/` (or the existing `translation_providers.rs`) that makes the API call and returns `Result<String, String>`.
+2. **Frontend**: add the provider to the provider registry used by the Translation Wizard and Settings > Providers.
+3. **P.T. time estimates**: add an entry to `prediction_tool.rs` `estimate_llm_times()` — users rely on this to pick a chain.
+4. **LLM chains**: add the provider to one or more of the 5 recommended chains (Local / Cloud / Hybrid / Budget / Premium) if appropriate.
+5. **Documentation**: add a row to the AI Providers table in `README.md`.
+6. **Test** with real credentials (use your own API key during development; never commit keys). Use `dotenv` or Settings.
+
+---
+
+## 🐛 Reporting Bugs
+
+Please use the [Issues](https://github.com/rouges78/GameStringer/issues) page and include:
+
+- **GameStringer version** (Settings → About, or see the footer)
+- **OS and version** (Windows 11 23H2, Ubuntu 24.04, etc.)
+- **Game affected** (title, store, engine if known)
+- **Steps to reproduce** — as specific as possible
+- **Expected behavior**
+- **Actual behavior**
+- **Screenshots or screen recordings** when the bug is visual
+- **Logs** — from the app: Settings → Debug Console → Copy logs, or from `%APPDATA%/GameStringer/logs/` (Windows) / `~/.config/GameStringer/logs/` (Linux)
+- **Prediction Tool report** if the bug is translation-related (export from `/prediction-tool`)
+
+Please **do not** report bugs you encountered while using GameStringer on online / multiplayer games — those use cases are unsupported by design.
+
+---
+
+## 💡 Suggesting Enhancements
+
+- **Small ideas**: open an Issue with the `enhancement` label.
+- **Large ideas** (new major feature, architecture changes): open a [Discussion](https://github.com/rouges78/GameStringer/discussions) under "Ideas" so the community can weigh in before it becomes a formal issue.
+- **Explain the use case**, not just the solution. "I want to translate game X which stores text in format Y" is more actionable than "add support for format Y".
+
+---
+
+## 🔒 Security Issues
+
+**Do NOT report security vulnerabilities in public issues.**
+
+If you discover a security issue (RCE, arbitrary file write, credential leak, auth bypass in the Community Hub, etc.), please email the maintainers privately or use [GitHub's private vulnerability reporting](https://github.com/rouges78/GameStringer/security/advisories/new).
+
+Include:
+- A clear description of the issue
+- Steps to reproduce
+- Affected versions
+- Suggested remediation if you have one
+
+We'll acknowledge within a few days and coordinate a fix and disclosure timeline with you.
+
+---
+
+## 👥 Community & Code of Conduct
+
+- Be kind, be specific, assume good intent.
+- English is the primary language for GitHub interactions (Issues, PRs, commit messages). Italian and other supported languages are welcome in the in-app Community Chat.
+- No harassment, no discrimination, no personal attacks. We reserve the right to block repeat offenders.
+- Credit others' work. If you port a file format parser from an existing open-source project, **include the credit in your PR and in the file header**, and respect the upstream license.
+
+Join the conversation:
+
+- 💬 **In-app Community Chat** (Supabase Realtime, 4 default rooms + custom)
+- 🗣️ **[GitHub Discussions](https://github.com/rouges78/GameStringer/discussions)** — Ideas, Q&A, Show and tell, Announcements
+- 🐛 **[GitHub Issues](https://github.com/rouges78/GameStringer/issues)** — bugs and tracked enhancements
+
+---
+
+## 📜 License
+
+By contributing, you agree that your contributions will be licensed under the project's [**Source-Available License v1.1**](LICENSE).
+
+Summary:
+- ✅ Free for personal use
+- ✅ Free to inspect, build, and modify for yourself
+- ❌ Commercial use requires written permission
+- ❌ Redistribution of modified versions requires written permission
+
+If you're unsure whether your intended contribution is compatible with the license, open a [Discussion](https://github.com/rouges78/GameStringer/discussions) and ask before starting the work.
+
+---
+
+<p align="center">
+  Thank you for helping make games playable in every language. ❤️<br>
+  <strong>— The GameStringer Team</strong>
+</p>

--- a/README.md
+++ b/README.md
@@ -22,13 +22,24 @@
   <a href="#-what-is-gamestringer">What is it</a> ·
   <a href="#-download">Download</a> ·
   <a href="#-how-it-works">How it works</a> ·
+  <a href="#-the-prediction-tool-pt">P.T.</a> ·
   <a href="#-supported-game-engines">Engines</a> ·
   <a href="#-features">Features</a> ·
   <a href="#-build-from-source">Build</a>
 </p>
 
 <p align="center">
-  <a href="README_IT.md">🇮🇹 Leggi in Italiano</a>
+  <strong>🌍 Read in your language:</strong><br>
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
 </p>
 
 ---
@@ -56,7 +67,7 @@
 </p>
 
 <p align="center">
-  <em>🔧 One-Click Patcher — BepInEx, XUnity, UnrealLocres, auto-backup</em>
+  <em>🔧 One-Click Patcher — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, auto-backup</em>
 </p>
 
 <p align="center">
@@ -64,7 +75,7 @@
 </p>
 
 <p align="center">
-  <em>💬 Community Chat — Supabase Realtime, stanze personalizzate, presenza online</em>
+  <em>💬 Community Chat — Supabase Realtime, custom rooms, online presence</em>
 </p>
 
 <p align="center">
@@ -72,7 +83,7 @@
 </p>
 
 <p align="center">
-  <em>🖥️ System Tray — azioni rapide, stato Ollama live, submenu strumenti</em>
+  <em>🖥️ System Tray — quick actions, live Ollama status, tools submenu</em>
 </p>
 
 ---
@@ -81,11 +92,11 @@
 
 GameStringer is a **desktop application** (Windows & Linux) that lets you translate video games that don't have your language.
 
-Most games store their text in files — JSON, XML, CSV, .locres, .rpy, and many other formats. GameStringer **scans your game folder**, finds those files, sends the text through an **AI translation provider** of your choice (OpenAI, Gemini, DeepSeek, Ollama, etc.), and **patches the translated text back** into the game. One click, no technical knowledge needed.
+Most games store their text in files — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, Unity Localization StringTables, and many other formats. GameStringer **scans your game folder**, finds those files, sends the text through an **AI translation provider** of your choice (OpenAI, Claude, Gemini, DeepSeek, Ollama, 20+ more), and **patches the translated text back** into the game. One click, no technical knowledge needed.
 
-For **Unity games** that lock text inside compiled assets, GameStringer **automatically installs BepInEx + XUnity.AutoTranslator** — no manual setup required.
+For **Unity games** that lock text inside compiled assets, GameStringer **automatically installs BepInEx + XUnity.AutoTranslator** — no manual setup. For **Bethesda games** (Skyrim, Fallout, Starfield) it parses BSA/BA2/ESP natively. For **CRI Middleware games** (Persona, Yakuza) it handles CPK/CRILAYLA/MSG/BMD. For **Unreal Engine** it edits `.locres` directly.
 
-**It's not a machine translation website.** It's a full pipeline: detect game → extract text → translate with AI → quality check → patch back → play.
+**It's not a machine translation website.** It's a full pipeline: **analyze with P.T. → detect engine → extract text → translate with AI → quality check → patch back → play.**
 
 ---
 
@@ -100,144 +111,236 @@ Get the latest release from **[GitHub Releases](https://github.com/rouges78/Game
 | **Linux** | `GameStringer.AppImage` | Universal (recommended) |
 | **Linux** | `GameStringer.deb` | Debian / Ubuntu |
 
-**Requirements:** Windows 10+ or Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ for local AI), 500 MB disk.
+**Requirements:** Windows 10+ or Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ for local AI), 500 MB disk. Releases are **code-signed** and **auto-updated** via Tauri Updater.
 
 ---
 
 ## 🚀 How it works
 
 1. **Install** GameStringer and launch it
-2. **Your game library loads automatically** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io
-3. **Pick a game** and click **"Translate"**
-4. **Choose your language** and AI provider
-5. GameStringer scans the game files, translates everything, and generates a patch
-6. **Apply the patch** — your game is now in your language
+2. **Your game library loads automatically** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ games detected in seconds)
+3. **Pick a game** → optionally run **P.T. (Prediction Tool)** to see difficulty, estimated time, best LLM chain
+4. Click **"String it!"** — GameStringer scans, extracts, translates, and patches automatically
+5. **Play in your language** — backups are always created before patching
 
 That's it. No command line, no manual file editing, no modding experience needed.
 
 ---
 
+## 🧠 The Prediction Tool (P.T.)
+
+> **The most powerful feature in GameStringer.** Don't start a translation blind — analyze first.
+
+P.T. is a deep analysis engine that runs *before* any translation. It scans your game folder, detects the engine, estimates the volume of translatable text, and tells you:
+
+- **Difficulty Score 0–100** — combined weight of string volume, engine complexity, DRM, encoding, linguistic challenges
+- **Estimated time** across **18 LLM models** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 recommended LLM chains**: Local (privacy), Cloud (quality), Hybrid (balanced), Budget, Premium — each with cost and quality score
+- **DRM detection**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — warns before you try
+- **Encoding analysis**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR detected per-file
+- **Translation complexity**: honorifics, gender agreement, RTL, ruby/furigana, CJK-specific handling
+- **Confidence score** and **workflow plan** — the exact steps that will run when you click "String it!"
+- **Export report** (JSON + Markdown) for sharing or archiving
+
+### P.T.Rank — Quick Ranking
+
+After running P.T. on multiple games, open **P.T.Rank** to see all analyzed titles sorted by difficulty. Perfect for planning your translation queue: start from the easy wins, save the 800k-string RPGs for last.
+
+### Dry Run Scanner
+
+Don't want to analyze one game at a time? Run **Dry Run** from the Library page to scan your **entire Steam library (800+ games) in batch**, with **zero file modification**. You get a JSON report categorizing every game as **Ready** (engine supported + strings extractable), **Errors** (manifest issues / DRM blocker), or **Unsupported** (unknown engine / no text). Progress is real-time, and no backup is needed because nothing gets touched.
+
+### String it! Smart Gate
+
+The **"String it!"** button on the game detail page is smart: if the game has already been analyzed by P.T. within the last 24h, it launches the translation wizard directly. Otherwise it suggests running P.T. first (with a one-click "Run P.T. first" / "String it! anyway" choice). No more wasted runs on games that turn out to be DRM-locked or 5-minute affairs.
+
+---
+
 ## 🎯 Supported Game Engines
+
+GameStringer supports **20+ engines** with varying levels of depth:
 
 | Engine | Support | How it works |
 |--------|---------|--------------|
-| **Unity** | ✅ Full | Auto-installs BepInEx + XUnity.AutoTranslator |
-| **Unreal Engine** | ✅ Full | .locres extraction and patching |
-| **Godot** | ✅ Full | Native .translation files |
-| **RPG Maker** | ✅ Full | MV/MZ JSON, VX/Ace via Trans |
-| **Ren'Py** | ✅ Full | Native .rpy script parsing |
-| **GameMaker** | ⚡ Partial | Via UndertaleModTool |
-| **Telltale** | ✅ Full | .langdb / .dlog support |
+| **Unity** | ✅ Full | Auto-installs BepInEx + XUnity.AutoTranslator + Unity Localization Package pipeline (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Full | `.locres` extraction and patching with UnrealLocres |
+| **Unreal _P.pak** | ✅ Full | Mod packaging as `<GameStringer>_P.pak` loaded via Paks folder |
+| **Godot** | ✅ Full | Native `.translation` file support |
+| **RPG Maker** | ✅ Full | MV/MZ JSON, VX/Ace via Trans, XP via RMXP |
+| **Ren'Py** | ✅ Full | Native `.rpy` script parsing with dialogue detection |
+| **GameMaker** | ⚡ Partial | Via UndertaleModTool integration |
+| **Telltale** | ✅ Full | `.langdb` / `.dlog` support |
 | **Wolf RPG** | ✅ Full | WolfTrans integration |
-| **Kirikiri** | ✅ Full | .ks / .scn parsing |
+| **Kirikiri** | ✅ Full | `.ks` / `.scn` parsing |
+| **TyranoScript** | ✅ Full | Fast-path extractor with JSON patching |
+| **Electron** | ✅ Full | ASAR unpacking + i18n JSON detection |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1) parser, STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD with Shift-JIS/UTF-8/UTF-16 auto-detection |
+| **Visionaire Studio** | ✅ Full | Daedalic adventures (Deponia, Edna, etc.) |
+| **Danganronpa WAD** | ✅ Full | WAD archive parser + STX dialogue patching |
 
 > **Unity games** get special treatment: if no translatable files are found, GameStringer detects it's a Unity game and offers to **automatically install BepInEx + XUnity.AutoTranslator** with one click. Just launch the game once after install, then re-scan — all text becomes translatable.
 >
-> ⚠️ **Anti-Cheat Warning**: BepInEx (DLL injection) can trigger anti-cheat systems (EAC, BattlEye, Vanguard). GameStringer includes anti-cheat detection and will warn you. **Only use on single-player / offline games.**
+> ⚠️ **Anti-Cheat Warning**: BepInEx (DLL injection) can trigger anti-cheat systems (EAC, BattlEye, Vanguard). GameStringer includes anti-cheat detection and will warn you. **Only use on single-player / offline games.** P.T. detects DRM before any modification.
 
 ---
 
 ## ✨ Features
 
-### AI Translation
+### 🤖 AI Translation
 
-- **20+ providers**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (local), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, and more
-- **Context-aware**: understands game genre, character voice, tone
-- **Translation Memory & Glossary**: consistency across the project
-- **Multi-LLM Compare**: run multiple providers in parallel, pick the best result
-- **Quality gates**: automatic QA scoring on every translated string
+- **20+ providers**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (local), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: understands game genre, character voice, tone, narrative vs UI vs dialogue
+- **Translation Memory & Glossary**: consistency across the project with auto-glossary extraction
+- **Multi-LLM Compare**: run multiple providers in parallel, pick the best result per string
+- **Quality gates**: automatic QA scoring on every translated string (0-100) with ContentTypeBadge
+- **Vision LLM Translator**: uses in-game screenshots for context (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: see quality scores in real-time during batch translation
+- **RTL support**: automatic direction detection and `dir` attribute handling
 
-### Game Library
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** with weighted factors (volume, engine, DRM, encoding, complexity)
+- **Time estimates for 18 LLM models** including Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 LLM chains** (Local / Cloud / Hybrid / Budget / Premium) with cost and quality estimates
+- **DRM / Anti-Cheat detection** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Encoding analysis** per-file (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Translation complexity analysis** (honorifics, gender, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — sort all analyzed games by difficulty
+- **Dry Run Scanner** — batch scan of entire Steam library (800+ games) without modification
+- **Workflow Orchestrator** — real execution engine with universal fast path for 6+ engines and real-time progress
+- **Prediction cache** (24h) — instant re-open of previously analyzed games
+- **Export report** (JSON + Markdown) for sharing and archiving
+
+### 📚 Game Library
 
 - **Auto-detect**: Steam (with Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
-- **600+ games** recognized from installed libraries
-- **Game cards** with cover art, metadata, and one-click translate
+- **800+ games** recognized from installed libraries in seconds
+- **Game cards** with cover art, metadata, engine badge, VR badge, install status
+- **Hover quick actions**: String it!, Batch, Community, P.T. — all one click
+- **Game Update Tracker**: detects when Steam updates a translated game (via `buildid`), verifies patch integrity (BepInEx files, `_P.pak` presence), warns if re-patching is needed
+- **"Stop monitoring"** button to untrack a specific game
 
-### Translation Tools
+### 🔧 Translation Tools
 
-- **One-Click Translate**: scan → translate → patch in a single flow
-- **Batch Translation**: translate entire games at once
-- **Vision LLM**: use in-game screenshots for context-aware translation (Ollama, Gemini, GPT-4o)
+- **One-Click Translate** ("String it!"): scan → translate → patch in a single flow
+- **Batch Translation**: translate entire games or folders at once
 - **Subtitle Translator**: SRT, VTT, ASS/SSA with timing preservation
-- **OCR Translator**: extract text from retro games (8-bit, 16-bit, DOS presets)
+- **OCR Translator**: extract text from retro games (8-bit, 16-bit, DOS presets) with real Tauri Tesseract backend
 - **Voice Pipeline**: speech-to-text → translate → text-to-speech
-- **Real-time Overlay**: see translations while playing
-
-### Advanced
-
+- **Real-time Overlay**: see translations while playing via VR/screen overlay
+- **Auto-Translate Review**: "Translate all untranslated" button with progress bar
 - **Lore Assistant**: RAG chat that knows the game's lore and dialogues
 - **Character Voice Profiles**: define personality, tone, speech patterns per character
 - **Translation Confidence Heatmap**: visual quality overview of all translations
-- **Auto-Hook Scanner**: process memory scanning (Windows)
-- **Community Hub**: share and download translation memories
+
+### 🎮 Game Engine Patchers
+
+- **Unity**: BepInEx + XUnity.AutoTranslator auto-installer, Unity Localization Package (StringTable, SharedTableData, Addressables catalog, Smart Strings validator)
+- **Unreal Engine**: `.locres` extraction + `_P.pak` mod packaging
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — all with native parsers
+- **Wizard Stepper**: shared multi-step UI for all patchers
+- **Universal PO Export** (gettext `.po`) for every patcher with project/language/source/engine metadata
+- **Auto-backup**: before every patch, with one-click restore
+
+### 🔌 Advanced
+
+- **Auto-Hook Scanner**: process memory scanning (Windows WinAPI) for hardcoded strings
+- **System Monitor**: real-time VRAM/RAM usage for local LLM planning
+- **Ollama Setup Wizard**: step-by-step local AI installation
+- **Ollama Manager**: auto-discovery of models from the ollama.com registry + auto-refresh on focus/navigation
+- **Debug Console**: integrated console with log intercept
+- **Plugin System**: design doc for third-party plugins (see `PLUGIN_SYSTEM.md`)
+- **Community Hub**: share and download translation memories + GitHub Discussions integration
 - **Public API v1**: REST endpoints for integration (`/api/v1/translate`, `/api/v1/batch`)
 
-### Game Engine Patchers (NEW in v1.6.0)
-
-- **Bethesda Engine Patcher**: Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA/BA2/STRINGS/ESP parser
-- **CRI Middleware Patcher**: Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
-- **Unity Localization Package**: StringTable + Addressables + Smart Strings validator
-- **Universal PO Export** (gettext) for every patcher
-- **Accessibility**: WCAG 2.1 AA sweep — aria-label, semantic headings, focus-visible, skip link, prefers-reduced-motion, Windows High Contrast
-- **OCR**: real Tauri Tesseract backend (replaces stub)
-
-### Community Chat (v1.5.0)
+### 💬 Community Chat
 
 - **Real-time chat** with other translators via Supabase Realtime
 - **4 default rooms**: General, Translations, Feedback & Bugs, Announcements
 - **Custom rooms**: create rooms for specific games or projects
 - **Auto-Bridge Auth**: your GameStringer profile auto-syncs to Supabase — zero extra login
-- **Online presence**: see who’s online in each room
+- **Online presence**: see who's online in each room
+- **Reply / edit / delete** messages with RLS-enforced ownership
+- **Expandable drawer widget** in the bottom-right corner
 
-### App
+### ♿ Accessibility (v1.6.0)
 
-- **11 languages UI**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
-- **Signed auto-updates**: one-click update from the app
-- **System Monitor**: real-time VRAM/RAM usage
+- **WCAG 2.1 AA sweep** — `aria-label` on icon buttons, semantic `CardTitle` headings, `focus-visible` on all primitives, skip-to-content link, `main` landmark, Italian `sr-only` helpers
+- **`prefers-reduced-motion`** respected throughout animations
+- **`forced-colors`** (Windows High Contrast Mode) respected
+- **11-language UI**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **RTL layout** support with automatic direction detection
+
+### 🎨 Design System (v1.6.0)
+
+- **Card variants** via `cva`: default, muted, highlight, success, error, warning
+- **Button sizes** including `xs` and `icon-sm`
+- **Text utilities**: `text-micro` (9px), `text-2xs` (10px) — no more arbitrary Tailwind
+- **Radix UI unified**: migrated 37 files from `@radix-ui/react-*` to `radix-ui`, 27 packages removed
+- **Optimized bundle**: `optimizePackageImports` for radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Signed auto-updates**: one-click update from the app via Tauri Updater
 - **Profiles**: multiple user profiles with recovery keys
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` XUnity toggle
+- **System Tray**: quick actions, live Ollama status, tools submenu
 - **Cross-platform**: Windows & Linux with native builds
+- **Windows tray fix**: prevents console flash loop on child process spawn
 
 ---
 
 ## 🔧 AI Providers
 
-| Provider | API Key | Free Tier |
-|----------|---------|-----------|
-| Ollama | No (local) | ✅ Unlimited |
-| LM Studio | No (local) | ✅ Unlimited |
-| TranslateGemma | No (Ollama) | ✅ Unlimited — 55 languages, Google |
-| HY-MT1.5 | No (Ollama) | ✅ Unlimited — ~1GB RAM, Tencent |
-| Qwen 3 | No (Ollama) | ✅ Unlimited — Best for CJK |
-| Gemini | Yes | ✅ Free tier (15 RPM) |
-| DeepSeek | Yes | ✅ $0.14/1M input |
-| Groq | Yes | ✅ 14,400 req/day |
-| Mistral | Yes | ✅ Free tier |
-| OpenAI | Yes | Paid |
-| Claude | Yes | Paid |
-| DeepL | Yes | ✅ 500k chars/month |
-| MyMemory | No | ✅ Unlimited |
-| Lingva | No | ✅ Unlimited |
-| Cerebras | Yes | ✅ Free tier |
-| Together AI | Yes | ✅ $25 free credit |
-| Fireworks | Yes | ✅ Free tier |
-| OpenRouter | Yes | ✅ Free models |
-| NLLB-200 | Yes | ✅ 200 languages |
-| Cohere | Yes | ✅ Free trial |
+| Provider | API Key | Free Tier | Best for |
+|----------|---------|-----------|----------|
+| **Ollama** | No (local) | ✅ Unlimited | Privacy, offline |
+| **LM Studio** | No (local) | ✅ Unlimited | Privacy, GGUF models |
+| **TranslateGemma** | No (Ollama) | ✅ Unlimited — 55 languages, Google | **Recommended start** |
+| **HY-MT1.5** | No (Ollama) | ✅ Unlimited — ~1GB RAM, Tencent | Low-RAM machines |
+| **Qwen 3** | No (Ollama) | ✅ Unlimited — multilingual | CJK languages |
+| **Gemma 4** | No (Ollama) | ✅ Unlimited — 27B MoE A4B/E4B/E2B | Quality local |
+| **Gemini** | Yes | ✅ Free tier (15 RPM) | **Recommended cloud** |
+| **DeepSeek** | Yes | ✅ $0.14/1M input | Budget cloud |
+| **Groq** | Yes | ✅ 14,400 req/day | Speed |
+| **Mistral** | Yes | ✅ Free tier | EU cloud |
+| **OpenAI** | Yes | Paid | GPT-4o quality |
+| **Claude** | Yes | Paid | Nuance, long context |
+| **DeepL** | Yes | ✅ 500k chars/month | European languages |
+| **MyMemory** | No | ✅ Unlimited | Fallback |
+| **Lingva** | No | ✅ Unlimited | Google MT mirror |
+| **Cerebras** | Yes | ✅ Free tier | Speed |
+| **Together AI** | Yes | ✅ $25 free credit | Open models |
+| **Fireworks** | Yes | ✅ Free tier | Open models |
+| **OpenRouter** | Yes | ✅ Free models | Model variety |
+| **NLLB-200** | Yes | ✅ 200 languages | Rare languages |
+| **Cohere** | Yes | ✅ Free trial | RAG |
 
-**Recommended to start**: **TranslateGemma** via Ollama (free, local, 55 languages) or **Gemini** (free tier, cloud). Low RAM: **HY-MT1.5** (~1GB).
+**Recommended to start**: **TranslateGemma** via Ollama (free, local, 55 languages) or **Gemini** (free tier, cloud). Low RAM: **HY-MT1.5** (~1GB). Best quality: **Claude 3.5** or **GPT-4o**. Best CJK: **Qwen 3**.
 
 ---
 
-## � Documentation
+## 📖 Documentation
 
-User guides in 11 languages:
+### User Guides (11 languages)
 
 | | | |
 |---|---|---|
-| �🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
 | 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
 | 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
 | 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Project Docs
+
+- **[CHANGELOG.md](CHANGELOG.md)** — full version history
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — versioning policy
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — current roadmap
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — plugin architecture design
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
 
 ---
 
@@ -251,7 +354,9 @@ cd GameStringer
 npm install
 npm run dev          # development
 npm run tauri:build  # production build
-```text
+```
+
+Rust backend: `cd src-tauri && cargo check` to verify the Tauri commands compile on your platform.
 
 ---
 
@@ -275,7 +380,7 @@ If GameStringer helped you play games in your language:
 
 ## 📜 License
 
-**Source-Available License** — the source code is public and you can build it yourself, but it is not OSI-approved "Open Source".
+**Source-Available License v1.1** — the source code is public and you can build it yourself, but it is not OSI-approved "Open Source".
 
 - ✅ Free for personal use
 - ✅ Free to inspect, build, and modify for yourself
@@ -290,8 +395,12 @@ See [LICENSE](LICENSE) for details. Questions? Open a [Discussion](https://githu
 
 - **[BepInEx](https://github.com/BepInEx/BepInEx)** — Unity modding framework (BepInEx Team)
 - **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Unity translation framework (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — Unreal `.locres` parser (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — GameMaker modding (krzys-h)
 - **[Tauri](https://tauri.app)** — Desktop app framework
 - **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCR engine
+- **[Ollama](https://ollama.com)** — Local LLM runtime
+- **[Supabase](https://supabase.com)** — Realtime backend for Community Chat
 
 ---
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Desktop-Anwendung, die Videospiele mithilfe von KI in jede Sprache übersetzt.</strong><br>
+  Wähle ein Spiel aus deiner Bibliothek, wähle eine Sprache, klicke auf Übersetzen — fertig.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-was-ist-gamestringer">Was ist es</a> ·
+  <a href="#-download">Download</a> ·
+  <a href="#-so-funktionierts">So funktioniert's</a> ·
+  <a href="#-das-prediction-tool-pt">P.T.</a> ·
+  <a href="#-unterstützte-game-engines">Engines</a> ·
+  <a href="#-funktionen">Funktionen</a> ·
+  <a href="#-aus-quellcode-bauen">Build</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Lies in deiner Sprache:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  🇩🇪 Deutsch ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Demo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Spielebibliothek — automatische Erkennung von Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 KI-Übersetzer — 20+ Anbieter, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 One-Click-Patcher — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, automatisches Backup</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, benutzerdefinierte Räume, Online-Präsenz</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — Schnellaktionen, Live-Ollama-Status, Tools-Untermenü</em>
+</p>
+
+---
+
+## 🎮 Was ist GameStringer?
+
+GameStringer ist eine **Desktop-Anwendung** (Windows und Linux), mit der du Videospiele übersetzen kannst, die deine Sprache nicht unterstützen.
+
+Die meisten Spiele speichern ihren Text in Dateien — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, Unity Localization StringTables und viele andere Formate. GameStringer **scannt deinen Spielordner**, findet diese Dateien, sendet den Text durch einen **KI-Übersetzungsanbieter** deiner Wahl (OpenAI, Claude, Gemini, DeepSeek, Ollama und 20+ weitere) und **patcht den übersetzten Text zurück** ins Spiel. Ein Klick, keine technischen Kenntnisse erforderlich.
+
+Für **Unity-Spiele**, die Text in kompilierten Assets einsperren, **installiert GameStringer automatisch BepInEx + XUnity.AutoTranslator** — ohne manuelle Einrichtung. Für **Bethesda-Spiele** (Skyrim, Fallout, Starfield) parst es BSA/BA2/ESP nativ. Für **CRI Middleware-Spiele** (Persona, Yakuza) verarbeitet es CPK/CRILAYLA/MSG/BMD. Für **Unreal Engine** bearbeitet es `.locres` direkt.
+
+**Es ist keine Website für maschinelle Übersetzung.** Es ist eine vollständige Pipeline: **Analyse mit P.T. → Engine erkennen → Text extrahieren → mit KI übersetzen → Qualitätsprüfung → zurückpatchen → spielen.**
+
+---
+
+## 📥 Download
+
+Hol dir die neueste Version von **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+
+| Plattform | Datei | Hinweise |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Installer (empfohlen) |
+| **Windows** | `GameStringer-Portable.zip` | Keine Installation nötig |
+| **Linux** | `GameStringer.AppImage` | Universal (empfohlen) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Anforderungen:** Windows 10+ oder Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ für lokale KI), 500 MB Speicherplatz. Releases sind **digital signiert** und werden **automatisch aktualisiert** über den Tauri Updater.
+
+---
+
+## 🚀 So funktioniert's
+
+1. **Installiere** GameStringer und starte es
+2. **Deine Spielebibliothek wird automatisch geladen** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ Spiele in Sekunden erkannt)
+3. **Wähle ein Spiel** → optional **P.T. (Prediction Tool)** ausführen, um Schwierigkeit, geschätzte Zeit und beste LLM-Kette zu sehen
+4. Klicke auf **„String it!"** — GameStringer scannt, extrahiert, übersetzt und patcht automatisch
+5. **Spiele in deiner Sprache** — Backups werden vor jedem Patch erstellt
+
+Das war's. Keine Kommandozeile, kein manuelles Bearbeiten von Dateien, keine Modding-Erfahrung nötig.
+
+---
+
+## 🧠 Das Prediction Tool (P.T.)
+
+> **Die mächtigste Funktion in GameStringer.** Beginne eine Übersetzung nicht blind — analysiere zuerst.
+
+P.T. ist eine Tiefenanalyse-Engine, die *vor* jeder Übersetzung läuft. Sie scannt deinen Spielordner, erkennt die Engine, schätzt das Volumen übersetzbaren Textes und sagt dir:
+
+- **Difficulty Score 0–100** — kombinierte Gewichtung von String-Volumen, Engine-Komplexität, DRM, Codierung, sprachlichen Herausforderungen
+- **Geschätzte Zeit** über **18 LLM-Modelle** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 empfohlene LLM-Ketten**: Local (Privatsphäre), Cloud (Qualität), Hybrid (ausgewogen), Budget, Premium — jeweils mit Kosten- und Qualitätsbewertung
+- **DRM-Erkennung**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — warnt dich vor dem Versuch
+- **Codierungsanalyse**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR pro Datei erkannt
+- **Übersetzungskomplexität**: Höflichkeitsformen, Geschlechterkongruenz, RTL, Ruby/Furigana, CJK-spezifische Behandlung
+- **Konfidenzscore** und **Workflow-Plan** — die exakten Schritte, die beim Klick auf „String it!" ausgeführt werden
+- **Report-Export** (JSON + Markdown) zum Teilen oder Archivieren
+
+### P.T.Rank — Schnelle Rangliste
+
+Nach dem Ausführen von P.T. auf mehreren Spielen öffne **P.T.Rank**, um alle analysierten Titel nach Schwierigkeit sortiert zu sehen. Perfekt zum Planen deiner Übersetzungsqueue: Beginne mit den leichten Siegen, spare die 800k-String-RPGs für den Schluss.
+
+### Dry Run Scanner
+
+Du willst nicht ein Spiel nach dem anderen analysieren? Führe **Dry Run** von der Bibliotheksseite aus, um **deine gesamte Steam-Bibliothek (800+ Spiele) im Batch** zu scannen, mit **null Dateiänderungen**. Du erhältst einen JSON-Bericht, der jedes Spiel als **Ready** (Engine unterstützt + Strings extrahierbar), **Errors** (Manifest-Probleme / DRM-Blocker) oder **Unsupported** (unbekannte Engine / kein Text) kategorisiert. Fortschritt in Echtzeit, kein Backup nötig, weil nichts angefasst wird.
+
+### String it! Smart Gate
+
+Die **„String it!"**-Schaltfläche auf der Spieldetailseite ist schlau: Wenn das Spiel in den letzten 24h von P.T. analysiert wurde, startet sie direkt den Übersetzungs-Wizard. Sonst schlägt sie vor, zuerst P.T. auszuführen (mit Ein-Klick-Auswahl „Run P.T. first" / „String it! anyway"). Keine verschwendeten Durchläufe mehr auf Spielen, die sich als DRM-gesperrt oder 5-Minuten-Angelegenheiten entpuppen.
+
+---
+
+## 🎯 Unterstützte Game Engines
+
+GameStringer unterstützt **20+ Engines** mit unterschiedlichem Tiefgang:
+
+| Engine | Support | Wie es funktioniert |
+|--------|---------|--------------|
+| **Unity** | ✅ Vollständig | Installiert automatisch BepInEx + XUnity.AutoTranslator + Unity Localization Package Pipeline (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Vollständig | `.locres`-Extraktion und -Patching mit UnrealLocres |
+| **Unreal _P.pak** | ✅ Vollständig | Mod-Paketierung als `<GameStringer>_P.pak`, geladen über den Paks-Ordner |
+| **Godot** | ✅ Vollständig | Native `.translation`-Datei-Unterstützung |
+| **RPG Maker** | ✅ Vollständig | MV/MZ JSON, VX/Ace via Trans, XP via RMXP |
+| **Ren'Py** | ✅ Vollständig | Natives `.rpy`-Script-Parsing mit Dialogerkennung |
+| **GameMaker** | ⚡ Teilweise | Via UndertaleModTool-Integration |
+| **Telltale** | ✅ Vollständig | `.langdb` / `.dlog`-Unterstützung |
+| **Wolf RPG** | ✅ Vollständig | WolfTrans-Integration |
+| **Kirikiri** | ✅ Vollständig | `.ks` / `.scn`-Parsing |
+| **TyranoScript** | ✅ Vollständig | Fast-Path-Extractor mit JSON-Patching |
+| **Electron** | ✅ Vollständig | ASAR-Unpacking + i18n-JSON-Erkennung |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1) Parser, STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD mit automatischer Erkennung von Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Vollständig | Daedalic-Adventures (Deponia, Edna usw.) |
+| **Danganronpa WAD** | ✅ Vollständig | WAD-Archiv-Parser + STX-Dialog-Patching |
+
+> **Unity-Spiele** erhalten eine Sonderbehandlung: Werden keine übersetzbaren Dateien gefunden, erkennt GameStringer, dass es sich um ein Unity-Spiel handelt, und bietet an, **BepInEx + XUnity.AutoTranslator automatisch mit einem Klick zu installieren**. Einfach das Spiel einmal nach der Installation starten, dann erneut scannen — der gesamte Text wird übersetzbar.
+>
+> ⚠️ **Anti-Cheat-Warnung**: BepInEx (DLL-Injection) kann Anti-Cheat-Systeme (EAC, BattlEye, Vanguard) auslösen. GameStringer enthält eine Anti-Cheat-Erkennung und warnt dich. **Nur bei Single-Player- / Offline-Spielen verwenden.** P.T. erkennt DRM vor jeder Modifikation.
+
+---
+
+## ✨ Funktionen
+
+### 🤖 KI-Übersetzung
+
+- **20+ Anbieter**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (lokal), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: versteht Spielgenre, Charakterstimme, Ton, Erzählung vs. UI vs. Dialog
+- **Translation Memory & Glossar**: Konsistenz im gesamten Projekt mit automatischer Glossar-Extraktion
+- **Multi-LLM Compare**: führt mehrere Anbieter parallel aus, wähle das beste Ergebnis pro String
+- **Quality Gates**: automatisches QA-Scoring für jeden übersetzten String (0-100) mit ContentTypeBadge
+- **Vision LLM Translator**: nutzt In-Game-Screenshots für Kontext (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: sieh Qualitätsbewertungen in Echtzeit während der Batch-Übersetzung
+- **RTL-Unterstützung**: automatische Richtungserkennung und `dir`-Attribut-Behandlung
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** mit gewichteten Faktoren (Volumen, Engine, DRM, Codierung, Komplexität)
+- **Zeitschätzungen für 18 LLM-Modelle** einschließlich Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 LLM-Ketten** (Local / Cloud / Hybrid / Budget / Premium) mit Kosten- und Qualitätsschätzungen
+- **DRM-/Anti-Cheat-Erkennung** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Codierungsanalyse** pro Datei (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Übersetzungskomplexitätsanalyse** (Höflichkeitsformen, Geschlecht, CJK, Ruby, RTL)
+- **P.T.Rank / Quick Ranking** — sortiere alle analysierten Spiele nach Schwierigkeit
+- **Dry Run Scanner** — Batch-Scan der gesamten Steam-Bibliothek (800+ Spiele) ohne Modifikation
+- **Workflow Orchestrator** — echter Ausführungsmotor mit universellem Fast Path für 6+ Engines und Echtzeit-Fortschritt
+- **Prediction-Cache** (24h) — sofortiges Wieder-Öffnen zuvor analysierter Spiele
+- **Report-Export** (JSON + Markdown) zum Teilen und Archivieren
+
+### 📚 Spielebibliothek
+
+- **Auto-Detect**: Steam (mit Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ Spiele** aus installierten Bibliotheken in Sekunden erkannt
+- **Spielkarten** mit Cover-Art, Metadaten, Engine-Badge, VR-Badge, Installationsstatus
+- **Hover-Schnellaktionen**: String it!, Batch, Community, P.T. — alles mit einem Klick
+- **Game Update Tracker**: erkennt, wenn Steam ein übersetztes Spiel aktualisiert (via `buildid`), prüft Patch-Integrität (BepInEx-Dateien, `_P.pak`-Präsenz), warnt, wenn ein Re-Patch nötig ist
+- **„Stop monitoring"**-Schaltfläche, um ein bestimmtes Spiel nicht mehr zu verfolgen
+
+### 🔧 Übersetzungs-Tools
+
+- **One-Click Translate** („String it!"): scannen → übersetzen → patchen in einem einzigen Fluss
+- **Batch Translation**: ganze Spiele oder Ordner auf einmal übersetzen
+- **Untertitel-Übersetzer**: SRT, VTT, ASS/SSA mit Timing-Erhaltung
+- **OCR Translator**: extrahiert Text aus Retro-Spielen (8-Bit-, 16-Bit-, DOS-Presets) mit echtem Tauri-Tesseract-Backend
+- **Voice Pipeline**: speech-to-text → übersetzen → text-to-speech
+- **Echtzeit-Overlay**: siehe Übersetzungen beim Spielen via VR/Screen-Overlay
+- **Auto-Translate Review**: „Translate all untranslated"-Schaltfläche mit Fortschrittsbalken
+- **Lore Assistant**: RAG-Chat, der Lore und Dialoge des Spiels kennt
+- **Character Voice Profiles**: definiere Persönlichkeit, Ton, Sprechmuster pro Charakter
+- **Translation Confidence Heatmap**: visuelle Qualitätsübersicht aller Übersetzungen
+
+### 🎮 Game-Engine-Patcher
+
+- **Unity**: BepInEx + XUnity.AutoTranslator-Auto-Installer, Unity Localization Package (StringTable, SharedTableData, Addressables-Katalog, Smart Strings-Validator)
+- **Unreal Engine**: `.locres`-Extraktion + `_P.pak`-Mod-Paketierung
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — alle mit nativen Parsern
+- **Wizard Stepper**: gemeinsames mehrstufiges UI für alle Patcher
+- **Universal PO Export** (gettext `.po`) für jeden Patcher mit Projekt-/Sprach-/Quell-/Engine-Metadaten
+- **Automatisches Backup**: vor jedem Patch, mit Ein-Klick-Wiederherstellung
+
+### 🔌 Erweitert
+
+- **Auto-Hook Scanner**: Prozessspeicher-Scanning (Windows WinAPI) für hartcodierte Strings
+- **System Monitor**: Echtzeit-VRAM/RAM-Nutzung für lokale LLM-Planung
+- **Ollama Setup Wizard**: schrittweise Installation der lokalen KI
+- **Ollama Manager**: Auto-Discovery von Modellen aus dem ollama.com-Register + Auto-Refresh bei Fokus/Navigation
+- **Debug Console**: integrierte Konsole mit Log-Intercept
+- **Plugin System**: Design-Dokument für Drittanbieter-Plugins (siehe `PLUGIN_SYSTEM.md`)
+- **Community Hub**: Teile und lade Translation Memories herunter + GitHub Discussions-Integration
+- **Public API v1**: REST-Endpunkte zur Integration (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Echtzeit-Chat** mit anderen Übersetzern via Supabase Realtime
+- **4 Standardräume**: General, Translations, Feedback & Bugs, Announcements
+- **Benutzerdefinierte Räume**: erstelle Räume für bestimmte Spiele oder Projekte
+- **Auto-Bridge Auth**: dein GameStringer-Profil synchronisiert automatisch mit Supabase — kein zusätzlicher Login
+- **Online-Präsenz**: sieh, wer in jedem Raum online ist
+- **Antworten / Bearbeiten / Löschen** von Nachrichten mit RLS-durchgesetztem Ownership
+- **Ausklappbares Drawer-Widget** in der unteren rechten Ecke
+
+### ♿ Barrierefreiheit (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` auf Icon-Buttons, semantische `CardTitle`-Überschriften, `focus-visible` auf allen Primitives, Skip-to-Content-Link, `main`-Landmark, italienische `sr-only`-Helper
+- **`prefers-reduced-motion`** in allen Animationen respektiert
+- **`forced-colors`** (Windows High Contrast Mode) respektiert
+- **UI in 11 Sprachen**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **RTL-Layout-Unterstützung** mit automatischer Richtungserkennung
+
+### 🎨 Design System (v1.6.0)
+
+- **Card-Varianten** via `cva`: default, muted, highlight, success, error, warning
+- **Button-Größen** einschließlich `xs` und `icon-sm`
+- **Text-Utilities**: `text-micro` (9px), `text-2xs` (10px) — keine willkürlichen Tailwind-Werte mehr
+- **Radix UI vereinheitlicht**: 37 Dateien von `@radix-ui/react-*` nach `radix-ui` migriert, 27 Pakete entfernt
+- **Bundle optimiert**: `optimizePackageImports` für radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Signierte Auto-Updates**: Ein-Klick-Update aus der App via Tauri Updater
+- **Profile**: mehrere Benutzerprofile mit Recovery-Schlüsseln
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` XUnity-Toggle
+- **System Tray**: Schnellaktionen, Live-Ollama-Status, Tools-Untermenü
+- **Cross-Platform**: Windows und Linux mit nativen Builds
+- **Windows-Tray-Fix**: verhindert Konsolen-Flash-Loop beim Spawn von Kindprozessen
+
+---
+
+## 🔧 KI-Anbieter
+
+| Anbieter | API-Key | Free Tier | Ideal für |
+|----------|---------|-----------|----------|
+| **Ollama** | Nein (lokal) | ✅ Unbegrenzt | Privatsphäre, offline |
+| **LM Studio** | Nein (lokal) | ✅ Unbegrenzt | Privatsphäre, GGUF-Modelle |
+| **TranslateGemma** | Nein (Ollama) | ✅ Unbegrenzt — 55 Sprachen, Google | **Empfohlener Start** |
+| **HY-MT1.5** | Nein (Ollama) | ✅ Unbegrenzt — ~1 GB RAM, Tencent | Maschinen mit wenig RAM |
+| **Qwen 3** | Nein (Ollama) | ✅ Unbegrenzt — mehrsprachig | CJK-Sprachen |
+| **Gemma 4** | Nein (Ollama) | ✅ Unbegrenzt — 27B MoE A4B/E4B/E2B | Lokale Qualität |
+| **Gemini** | Ja | ✅ Free Tier (15 RPM) | **Empfohlene Cloud** |
+| **DeepSeek** | Ja | ✅ $0.14/1M input | Günstige Cloud |
+| **Groq** | Ja | ✅ 14.400 Anfragen/Tag | Geschwindigkeit |
+| **Mistral** | Ja | ✅ Free Tier | EU-Cloud |
+| **OpenAI** | Ja | Kostenpflichtig | GPT-4o-Qualität |
+| **Claude** | Ja | Kostenpflichtig | Nuance, langer Kontext |
+| **DeepL** | Ja | ✅ 500k Zeichen/Monat | Europäische Sprachen |
+| **MyMemory** | Nein | ✅ Unbegrenzt | Fallback |
+| **Lingva** | Nein | ✅ Unbegrenzt | Google MT-Spiegel |
+| **Cerebras** | Ja | ✅ Free Tier | Geschwindigkeit |
+| **Together AI** | Ja | ✅ $25 Gratis-Guthaben | Offene Modelle |
+| **Fireworks** | Ja | ✅ Free Tier | Offene Modelle |
+| **OpenRouter** | Ja | ✅ Kostenlose Modelle | Modellvielfalt |
+| **NLLB-200** | Ja | ✅ 200 Sprachen | Seltene Sprachen |
+| **Cohere** | Ja | ✅ Gratis-Testphase | RAG |
+
+**Empfohlener Einstieg**: **TranslateGemma** via Ollama (kostenlos, lokal, 55 Sprachen) oder **Gemini** (Free Tier, Cloud). Wenig RAM: **HY-MT1.5** (~1 GB). Beste Qualität: **Claude 3.5** oder **GPT-4o**. Bestes CJK: **Qwen 3**.
+
+---
+
+## 📖 Dokumentation
+
+### Benutzerhandbücher (11 Sprachen)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Projekt-Dokumentation
+
+- **[CHANGELOG.md](CHANGELOG.md)** — vollständige Versionshistorie
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — Versionierungsrichtlinie
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — aktuelle Roadmap
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — Plugin-Architektur-Design
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Aus Quellcode bauen
+
+**Voraussetzungen**: Node.js 18+, Rust 1.70+, npm. Unter Linux zusätzlich: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # Entwicklung
+npm run tauri:build  # Produktions-Build
+```
+
+Rust-Backend: `cd src-tauri && cargo check`, um zu prüfen, ob die Tauri-Befehle auf deiner Plattform kompilieren.
+
+---
+
+## 💖 Unterstützung
+
+Wenn GameStringer dir geholfen hat, Spiele in deiner Sprache zu spielen:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Lizenz
+
+**Source-Available License v1.1** — der Quellcode ist öffentlich und du kannst ihn selbst bauen, aber er ist nicht OSI-genehmigtes „Open Source".
+
+- ✅ Kostenlos für private Nutzung
+- ✅ Frei zum Prüfen, Bauen und Modifizieren für dich selbst
+- ❌ Kommerzielle Nutzung erfordert schriftliche Genehmigung
+- ❌ Weiterverbreitung modifizierter Versionen erfordert schriftliche Genehmigung
+
+Siehe [LICENSE](LICENSE) für Details. Fragen? Öffne eine [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — Unity-Modding-Framework (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Unity-Übersetzungs-Framework (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — Unreal `.locres`-Parser (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — GameMaker-Modding (krzys-h)
+- **[Tauri](https://tauri.app)** — Desktop-App-Framework
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCR-Engine
+- **[Ollama](https://ollama.com)** — lokale LLM-Runtime
+- **[Supabase](https://supabase.com)** — Realtime-Backend für den Community Chat
+
+---
+
+<p align="center">
+  Mit ❤️ gemacht für Gamer, die in ihrer eigenen Sprache spielen wollen<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Aplicación de escritorio que traduce videojuegos a cualquier idioma usando IA.</strong><br>
+  Elige un juego de tu biblioteca, selecciona un idioma, pulsa traducir — listo.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-qué-es-gamestringer">Qué es</a> ·
+  <a href="#-descarga">Descarga</a> ·
+  <a href="#-cómo-funciona">Cómo funciona</a> ·
+  <a href="#-el-prediction-tool-pt">P.T.</a> ·
+  <a href="#-motores-de-juego-soportados">Motores</a> ·
+  <a href="#-funciones">Funciones</a> ·
+  <a href="#-compilar-desde-el-código-fuente">Build</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Lee en tu idioma:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  🇪🇸 Español ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Demo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Biblioteca de Juegos — detección automática de Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Traductor IA — 20+ proveedores, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Patcher de un clic — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, copia de seguridad automática</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, salas personalizadas, presencia en línea</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — acciones rápidas, estado de Ollama en vivo, submenú de herramientas</em>
+</p>
+
+---
+
+## 🎮 ¿Qué es GameStringer?
+
+GameStringer es una **aplicación de escritorio** (Windows y Linux) que te permite traducir videojuegos que no están en tu idioma.
+
+La mayoría de los juegos almacenan su texto en archivos — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTables de Unity Localization y muchos otros formatos. GameStringer **escanea la carpeta del juego**, encuentra esos archivos, envía el texto a través de un **proveedor de traducción IA** de tu elección (OpenAI, Claude, Gemini, DeepSeek, Ollama, 20+ más) y **aplica el texto traducido** al juego. Un clic, sin conocimientos técnicos necesarios.
+
+Para **juegos Unity** que bloquean el texto dentro de assets compilados, GameStringer **instala automáticamente BepInEx + XUnity.AutoTranslator** — sin configuración manual. Para **juegos de Bethesda** (Skyrim, Fallout, Starfield) analiza BSA/BA2/ESP de forma nativa. Para **juegos con CRI Middleware** (Persona, Yakuza) gestiona CPK/CRILAYLA/MSG/BMD. Para **Unreal Engine** edita `.locres` directamente.
+
+**No es un sitio web de traducción automática.** Es una pipeline completa: **analizar con P.T. → detectar motor → extraer texto → traducir con IA → control de calidad → aplicar parche → jugar.**
+
+---
+
+## 📥 Descarga
+
+Obtén la última versión desde **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+
+| Plataforma | Archivo | Notas |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Instalador (recomendado) |
+| **Windows** | `GameStringer-Portable.zip` | Sin instalación |
+| **Linux** | `GameStringer.AppImage` | Universal (recomendado) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Requisitos:** Windows 10+ o Linux (Ubuntu 22.04+, Fedora 38+), 4 GB de RAM (8 GB+ para IA local), 500 MB de disco. Las versiones están **firmadas digitalmente** y **auto-actualizadas** mediante Tauri Updater.
+
+---
+
+## 🚀 Cómo funciona
+
+1. **Instala** GameStringer y ejecútalo
+2. **Tu biblioteca de juegos se carga automáticamente** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ juegos detectados en segundos)
+3. **Elige un juego** → opcionalmente ejecuta **P.T. (Prediction Tool)** para ver dificultad, tiempo estimado, mejor cadena LLM
+4. Haz clic en **"String it!"** — GameStringer escanea, extrae, traduce y aplica el parche automáticamente
+5. **Juega en tu idioma** — siempre se crean copias de seguridad antes del parcheo
+
+Eso es todo. Sin línea de comandos, sin edición manual de archivos, sin experiencia en modding.
+
+---
+
+## 🧠 El Prediction Tool (P.T.)
+
+> **La función más potente de GameStringer.** No empieces una traducción a ciegas — analiza primero.
+
+P.T. es un motor de análisis profundo que se ejecuta *antes* de cualquier traducción. Escanea la carpeta del juego, detecta el motor, estima el volumen de texto traducible y te dice:
+
+- **Difficulty Score 0–100** — peso combinado de volumen de cadenas, complejidad del motor, DRM, codificación, desafíos lingüísticos
+- **Tiempo estimado** en **18 modelos LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 cadenas LLM recomendadas**: Local (privacidad), Cloud (calidad), Hybrid (equilibrada), Budget, Premium — cada una con puntuación de coste y calidad
+- **Detección de DRM**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — te avisa antes de intentarlo
+- **Análisis de codificación**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR detectados por archivo
+- **Complejidad de traducción**: honoríficos, concordancia de género, RTL, ruby/furigana, manejo específico de CJK
+- **Puntuación de confianza** y **plan de workflow** — los pasos exactos que se ejecutarán al hacer clic en "String it!"
+- **Exportar informe** (JSON + Markdown) para compartir o archivar
+
+### P.T.Rank — Clasificación rápida
+
+Tras ejecutar P.T. en varios juegos, abre **P.T.Rank** para ver todos los títulos analizados ordenados por dificultad. Perfecto para planificar tu cola de traducción: empieza por los fáciles, deja los RPG de 800k cadenas para el final.
+
+### Dry Run Scanner
+
+¿No quieres analizar un juego a la vez? Ejecuta **Dry Run** desde la página de Biblioteca para escanear **toda tu biblioteca de Steam (800+ juegos) en lote**, con **cero modificaciones a los archivos**. Obtienes un informe JSON que categoriza cada juego como **Ready** (motor soportado + cadenas extraíbles), **Errors** (problemas del manifiesto / bloqueo DRM) o **Unsupported** (motor desconocido / sin texto). El progreso es en tiempo real y no se necesita copia de seguridad porque nada se toca.
+
+### String it! Smart Gate
+
+El botón **"String it!"** en la página de detalle del juego es inteligente: si el juego ya ha sido analizado por P.T. en las últimas 24h, lanza directamente el asistente de traducción. Si no, sugiere ejecutar primero P.T. (con elección de un clic "Run P.T. first" / "String it! anyway"). No más ejecuciones desperdiciadas en juegos que resultan estar bloqueados por DRM o ser asuntos de 5 minutos.
+
+---
+
+## 🎯 Motores de juego soportados
+
+GameStringer soporta **20+ motores** con distintos niveles de profundidad:
+
+| Motor | Soporte | Cómo funciona |
+|--------|---------|--------------|
+| **Unity** | ✅ Completo | Instala automáticamente BepInEx + XUnity.AutoTranslator + pipeline Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Completo | Extracción y parcheo `.locres` con UnrealLocres |
+| **Unreal _P.pak** | ✅ Completo | Empaquetado de mod como `<GameStringer>_P.pak` cargado desde la carpeta Paks |
+| **Godot** | ✅ Completo | Soporte nativo para archivos `.translation` |
+| **RPG Maker** | ✅ Completo | MV/MZ JSON, VX/Ace vía Trans, XP vía RMXP |
+| **Ren'Py** | ✅ Completo | Parseo nativo de scripts `.rpy` con detección de diálogos |
+| **GameMaker** | ⚡ Parcial | Vía integración UndertaleModTool |
+| **Telltale** | ✅ Completo | Soporte `.langdb` / `.dlog` |
+| **Wolf RPG** | ✅ Completo | Integración WolfTrans |
+| **Kirikiri** | ✅ Completo | Parseo `.ks` / `.scn` |
+| **TyranoScript** | ✅ Completo | Extractor fast-path con parcheo JSON |
+| **Electron** | ✅ Completo | Desempaquetado ASAR + detección de JSON i18n |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD con auto-detección de Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Completo | Aventuras Daedalic (Deponia, Edna, etc.) |
+| **Danganronpa WAD** | ✅ Completo | Parser de archivo WAD + parcheo de diálogos STX |
+
+> **Los juegos Unity** reciben un trato especial: si no se encuentran archivos traducibles, GameStringer detecta que es un juego Unity y ofrece **instalar automáticamente BepInEx + XUnity.AutoTranslator** con un clic. Solo tienes que lanzar el juego una vez tras la instalación, luego volver a escanear — todo el texto pasa a ser traducible.
+>
+> ⚠️ **Advertencia Anti-Cheat**: BepInEx (inyección de DLL) puede disparar sistemas anti-cheat (EAC, BattlEye, Vanguard). GameStringer incluye detección anti-cheat y te avisará. **Úsalo solo en juegos single-player / offline.** P.T. detecta el DRM antes de cualquier modificación.
+
+---
+
+## ✨ Funciones
+
+### 🤖 Traducción IA
+
+- **20+ proveedores**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (local), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: entiende el género del juego, la voz del personaje, el tono, narrativa vs UI vs diálogo
+- **Translation Memory y Glosario**: consistencia en todo el proyecto con extracción automática de glosario
+- **Multi-LLM Compare**: ejecuta múltiples proveedores en paralelo, elige el mejor resultado por cadena
+- **Quality gates**: puntuación QA automática en cada cadena traducida (0-100) con ContentTypeBadge
+- **Vision LLM Translator**: usa capturas in-game para contexto (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: ve las puntuaciones de calidad en tiempo real durante la traducción por lotes
+- **Soporte RTL**: detección automática de dirección y manejo del atributo `dir`
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** con factores ponderados (volumen, motor, DRM, codificación, complejidad)
+- **Estimaciones de tiempo para 18 modelos LLM** incluyendo Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 cadenas LLM** (Local / Cloud / Hybrid / Budget / Premium) con estimaciones de coste y calidad
+- **Detección de DRM / Anti-Cheat** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Análisis de codificación** por archivo (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Análisis de complejidad de traducción** (honoríficos, género, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — ordena todos los juegos analizados por dificultad
+- **Dry Run Scanner** — escaneo por lotes de toda la biblioteca de Steam (800+ juegos) sin modificación
+- **Workflow Orchestrator** — motor de ejecución real con fast path universal para 6+ motores y progreso en tiempo real
+- **Caché de predicción** (24h) — reapertura instantánea de juegos ya analizados
+- **Exportar informe** (JSON + Markdown) para compartir y archivar
+
+### 📚 Biblioteca de Juegos
+
+- **Auto-detect**: Steam (con Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ juegos** reconocidos desde bibliotecas instaladas en segundos
+- **Tarjetas de juego** con carátulas, metadatos, badge de motor, badge VR, estado de instalación
+- **Acciones rápidas al pasar el cursor**: String it!, Batch, Community, P.T. — todas a un clic
+- **Game Update Tracker**: detecta cuándo Steam actualiza un juego traducido (vía `buildid`), verifica la integridad del parche (archivos BepInEx, presencia de `_P.pak`), avisa si se necesita reparchar
+- Botón **"Stop monitoring"** para dejar de rastrear un juego específico
+
+### 🔧 Herramientas de Traducción
+
+- **One-Click Translate** ("String it!"): escanear → traducir → parchear en un solo flujo
+- **Batch Translation**: traduce juegos o carpetas enteras a la vez
+- **Traductor de Subtítulos**: SRT, VTT, ASS/SSA con preservación de tiempos
+- **OCR Translator**: extrae texto de juegos retro (presets 8-bit, 16-bit, DOS) con backend Tauri Tesseract real
+- **Voice Pipeline**: speech-to-text → traducir → text-to-speech
+- **Overlay en tiempo real**: ve traducciones mientras juegas vía VR/screen overlay
+- **Auto-Translate Review**: botón "Translate all untranslated" con barra de progreso
+- **Lore Assistant**: chat RAG que conoce el lore y los diálogos del juego
+- **Character Voice Profiles**: define personalidad, tono, patrones de habla por personaje
+- **Translation Confidence Heatmap**: visión general visual de la calidad de todas las traducciones
+
+### 🎮 Patchers de motores de juego
+
+- **Unity**: auto-instalador BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, catálogo Addressables, validador Smart Strings)
+- **Unreal Engine**: extracción `.locres` + empaquetado mod `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — todos con parsers nativos
+- **Wizard Stepper**: UI multipaso compartida para todos los patchers
+- **Universal PO Export** (gettext `.po`) para cada patcher con metadatos de proyecto/idioma/fuente/motor
+- **Copia de seguridad automática**: antes de cada parche, con restauración de un clic
+
+### 🔌 Avanzado
+
+- **Auto-Hook Scanner**: escaneo de memoria de proceso (Windows WinAPI) para cadenas hardcoded
+- **System Monitor**: uso de VRAM/RAM en tiempo real para planificar LLM local
+- **Ollama Setup Wizard**: instalación paso a paso de IA local
+- **Ollama Manager**: auto-discovery de modelos desde el registro de ollama.com + auto-refresh al enfocar/navegar
+- **Debug Console**: consola integrada con log intercept
+- **Plugin System**: documento de diseño para plugins de terceros (ver `PLUGIN_SYSTEM.md`)
+- **Community Hub**: comparte y descarga translation memories + integración con GitHub Discussions
+- **Public API v1**: endpoints REST para integración (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Chat en tiempo real** con otros traductores vía Supabase Realtime
+- **4 salas por defecto**: General, Translations, Feedback & Bugs, Announcements
+- **Salas personalizadas**: crea salas para juegos o proyectos específicos
+- **Auto-Bridge Auth**: tu perfil de GameStringer se sincroniza automáticamente con Supabase — sin login extra
+- **Presencia en línea**: ve quién está en cada sala
+- **Responder / editar / borrar** mensajes con ownership aplicado por RLS
+- **Widget drawer expandible** en la esquina inferior derecha
+
+### ♿ Accesibilidad (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` en botones de icono, encabezados semánticos `CardTitle`, `focus-visible` en todas las primitivas, enlace skip-to-content, landmark `main`, helpers `sr-only` en italiano
+- **`prefers-reduced-motion`** respetado en todas las animaciones
+- **`forced-colors`** (Windows High Contrast Mode) respetado
+- **UI en 11 idiomas**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **Soporte de layout RTL** con detección automática de dirección
+
+### 🎨 Design System (v1.6.0)
+
+- **Variantes de Card** vía `cva`: default, muted, highlight, success, error, warning
+- **Tamaños de Button** incluyendo `xs` y `icon-sm`
+- **Utilidades de texto**: `text-micro` (9px), `text-2xs` (10px) — se acabaron los valores arbitrarios de Tailwind
+- **Radix UI unificado**: migrados 37 archivos de `@radix-ui/react-*` a `radix-ui`, 27 paquetes eliminados
+- **Bundle optimizado**: `optimizePackageImports` para radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Auto-updates firmados**: actualización de un clic desde la app vía Tauri Updater
+- **Perfiles**: múltiples perfiles de usuario con claves de recuperación
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` toggle XUnity
+- **System Tray**: acciones rápidas, estado Ollama en vivo, submenú de herramientas
+- **Cross-platform**: Windows y Linux con builds nativos
+- **Fix tray Windows**: previene el bucle de flash de consola al spawn de procesos hijos
+
+---
+
+## 🔧 Proveedores de IA
+
+| Proveedor | API Key | Free Tier | Mejor para |
+|----------|---------|-----------|----------|
+| **Ollama** | No (local) | ✅ Ilimitado | Privacidad, offline |
+| **LM Studio** | No (local) | ✅ Ilimitado | Privacidad, modelos GGUF |
+| **TranslateGemma** | No (Ollama) | ✅ Ilimitado — 55 idiomas, Google | **Inicio recomendado** |
+| **HY-MT1.5** | No (Ollama) | ✅ Ilimitado — ~1GB RAM, Tencent | Máquinas con poca RAM |
+| **Qwen 3** | No (Ollama) | ✅ Ilimitado — multilingüe | Idiomas CJK |
+| **Gemma 4** | No (Ollama) | ✅ Ilimitado — 27B MoE A4B/E4B/E2B | Calidad local |
+| **Gemini** | Sí | ✅ Free tier (15 RPM) | **Cloud recomendado** |
+| **DeepSeek** | Sí | ✅ $0.14/1M input | Cloud económico |
+| **Groq** | Sí | ✅ 14.400 req/día | Velocidad |
+| **Mistral** | Sí | ✅ Free tier | Cloud UE |
+| **OpenAI** | Sí | De pago | Calidad GPT-4o |
+| **Claude** | Sí | De pago | Matices, contexto largo |
+| **DeepL** | Sí | ✅ 500k caracteres/mes | Idiomas europeos |
+| **MyMemory** | No | ✅ Ilimitado | Fallback |
+| **Lingva** | No | ✅ Ilimitado | Mirror de Google MT |
+| **Cerebras** | Sí | ✅ Free tier | Velocidad |
+| **Together AI** | Sí | ✅ $25 de crédito gratis | Modelos abiertos |
+| **Fireworks** | Sí | ✅ Free tier | Modelos abiertos |
+| **OpenRouter** | Sí | ✅ Modelos gratis | Variedad de modelos |
+| **NLLB-200** | Sí | ✅ 200 idiomas | Idiomas raros |
+| **Cohere** | Sí | ✅ Prueba gratis | RAG |
+
+**Recomendados para empezar**: **TranslateGemma** vía Ollama (gratis, local, 55 idiomas) o **Gemini** (free tier, cloud). Poca RAM: **HY-MT1.5** (~1GB). Mejor calidad: **Claude 3.5** o **GPT-4o**. Mejor CJK: **Qwen 3**.
+
+---
+
+## 📖 Documentación
+
+### Guías de usuario (11 idiomas)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Documentación del proyecto
+
+- **[CHANGELOG.md](CHANGELOG.md)** — historial completo de versiones
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — política de versionado
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — roadmap actual
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — diseño de arquitectura de plugins
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Compilar desde el código fuente
+
+**Prerrequisitos**: Node.js 18+, Rust 1.70+, npm. En Linux también: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # desarrollo
+npm run tauri:build  # build de producción
+```
+
+Backend Rust: `cd src-tauri && cargo check` para verificar que los comandos Tauri compilan en tu plataforma.
+
+---
+
+## 💖 Apoyo
+
+Si GameStringer te ayudó a jugar a juegos en tu idioma:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Licencia
+
+**Source-Available License v1.1** — el código fuente es público y puedes compilarlo tú mismo, pero no es "Open Source" aprobado por la OSI.
+
+- ✅ Gratuito para uso personal
+- ✅ Libre para inspeccionar, compilar y modificar para ti mismo
+- ❌ El uso comercial requiere permiso por escrito
+- ❌ La redistribución de versiones modificadas requiere permiso por escrito
+
+Consulta [LICENSE](LICENSE) para más detalles. ¿Preguntas? Abre una [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — framework de modding para Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — framework de traducción para Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — parser `.locres` de Unreal (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — modding GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — framework para apps de escritorio
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — motor OCR
+- **[Ollama](https://ollama.com)** — runtime LLM local
+- **[Supabase](https://supabase.com)** — backend realtime para la Community Chat
+
+---
+
+<p align="center">
+  Hecho con ❤️ para los gamers que quieren jugar en su propio idioma<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Application de bureau qui traduit les jeux vidéo dans n'importe quelle langue grâce à l'IA.</strong><br>
+  Choisissez un jeu dans votre bibliothèque, sélectionnez une langue, cliquez sur traduire — terminé.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-quest-ce-que-gamestringer">Présentation</a> ·
+  <a href="#-téléchargement">Téléchargement</a> ·
+  <a href="#-comment-ça-marche">Comment ça marche</a> ·
+  <a href="#-le-prediction-tool-pt">P.T.</a> ·
+  <a href="#-moteurs-de-jeu-pris-en-charge">Moteurs</a> ·
+  <a href="#-fonctionnalités">Fonctionnalités</a> ·
+  <a href="#-compilation-depuis-les-sources">Build</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Lisez dans votre langue :</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  🇫🇷 Français ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Démo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Bibliothèque de jeux — détection automatique de Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Traducteur IA — 20+ fournisseurs, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Patcher en un clic — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, sauvegarde automatique</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, salons personnalisés, présence en ligne</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — actions rapides, statut Ollama en direct, sous-menu d'outils</em>
+</p>
+
+---
+
+## 🎮 Qu'est-ce que GameStringer ?
+
+GameStringer est une **application de bureau** (Windows et Linux) qui vous permet de traduire les jeux vidéo qui n'existent pas dans votre langue.
+
+La plupart des jeux stockent leur texte dans des fichiers — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTables d'Unity Localization et beaucoup d'autres formats. GameStringer **scanne le dossier du jeu**, trouve ces fichiers, envoie le texte via un **fournisseur de traduction IA** de votre choix (OpenAI, Claude, Gemini, DeepSeek, Ollama, et 20+ autres) et **applique le texte traduit** dans le jeu. Un clic, aucune connaissance technique requise.
+
+Pour les **jeux Unity** qui verrouillent le texte dans des assets compilés, GameStringer **installe automatiquement BepInEx + XUnity.AutoTranslator** — sans configuration manuelle. Pour les **jeux Bethesda** (Skyrim, Fallout, Starfield), il parse nativement BSA/BA2/ESP. Pour les **jeux CRI Middleware** (Persona, Yakuza), il gère CPK/CRILAYLA/MSG/BMD. Pour **Unreal Engine**, il édite les `.locres` directement.
+
+**Ce n'est pas un site de traduction automatique.** C'est un pipeline complet : **analyse avec P.T. → détection du moteur → extraction du texte → traduction IA → contrôle qualité → application du patch → jouer.**
+
+---
+
+## 📥 Téléchargement
+
+Obtenez la dernière version depuis **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)** :
+
+| Plateforme | Fichier | Notes |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Installeur (recommandé) |
+| **Windows** | `GameStringer-Portable.zip` | Sans installation |
+| **Linux** | `GameStringer.AppImage` | Universel (recommandé) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Prérequis :** Windows 10+ ou Linux (Ubuntu 22.04+, Fedora 38+), 4 Go de RAM (8 Go+ pour l'IA locale), 500 Mo de disque. Les versions sont **signées numériquement** et **auto-mises à jour** via Tauri Updater.
+
+---
+
+## 🚀 Comment ça marche
+
+1. **Installez** GameStringer et lancez-le
+2. **Votre bibliothèque de jeux se charge automatiquement** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ jeux détectés en quelques secondes)
+3. **Choisissez un jeu** → lancez éventuellement **P.T. (Prediction Tool)** pour voir la difficulté, le temps estimé, la meilleure chaîne LLM
+4. Cliquez sur **« String it! »** — GameStringer scanne, extrait, traduit et applique le patch automatiquement
+5. **Jouez dans votre langue** — des sauvegardes sont toujours créées avant le patch
+
+C'est tout. Pas de ligne de commande, pas d'édition manuelle de fichiers, pas d'expérience de modding requise.
+
+---
+
+## 🧠 Le Prediction Tool (P.T.)
+
+> **La fonctionnalité la plus puissante de GameStringer.** Ne commencez pas une traduction à l'aveugle — analysez d'abord.
+
+P.T. est un moteur d'analyse approfondie qui s'exécute *avant* toute traduction. Il scanne le dossier du jeu, détecte le moteur, estime le volume de texte traduisible et vous indique :
+
+- **Difficulty Score 0–100** — poids combiné du volume de chaînes, de la complexité du moteur, du DRM, de l'encodage, des défis linguistiques
+- **Temps estimé** sur **18 modèles LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 chaînes LLM recommandées** : Local (confidentialité), Cloud (qualité), Hybrid (équilibrée), Budget, Premium — chacune avec score de coût et qualité
+- **Détection DRM** : Denuvo, VMProtect, Steam DRM, EAC, BattlEye — vous avertit avant d'essayer
+- **Analyse d'encodage** : Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR détectés fichier par fichier
+- **Complexité de traduction** : formes honorifiques, accord de genre, RTL, ruby/furigana, traitement spécifique CJK
+- **Score de confiance** et **plan de workflow** — les étapes exactes qui seront exécutées en cliquant sur « String it! »
+- **Export du rapport** (JSON + Markdown) pour partage ou archivage
+
+### P.T.Rank — Classement rapide
+
+Après avoir exécuté P.T. sur plusieurs jeux, ouvrez **P.T.Rank** pour voir tous les titres analysés triés par difficulté. Idéal pour planifier votre file de traduction : commencez par les plus faciles, gardez les RPG de 800k chaînes pour la fin.
+
+### Dry Run Scanner
+
+Vous ne voulez pas analyser un jeu à la fois ? Lancez **Dry Run** depuis la page Bibliothèque pour scanner **toute votre bibliothèque Steam (800+ jeux) en lot**, avec **zéro modification de fichier**. Vous obtenez un rapport JSON qui catégorise chaque jeu en **Ready** (moteur supporté + chaînes extractibles), **Errors** (problèmes de manifest / blocage DRM) ou **Unsupported** (moteur inconnu / pas de texte). La progression est en temps réel et aucune sauvegarde n'est nécessaire puisque rien n'est touché.
+
+### String it! Smart Gate
+
+Le bouton **« String it! »** sur la page de détail du jeu est intelligent : si le jeu a déjà été analysé par P.T. dans les dernières 24h, il lance directement l'assistant de traduction. Sinon, il suggère d'exécuter P.T. d'abord (avec le choix en un clic « Run P.T. first » / « String it! anyway »). Plus d'exécutions gaspillées sur des jeux qui s'avèrent verrouillés par DRM ou des affaires de 5 minutes.
+
+---
+
+## 🎯 Moteurs de jeu pris en charge
+
+GameStringer prend en charge **20+ moteurs** avec différents niveaux de profondeur :
+
+| Moteur | Support | Comment ça marche |
+|--------|---------|--------------|
+| **Unity** | ✅ Complet | Installe automatiquement BepInEx + XUnity.AutoTranslator + pipeline Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Complet | Extraction et patching `.locres` avec UnrealLocres |
+| **Unreal _P.pak** | ✅ Complet | Empaquetage du mod en `<GameStringer>_P.pak` chargé via le dossier Paks |
+| **Godot** | ✅ Complet | Support natif des fichiers `.translation` |
+| **RPG Maker** | ✅ Complet | MV/MZ JSON, VX/Ace via Trans, XP via RMXP |
+| **Ren'Py** | ✅ Complet | Parsing natif des scripts `.rpy` avec détection de dialogues |
+| **GameMaker** | ⚡ Partiel | Via intégration UndertaleModTool |
+| **Telltale** | ✅ Complet | Support `.langdb` / `.dlog` |
+| **Wolf RPG** | ✅ Complet | Intégration WolfTrans |
+| **Kirikiri** | ✅ Complet | Parsing `.ks` / `.scn` |
+| **TyranoScript** | ✅ Complet | Extracteur fast-path avec patching JSON |
+| **Electron** | ✅ Complet | Dépaquetage ASAR + détection JSON i18n |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD avec auto-détection Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Complet | Aventures Daedalic (Deponia, Edna, etc.) |
+| **Danganronpa WAD** | ✅ Complet | Parser d'archive WAD + patching des dialogues STX |
+
+> **Les jeux Unity** bénéficient d'un traitement spécial : si aucun fichier traduisible n'est trouvé, GameStringer détecte qu'il s'agit d'un jeu Unity et propose d'**installer automatiquement BepInEx + XUnity.AutoTranslator** en un clic. Il suffit de lancer le jeu une fois après l'installation, puis de re-scanner — tout le texte devient traduisible.
+>
+> ⚠️ **Avertissement Anti-Cheat** : BepInEx (injection DLL) peut déclencher les systèmes anti-cheat (EAC, BattlEye, Vanguard). GameStringer inclut une détection anti-cheat et vous avertira. **À utiliser uniquement sur des jeux solo / hors ligne.** P.T. détecte le DRM avant toute modification.
+
+---
+
+## ✨ Fonctionnalités
+
+### 🤖 Traduction IA
+
+- **20+ fournisseurs** : OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (local), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware** : comprend le genre du jeu, la voix du personnage, le ton, narration vs UI vs dialogue
+- **Translation Memory et Glossaire** : cohérence sur tout le projet avec extraction automatique de glossaire
+- **Multi-LLM Compare** : exécute plusieurs fournisseurs en parallèle, choisissez le meilleur résultat par chaîne
+- **Quality gates** : score QA automatique sur chaque chaîne traduite (0-100) avec ContentTypeBadge
+- **Vision LLM Translator** : utilise des captures en jeu pour le contexte (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview** : voyez les scores de qualité en temps réel pendant la traduction par lot
+- **Support RTL** : détection automatique de direction et gestion de l'attribut `dir`
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** avec facteurs pondérés (volume, moteur, DRM, encodage, complexité)
+- **Estimations de temps pour 18 modèles LLM** incluant Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 chaînes LLM** (Local / Cloud / Hybrid / Budget / Premium) avec estimations de coût et qualité
+- **Détection DRM / Anti-Cheat** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Analyse d'encodage** fichier par fichier (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Analyse de complexité de traduction** (honorifiques, genre, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — trie tous les jeux analysés par difficulté
+- **Dry Run Scanner** — scan par lot de toute la bibliothèque Steam (800+ jeux) sans modification
+- **Workflow Orchestrator** — moteur d'exécution réel avec fast path universel pour 6+ moteurs et progression en temps réel
+- **Cache de prédiction** (24h) — réouverture instantanée des jeux déjà analysés
+- **Export du rapport** (JSON + Markdown) pour partage et archivage
+
+### 📚 Bibliothèque de jeux
+
+- **Auto-detect** : Steam (avec Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ jeux** reconnus depuis les bibliothèques installées en quelques secondes
+- **Cartes de jeux** avec jaquettes, métadonnées, badge moteur, badge VR, statut d'installation
+- **Actions rapides au survol** : String it!, Batch, Community, P.T. — toutes en un clic
+- **Game Update Tracker** : détecte quand Steam met à jour un jeu traduit (via `buildid`), vérifie l'intégrité du patch (fichiers BepInEx, présence de `_P.pak`), avertit si un re-patch est nécessaire
+- Bouton **« Stop monitoring »** pour arrêter le suivi d'un jeu spécifique
+
+### 🔧 Outils de traduction
+
+- **One-Click Translate** (« String it! ») : scan → traduction → patch en un seul flux
+- **Batch Translation** : traduisez des jeux ou dossiers entiers d'un coup
+- **Traducteur de sous-titres** : SRT, VTT, ASS/SSA avec préservation du timing
+- **OCR Translator** : extrait le texte de jeux rétro (presets 8-bit, 16-bit, DOS) avec vrai backend Tauri Tesseract
+- **Voice Pipeline** : speech-to-text → traduction → text-to-speech
+- **Overlay temps réel** : voyez les traductions pendant que vous jouez via VR/screen overlay
+- **Auto-Translate Review** : bouton « Translate all untranslated » avec barre de progression
+- **Lore Assistant** : chat RAG qui connaît le lore et les dialogues du jeu
+- **Character Voice Profiles** : définissez personnalité, ton, manière de parler par personnage
+- **Translation Confidence Heatmap** : vue d'ensemble visuelle de la qualité de toutes les traductions
+
+### 🎮 Patchers de moteurs de jeu
+
+- **Unity** : auto-installeur BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, catalogue Addressables, validateur Smart Strings)
+- **Unreal Engine** : extraction `.locres` + empaquetage mod `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0) : Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0) : Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — tous avec parsers natifs
+- **Wizard Stepper** : UI multi-étapes partagée pour tous les patchers
+- **Universal PO Export** (gettext `.po`) pour chaque patcher avec métadonnées projet/langue/source/moteur
+- **Sauvegarde automatique** : avant chaque patch, avec restauration en un clic
+
+### 🔌 Avancé
+
+- **Auto-Hook Scanner** : scan de la mémoire de processus (Windows WinAPI) pour chaînes hardcoded
+- **System Monitor** : usage VRAM/RAM en temps réel pour la planification LLM local
+- **Ollama Setup Wizard** : installation pas à pas de l'IA locale
+- **Ollama Manager** : auto-discovery des modèles depuis le registre ollama.com + auto-refresh au focus/navigation
+- **Debug Console** : console intégrée avec interception de logs
+- **Plugin System** : document de conception pour plugins tiers (voir `PLUGIN_SYSTEM.md`)
+- **Community Hub** : partagez et téléchargez des translation memories + intégration GitHub Discussions
+- **Public API v1** : endpoints REST pour l'intégration (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Chat en temps réel** avec d'autres traducteurs via Supabase Realtime
+- **4 salons par défaut** : General, Translations, Feedback & Bugs, Announcements
+- **Salons personnalisés** : créez des salons pour des jeux ou projets spécifiques
+- **Auto-Bridge Auth** : votre profil GameStringer se synchronise automatiquement avec Supabase — aucune connexion supplémentaire
+- **Présence en ligne** : voyez qui est en ligne dans chaque salon
+- **Répondre / modifier / supprimer** les messages avec ownership imposé par RLS
+- **Widget drawer extensible** dans le coin inférieur droit
+
+### ♿ Accessibilité (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` sur les boutons icône, en-têtes sémantiques `CardTitle`, `focus-visible` sur toutes les primitives, lien skip-to-content, landmark `main`, helpers `sr-only` en italien
+- **`prefers-reduced-motion`** respecté dans toutes les animations
+- **`forced-colors`** (mode Contraste élevé Windows) respecté
+- **UI en 11 langues** : IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **Support du layout RTL** avec détection automatique de direction
+
+### 🎨 Design System (v1.6.0)
+
+- **Variantes Card** via `cva` : default, muted, highlight, success, error, warning
+- **Tailles de Button** incluant `xs` et `icon-sm`
+- **Utilitaires de texte** : `text-micro` (9px), `text-2xs` (10px) — plus de valeurs Tailwind arbitraires
+- **Radix UI unifié** : 37 fichiers migrés de `@radix-ui/react-*` vers `radix-ui`, 27 paquets supprimés
+- **Bundle optimisé** : `optimizePackageImports` pour radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Mises à jour automatiques signées** : mise à jour en un clic depuis l'application via Tauri Updater
+- **Profils** : plusieurs profils utilisateur avec clés de récupération
+- **Global Hotkeys** : `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` bascule XUnity
+- **System Tray** : actions rapides, statut Ollama en direct, sous-menu d'outils
+- **Cross-platform** : Windows et Linux avec builds natifs
+- **Correctif tray Windows** : empêche la boucle de flash console au spawn des processus enfants
+
+---
+
+## 🔧 Fournisseurs IA
+
+| Fournisseur | Clé API | Free Tier | Idéal pour |
+|----------|---------|-----------|----------|
+| **Ollama** | Non (local) | ✅ Illimité | Confidentialité, hors ligne |
+| **LM Studio** | Non (local) | ✅ Illimité | Confidentialité, modèles GGUF |
+| **TranslateGemma** | Non (Ollama) | ✅ Illimité — 55 langues, Google | **Démarrage recommandé** |
+| **HY-MT1.5** | Non (Ollama) | ✅ Illimité — ~1 Go RAM, Tencent | Machines à faible RAM |
+| **Qwen 3** | Non (Ollama) | ✅ Illimité — multilingue | Langues CJK |
+| **Gemma 4** | Non (Ollama) | ✅ Illimité — 27B MoE A4B/E4B/E2B | Qualité locale |
+| **Gemini** | Oui | ✅ Free tier (15 RPM) | **Cloud recommandé** |
+| **DeepSeek** | Oui | ✅ $0.14/1M input | Cloud économique |
+| **Groq** | Oui | ✅ 14 400 req/jour | Rapidité |
+| **Mistral** | Oui | ✅ Free tier | Cloud UE |
+| **OpenAI** | Oui | Payant | Qualité GPT-4o |
+| **Claude** | Oui | Payant | Nuance, contexte long |
+| **DeepL** | Oui | ✅ 500k caractères/mois | Langues européennes |
+| **MyMemory** | Non | ✅ Illimité | Fallback |
+| **Lingva** | Non | ✅ Illimité | Miroir Google MT |
+| **Cerebras** | Oui | ✅ Free tier | Rapidité |
+| **Together AI** | Oui | ✅ $25 de crédit gratuit | Modèles ouverts |
+| **Fireworks** | Oui | ✅ Free tier | Modèles ouverts |
+| **OpenRouter** | Oui | ✅ Modèles gratuits | Variété de modèles |
+| **NLLB-200** | Oui | ✅ 200 langues | Langues rares |
+| **Cohere** | Oui | ✅ Essai gratuit | RAG |
+
+**Recommandés pour démarrer** : **TranslateGemma** via Ollama (gratuit, local, 55 langues) ou **Gemini** (free tier, cloud). Faible RAM : **HY-MT1.5** (~1 Go). Meilleure qualité : **Claude 3.5** ou **GPT-4o**. Meilleur CJK : **Qwen 3**.
+
+---
+
+## 📖 Documentation
+
+### Guides utilisateur (11 langues)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Documentation du projet
+
+- **[CHANGELOG.md](CHANGELOG.md)** — historique complet des versions
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — politique de versioning
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — feuille de route actuelle
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — conception de l'architecture des plugins
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Compilation depuis les sources
+
+**Prérequis** : Node.js 18+, Rust 1.70+, npm. Sous Linux aussi : `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # développement
+npm run tauri:build  # build de production
+```
+
+Backend Rust : `cd src-tauri && cargo check` pour vérifier que les commandes Tauri compilent sur votre plateforme.
+
+---
+
+## 💖 Support
+
+Si GameStringer vous a aidé à jouer dans votre langue :
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Licence
+
+**Source-Available License v1.1** — le code source est public et vous pouvez le compiler vous-même, mais ce n'est pas « Open Source » approuvé OSI.
+
+- ✅ Gratuit pour un usage personnel
+- ✅ Libre d'inspecter, compiler et modifier pour vous-même
+- ❌ L'usage commercial nécessite une permission écrite
+- ❌ La redistribution de versions modifiées nécessite une permission écrite
+
+Voir [LICENSE](LICENSE) pour les détails. Des questions ? Ouvrez une [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — framework de modding Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — framework de traduction Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — parser Unreal `.locres` (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — modding GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — framework pour applications desktop
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — moteur OCR
+- **[Ollama](https://ollama.com)** — runtime LLM local
+- **[Supabase](https://supabase.com)** — backend temps réel pour la Community Chat
+
+---
+
+<p align="center">
+  Fait avec ❤️ pour les joueurs qui veulent jouer dans leur propre langue<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_IT.md
+++ b/README_IT.md
@@ -5,14 +5,14 @@
 <h1 align="center">GameStringer</h1>
 
 <p align="center">
-  <strong>App desktop che traduce i videogiochi in qualsiasi lingua usando l'AI.</strong><br>
-  Scegli un gioco dalla libreria, seleziona la lingua, clicca traduci — fatto.
+  <strong>App desktop che traduce i videogiochi in qualsiasi lingua usando l'IA.</strong><br>
+  Scegli un gioco dalla tua libreria, seleziona una lingua, clicca traduci — fatto.
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/versione-1.6.0-blue" alt="Versione" />
-  <img src="https://img.shields.io/badge/piattaforma-Windows%20%7C%20Linux-lightgrey" alt="Piattaforma" />
-  <img src="https://img.shields.io/badge/licenza-Source--Available-green" alt="Licenza" />
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
   <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
   <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
   <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
@@ -22,144 +22,311 @@
   <a href="#-cosè-gamestringer">Cos'è</a> ·
   <a href="#-download">Download</a> ·
   <a href="#-come-funziona">Come funziona</a> ·
-  <a href="#-engine-supportati">Engine</a> ·
+  <a href="#-il-prediction-tool-pt">P.T.</a> ·
+  <a href="#-motori-di-gioco-supportati">Motori</a> ·
   <a href="#-funzionalità">Funzionalità</a> ·
-  <a href="#%EF%B8%8F-compila-da-sorgente">Build</a>
+  <a href="#-compilazione-dai-sorgenti">Build</a>
 </p>
 
 <p align="center">
-  <a href="README.md">🇬🇧 Read in English</a>
+  <strong>🌍 Leggi nella tua lingua:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  🇮🇹 Italiano ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Demo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Libreria Giochi — rilevamento automatico di Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Traduttore IA — 20+ provider, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Patcher One-Click — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, backup automatico</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, stanze personalizzate, presenza online</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — azioni rapide, stato Ollama live, sottomenu strumenti</em>
 </p>
 
 ---
 
 ## 🎮 Cos'è GameStringer?
 
-GameStringer è un'**applicazione desktop** (Windows e Linux) che ti permette di tradurre i videogiochi che non hanno la tua lingua.
+GameStringer è un'**applicazione desktop** (Windows e Linux) che ti permette di tradurre videogiochi che non supportano la tua lingua.
 
-La maggior parte dei giochi salva i testi in file — JSON, XML, CSV, .locres, .rpy e molti altri formati. GameStringer **scansiona la cartella del gioco**, trova quei file, invia il testo a un **provider AI di traduzione** a tua scelta (OpenAI, Gemini, DeepSeek, Ollama, ecc.) e **reinserisce il testo tradotto** nel gioco. Un click, nessuna competenza tecnica richiesta.
+La maggior parte dei giochi memorizza il testo in file — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTable di Unity Localization e molti altri formati. GameStringer **scansiona la cartella del gioco**, trova quei file, invia il testo tramite un **provider di traduzione IA** a tua scelta (OpenAI, Claude, Gemini, DeepSeek, Ollama, 20+ altri) e **applica la patch del testo tradotto** al gioco. Un clic, senza conoscenze tecniche.
 
-Per i **giochi Unity** che bloccano il testo dentro gli asset compilati, GameStringer **installa automaticamente BepInEx + XUnity.AutoTranslator** — nessun setup manuale.
+Per i **giochi Unity** che bloccano il testo in asset compilati, GameStringer **installa automaticamente BepInEx + XUnity.AutoTranslator** — senza setup manuale. Per i **giochi Bethesda** (Skyrim, Fallout, Starfield) analizza nativamente BSA/BA2/ESP. Per i **giochi CRI Middleware** (Persona, Yakuza) gestisce CPK/CRILAYLA/MSG/BMD. Per **Unreal Engine** modifica direttamente i `.locres`.
 
-**Non è un sito di traduzione automatica.** È una pipeline completa: rileva il gioco → estrai il testo → traduci con AI → controllo qualità → patcha → gioca.
+**Non è un sito di traduzione automatica.** È una pipeline completa: **analisi con P.T. → rilevamento motore → estrazione testo → traduzione IA → controllo qualità → patch di ritorno → gioca.**
 
 ---
 
 ## 📥 Download
 
-Scarica l'ultima release da **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+Ottieni l'ultima versione da **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
 
 | Piattaforma | File | Note |
-|-------------|------|------|
+|----------|------|-------|
 | **Windows** | `GameStringer-Setup.exe` | Installer (consigliato) |
 | **Windows** | `GameStringer-Portable.zip` | Nessuna installazione |
 | **Linux** | `GameStringer.AppImage` | Universale (consigliato) |
 | **Linux** | `GameStringer.deb` | Debian / Ubuntu |
 
-**Requisiti:** Windows 10+ o Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ per AI locale), 500 MB disco.
+**Requisiti:** Windows 10+ o Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ per IA locale), 500 MB di spazio su disco. Le release sono **firmate digitalmente** e **auto-aggiornate** tramite Tauri Updater.
 
 ---
 
 ## 🚀 Come funziona
 
 1. **Installa** GameStringer e avvialo
-2. **La libreria giochi si carica automaticamente** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io
-3. **Scegli un gioco** e clicca **"Traduci"**
-4. **Seleziona la lingua** e il provider AI
-5. GameStringer scansiona i file, traduce tutto e genera una patch
-6. **Applica la patch** — il gioco è nella tua lingua
+2. **La tua libreria di giochi si carica automaticamente** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ giochi rilevati in pochi secondi)
+3. **Scegli un gioco** → opzionalmente esegui **P.T. (Prediction Tool)** per vedere difficoltà, tempo stimato, miglior catena LLM
+4. Clicca **"String it!"** — GameStringer scansiona, estrae, traduce e applica la patch automaticamente
+5. **Gioca nella tua lingua** — i backup vengono sempre creati prima del patching
 
-Tutto qui. Niente terminale, niente file da modificare a mano, niente esperienza di modding.
+Tutto qui. Nessuna riga di comando, nessuna modifica manuale dei file, nessuna esperienza di modding richiesta.
 
 ---
 
-## � Engine Supportati
+## 🧠 Il Prediction Tool (P.T.)
 
-| Engine | Supporto | Come funziona |
-|--------|----------|---------------|
-| **Unity** | ✅ Completo | Installa automaticamente BepInEx + XUnity.AutoTranslator |
-| **Unreal Engine** | ✅ Completo | Estrazione e patching .locres |
-| **Godot** | ✅ Completo | File .translation nativi |
-| **RPG Maker** | ✅ Completo | MV/MZ JSON, VX/Ace via Trans |
-| **Ren'Py** | ✅ Completo | Parsing script .rpy nativo |
-| **GameMaker** | ⚡ Parziale | Via UndertaleModTool |
-| **Telltale** | ✅ Completo | Supporto .langdb / .dlog |
+> **La funzionalità più potente di GameStringer.** Non iniziare una traduzione alla cieca — analizza prima.
+
+P.T. è un motore di analisi approfondita che viene eseguito *prima* di qualsiasi traduzione. Scansiona la cartella del gioco, rileva il motore, stima il volume di testo traducibile e ti dice:
+
+- **Difficulty Score 0–100** — peso combinato di volume di stringhe, complessità del motore, DRM, encoding, sfide linguistiche
+- **Tempo stimato** su **18 modelli LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 catene LLM consigliate**: Local (privacy), Cloud (qualità), Hybrid (bilanciato), Budget, Premium — ciascuna con punteggio di costo e qualità
+- **Rilevamento DRM**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — ti avvisa prima di provare
+- **Analisi encoding**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR rilevati per file
+- **Complessità della traduzione**: onorifici, concordanza di genere, RTL, ruby/furigana, gestione specifica CJK
+- **Punteggio di confidenza** e **piano di workflow** — i passi esatti che verranno eseguiti quando clicchi "String it!"
+- **Export report** (JSON + Markdown) per condivisione o archiviazione
+
+### P.T.Rank — Classifica Rapida
+
+Dopo aver eseguito P.T. su più giochi, apri **P.T.Rank** per vedere tutti i titoli analizzati ordinati per difficoltà. Perfetto per pianificare la tua coda di traduzione: inizia dai giochi facili, lascia per ultimi gli RPG da 800k stringhe.
+
+### Dry Run Scanner
+
+Non vuoi analizzare un gioco alla volta? Esegui **Dry Run** dalla pagina Libreria per scansionare **l'intera libreria Steam (800+ giochi) in batch**, con **zero modifiche ai file**. Ottieni un report JSON che categorizza ogni gioco come **Ready** (motore supportato + stringhe estraibili), **Errors** (problemi del manifest / blocco DRM) o **Unsupported** (motore sconosciuto / nessun testo). Il progresso è in tempo reale e non serve backup perché nulla viene toccato.
+
+### String it! Smart Gate
+
+Il pulsante **"String it!"** nella pagina di dettaglio del gioco è intelligente: se il gioco è già stato analizzato da P.T. nelle ultime 24h, avvia direttamente il wizard di traduzione. Altrimenti suggerisce di eseguire prima P.T. (con scelta one-click "Run P.T. first" / "String it! anyway"). Niente più esecuzioni sprecate su giochi che si rivelano bloccati da DRM o affari di 5 minuti.
+
+---
+
+## 🎯 Motori di gioco supportati
+
+GameStringer supporta **20+ motori** con diversi livelli di profondità:
+
+| Motore | Supporto | Come funziona |
+|--------|---------|--------------|
+| **Unity** | ✅ Completo | Installa automaticamente BepInEx + XUnity.AutoTranslator + pipeline Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Completo | Estrazione e patching `.locres` con UnrealLocres |
+| **Unreal _P.pak** | ✅ Completo | Packaging mod come `<GameStringer>_P.pak` caricato tramite cartella Paks |
+| **Godot** | ✅ Completo | Supporto nativo file `.translation` |
+| **RPG Maker** | ✅ Completo | MV/MZ JSON, VX/Ace via Trans, XP via RMXP |
+| **Ren'Py** | ✅ Completo | Parsing nativo script `.rpy` con rilevamento dialoghi |
+| **GameMaker** | ⚡ Parziale | Via integrazione UndertaleModTool |
+| **Telltale** | ✅ Completo | Supporto `.langdb` / `.dlog` |
 | **Wolf RPG** | ✅ Completo | Integrazione WolfTrans |
-| **Kirikiri** | ✅ Completo | Parsing .ks / .scn |
+| **Kirikiri** | ✅ Completo | Parsing `.ks` / `.scn` |
+| **TyranoScript** | ✅ Completo | Estrattore fast-path con patching JSON |
+| **Electron** | ✅ Completo | Unpacking ASAR + rilevamento i18n JSON |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD con auto-detect Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Completo | Avventure Daedalic (Deponia, Edna, ecc.) |
+| **Danganronpa WAD** | ✅ Completo | Parser archivio WAD + patching dialoghi STX |
 
-> I **giochi Unity** hanno un trattamento speciale: se non vengono trovati file traducibili, GameStringer rileva che è un gioco Unity e propone di **installare automaticamente BepInEx + XUnity.AutoTranslator** con un click. Basta avviare il gioco una volta dopo l'installazione, poi ri-scansionare — tutti i testi diventano traducibili.
+> **I giochi Unity** ricevono un trattamento speciale: se non vengono trovati file traducibili, GameStringer rileva che è un gioco Unity e offre di **installare automaticamente BepInEx + XUnity.AutoTranslator** con un clic. Basta avviare il gioco una volta dopo l'installazione, poi ri-scansionare — tutto il testo diventa traducibile.
 >
-> ⚠️ **Avviso Anti-Cheat**: BepInEx (iniezione DLL) può attivare sistemi anti-cheat (EAC, BattlEye, Vanguard). GameStringer include il rilevamento anti-cheat e ti avviserà. **Usalo solo su giochi single-player / offline.**
+> ⚠️ **Avviso Anti-Cheat**: BepInEx (DLL injection) può attivare sistemi anti-cheat (EAC, BattlEye, Vanguard). GameStringer include rilevamento anti-cheat e ti avviserà. **Usare solo su giochi single-player / offline.** P.T. rileva il DRM prima di qualsiasi modifica.
 
 ---
 
 ## ✨ Funzionalità
 
-### Traduzione AI
+### 🤖 Traduzione IA
 
-- **18+ provider**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (locale), LM Studio, Qwen 3, NLLB-200 e altri
-- **Consapevole del contesto**: comprende genere, voce dei personaggi, tono
-- **Memoria di Traduzione e Glossario**: coerenza in tutto il progetto
-- **Confronto Multi-LLM**: esegui più provider in parallelo, scegli il risultato migliore
-- **Quality gates**: controllo qualità automatico su ogni stringa
+- **20+ provider**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (locale), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: comprende genere del gioco, voce del personaggio, tono, narrazione vs UI vs dialogo
+- **Translation Memory e Glossario**: coerenza nel progetto con estrazione automatica del glossario
+- **Multi-LLM Compare**: esegue più provider in parallelo, scegli il miglior risultato per stringa
+- **Quality gates**: punteggio QA automatico su ogni stringa tradotta (0-100) con ContentTypeBadge
+- **Vision LLM Translator**: usa screenshot in-game per il contesto (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: vedi i punteggi di qualità in tempo reale durante la traduzione batch
+- **Supporto RTL**: rilevamento automatico della direzione e gestione attributo `dir`
 
-### Libreria Giochi
+### 🧠 P.T. — Prediction Tool (v1.6.0)
 
-- **Rilevamento automatico**: Steam (con Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
-- **600+ giochi** riconosciuti dalle librerie installate
-- **Schede gioco** con copertina, metadati e traduzione con un click
+- **Difficulty Score 0-100** con fattori ponderati (volume, motore, DRM, encoding, complessità)
+- **Stime di tempo per 18 modelli LLM** inclusi Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 catene LLM** (Local / Cloud / Hybrid / Budget / Premium) con stime di costo e qualità
+- **Rilevamento DRM / Anti-Cheat** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Analisi encoding** per file (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Analisi complessità traduzione** (onorifici, genere, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — ordina tutti i giochi analizzati per difficoltà
+- **Dry Run Scanner** — scansione batch dell'intera libreria Steam (800+ giochi) senza modifiche
+- **Workflow Orchestrator** — motore di esecuzione reale con fast path universale per 6+ motori e progresso in tempo reale
+- **Prediction cache** (24h) — riapertura istantanea di giochi già analizzati
+- **Export report** (JSON + Markdown) per condivisione e archiviazione
 
-### Strumenti di Traduzione
+### 📚 Libreria Giochi
 
-- **Traduci con un Click**: scansiona → traduci → patcha in un solo flusso
-- **Traduzione Batch**: traduci interi giochi in una volta
-- **Vision LLM**: usa screenshot del gioco per traduzioni context-aware (Ollama, Gemini, GPT-4o)
-- **Traduttore Sottotitoli**: SRT, VTT, ASS/SSA con preservazione timing
-- **Traduttore OCR**: estrai testo da giochi retro (preset 8-bit, 16-bit, DOS)
-- **Pipeline Vocale**: speech-to-text → traduzione → text-to-speech
-- **Overlay Real-time**: vedi le traduzioni mentre giochi
+- **Auto-detect**: Steam (con Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ giochi** riconosciuti dalle librerie installate in pochi secondi
+- **Card dei giochi** con copertine, metadati, badge motore, badge VR, stato di installazione
+- **Azioni rapide hover**: String it!, Batch, Community, P.T. — tutte a un clic
+- **Game Update Tracker**: rileva quando Steam aggiorna un gioco tradotto (tramite `buildid`), verifica l'integrità della patch (file BepInEx, presenza `_P.pak`), avvisa se è necessario ri-patchare
+- Pulsante **"Stop monitoring"** per non tracciare più un gioco specifico
 
-### Avanzati
+### 🔧 Strumenti di Traduzione
 
-- **Lore Assistant**: chat RAG che conosce il lore e i dialoghi del gioco
-- **Profili Voce Personaggio**: definisci personalità, tono, pattern vocali per personaggio
-- **Heatmap Confidenza Traduzione**: panoramica visiva della qualità di tutte le traduzioni
-- **Auto-Hook Scanner**: scansione memoria processo (Windows)
-- **Community Hub**: condividi e scarica memorie di traduzione
-- **API Pubblica v1**: endpoint REST per integrazione (`/api/v1/translate`, `/api/v1/batch`)
+- **One-Click Translate** ("String it!"): scansione → traduzione → patch in un unico flusso
+- **Batch Translation**: traduci interi giochi o cartelle in una volta
+- **Traduttore Sottotitoli**: SRT, VTT, ASS/SSA con preservazione del timing
+- **OCR Translator**: estrae testo da giochi retro (preset 8-bit, 16-bit, DOS) con backend Tauri Tesseract reale
+- **Voice Pipeline**: speech-to-text → traduci → text-to-speech
+- **Real-time Overlay**: vedi le traduzioni mentre giochi tramite VR/screen overlay
+- **Auto-Translate Review**: pulsante "Translate all untranslated" con barra di progresso
+- **Lore Assistant**: chat RAG che conosce lore e dialoghi del gioco
+- **Character Voice Profiles**: definisci personalità, tono, pattern di linguaggio per personaggio
+- **Translation Confidence Heatmap**: panoramica visiva della qualità di tutte le traduzioni
 
-### App
+### 🎮 Patcher per Motori di Gioco
 
+- **Unity**: auto-installer BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, catalogo Addressables, validatore Smart Strings)
+- **Unreal Engine**: estrazione `.locres` + mod packaging `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — tutti con parser nativi
+- **Wizard Stepper**: UI multi-step condivisa per tutti i patcher
+- **Universal PO Export** (gettext `.po`) per ogni patcher con metadati progetto/lingua/sorgente/motore
+- **Backup automatico**: prima di ogni patch, con ripristino one-click
+
+### 🔌 Avanzate
+
+- **Auto-Hook Scanner**: scansione memoria processo (Windows WinAPI) per stringhe hardcoded
+- **System Monitor**: uso VRAM/RAM in tempo reale per pianificazione LLM locale
+- **Ollama Setup Wizard**: installazione IA locale passo-passo
+- **Ollama Manager**: auto-discovery di modelli dal registro ollama.com + auto-refresh su focus/navigazione
+- **Debug Console**: console integrata con log intercept
+- **Plugin System**: design doc per plugin di terze parti (vedi `PLUGIN_SYSTEM.md`)
+- **Community Hub**: condividi e scarica translation memories + integrazione GitHub Discussions
+- **Public API v1**: endpoint REST per integrazione (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Chat in tempo reale** con altri traduttori via Supabase Realtime
+- **4 stanze predefinite**: General, Translations, Feedback & Bugs, Announcements
+- **Stanze personalizzate**: crea stanze per giochi o progetti specifici
+- **Auto-Bridge Auth**: il tuo profilo GameStringer si sincronizza automaticamente con Supabase — nessun login extra
+- **Presenza online**: vedi chi è online in ogni stanza
+- **Rispondi / modifica / elimina** messaggi con ownership enforced da RLS
+- **Widget drawer espandibile** nell'angolo in basso a destra
+
+### ♿ Accessibilità (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` sui pulsanti icona, heading semantici `CardTitle`, `focus-visible` su tutte le primitive, link skip-to-content, landmark `main`, helper `sr-only` italiani
+- **`prefers-reduced-motion`** rispettato in tutte le animazioni
+- **`forced-colors`** (Windows High Contrast Mode) rispettato
 - **UI in 11 lingue**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
-- **Aggiornamenti automatici firmati**: aggiorna con un click dall'app
-- **System Monitor**: utilizzo VRAM/RAM in tempo reale
-- **Profili**: profili utente multipli con chiavi di recupero
+- **Supporto layout RTL** con rilevamento automatico della direzione
+
+### 🎨 Design System (v1.6.0)
+
+- **Varianti Card** tramite `cva`: default, muted, highlight, success, error, warning
+- **Dimensioni Button** incluse `xs` e `icon-sm`
+- **Text utilities**: `text-micro` (9px), `text-2xs` (10px) — niente più valori Tailwind arbitrari
+- **Radix UI unificato**: migrati 37 file da `@radix-ui/react-*` a `radix-ui`, 27 pacchetti rimossi
+- **Bundle ottimizzato**: `optimizePackageImports` per radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Auto-updates firmati**: aggiornamento one-click dall'app via Tauri Updater
+- **Profili**: profili utente multipli con recovery key
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` toggle XUnity
+- **System Tray**: azioni rapide, stato Ollama live, sottomenu strumenti
 - **Cross-platform**: Windows e Linux con build native
+- **Fix tray Windows**: previene il loop di flash console allo spawn di processi figli
 
 ---
 
-## 🔧 Provider AI
+## 🔧 AI Provider
 
-| Provider | API Key | Tier Gratuito |
-|----------|---------|---------------|
-| Ollama | No (locale) | ✅ Illimitato |
-| LM Studio | No (locale) | ✅ Illimitato |
-| Gemini | Sì | ✅ Tier gratuito |
-| DeepSeek | Sì | ✅ Molto economico |
-| Groq | Sì | ✅ 14.400 req/giorno |
-| Mistral | Sì | ✅ Tier gratuito |
-| OpenAI | Sì | A pagamento |
-| Claude | Sì | A pagamento |
-| DeepL | Sì | ✅ 500k car/mese |
-| MyMemory | No | ✅ 1000 parole/giorno |
+| Provider | API Key | Free Tier | Ideale per |
+|----------|---------|-----------|----------|
+| **Ollama** | No (locale) | ✅ Illimitato | Privacy, offline |
+| **LM Studio** | No (locale) | ✅ Illimitato | Privacy, modelli GGUF |
+| **TranslateGemma** | No (Ollama) | ✅ Illimitato — 55 lingue, Google | **Inizio consigliato** |
+| **HY-MT1.5** | No (Ollama) | ✅ Illimitato — ~1GB RAM, Tencent | Macchine con poca RAM |
+| **Qwen 3** | No (Ollama) | ✅ Illimitato — multilingua | Lingue CJK |
+| **Gemma 4** | No (Ollama) | ✅ Illimitato — 27B MoE A4B/E4B/E2B | Qualità locale |
+| **Gemini** | Sì | ✅ Free tier (15 RPM) | **Cloud consigliato** |
+| **DeepSeek** | Sì | ✅ $0.14/1M input | Cloud economico |
+| **Groq** | Sì | ✅ 14.400 req/giorno | Velocità |
+| **Mistral** | Sì | ✅ Free tier | Cloud UE |
+| **OpenAI** | Sì | A pagamento | Qualità GPT-4o |
+| **Claude** | Sì | A pagamento | Sfumature, contesto lungo |
+| **DeepL** | Sì | ✅ 500k caratteri/mese | Lingue europee |
+| **MyMemory** | No | ✅ Illimitato | Fallback |
+| **Lingva** | No | ✅ Illimitato | Mirror Google MT |
+| **Cerebras** | Sì | ✅ Free tier | Velocità |
+| **Together AI** | Sì | ✅ $25 di credito gratis | Modelli aperti |
+| **Fireworks** | Sì | ✅ Free tier | Modelli aperti |
+| **OpenRouter** | Sì | ✅ Modelli gratuiti | Varietà modelli |
+| **NLLB-200** | Sì | ✅ 200 lingue | Lingue rare |
+| **Cohere** | Sì | ✅ Prova gratuita | RAG |
 
-**Per iniziare**: **Ollama** (gratuito, locale) o **Gemini** (tier gratuito, cloud).
+**Consigliati per iniziare**: **TranslateGemma** via Ollama (gratis, locale, 55 lingue) o **Gemini** (free tier, cloud). Poca RAM: **HY-MT1.5** (~1GB). Migliore qualità: **Claude 3.5** o **GPT-4o**. Miglior CJK: **Qwen 3**.
 
 ---
 
 ## 📖 Documentazione
 
-Guide utente in 11 lingue:
+### Guide Utente (11 lingue)
 
 | | | |
 |---|---|---|
@@ -168,9 +335,17 @@ Guide utente in 11 lingue:
 | 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
 | 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
 
+### Documentazione di Progetto
+
+- **[CHANGELOG.md](CHANGELOG.md)** — storico completo delle versioni
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — policy di versioning
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — roadmap attuale
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — design dell'architettura plugin
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
 ---
 
-## 🛠️ Compila da Sorgente
+## 🛠️ Compilazione dai sorgenti
 
 **Prerequisiti**: Node.js 18+, Rust 1.70+, npm. Su Linux anche: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
 
@@ -179,12 +354,14 @@ git clone https://github.com/rouges78/GameStringer.git
 cd GameStringer
 npm install
 npm run dev          # sviluppo
-npm run tauri:build  # build produzione
-```text
+npm run tauri:build  # build di produzione
+```
+
+Backend Rust: `cd src-tauri && cargo check` per verificare che i comandi Tauri compilino sulla tua piattaforma.
 
 ---
 
-## 💖 Supporta
+## 💖 Supporto
 
 Se GameStringer ti ha aiutato a giocare nella tua lingua:
 
@@ -204,27 +381,31 @@ Se GameStringer ti ha aiutato a giocare nella tua lingua:
 
 ## 📜 Licenza
 
-**Licenza Source-Available** — il codice sorgente è pubblico e puoi compilarlo tu stesso, ma non è "Open Source" approvato OSI.
+**Source-Available License v1.1** — il codice sorgente è pubblico e puoi compilarlo tu stesso, ma non è "Open Source" approvato OSI.
 
 - ✅ Gratuito per uso personale
-- ✅ Libero di ispezionare, compilare e modificare per sé
-- ❌ Uso commerciale richiede permesso scritto
-- ❌ Ridistribuzione di versioni modificate richiede permesso scritto
+- ✅ Libero di ispezionare, compilare e modificare per te stesso
+- ❌ L'uso commerciale richiede permesso scritto
+- ❌ La ridistribuzione di versioni modificate richiede permesso scritto
 
-Vedi [LICENSE](LICENSE) per i dettagli. Domande? Apri una [Discussione](https://github.com/rouges78/GameStringer/discussions).
+Vedi [LICENSE](LICENSE) per i dettagli. Domande? Apri una [Discussion](https://github.com/rouges78/GameStringer/discussions).
 
 ---
 
-## 🙏 Crediti
+## 🙏 Credits
 
-- **[BepInEx](https://github.com/BepInEx/BepInEx)** — Framework modding Unity (BepInEx Team)
-- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Framework traduzione Unity (bbepis)
-- **[Tauri](https://tauri.app)** — Framework app desktop
-- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — Motore OCR
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — framework di modding Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — framework di traduzione Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — parser Unreal `.locres` (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — modding GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — framework per app desktop
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — motore OCR
+- **[Ollama](https://ollama.com)** — runtime LLM locale
+- **[Supabase](https://supabase.com)** — backend realtime per la Community Chat
 
 ---
 
 <p align="center">
-  Fatto con ❤️ per i gamer che vogliono giocare nella propria lingua<br>
+  Fatto con ❤️ per i giocatori che vogliono giocare nella loro lingua<br>
   <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
 </p>

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>AIを使ってビデオゲームをあらゆる言語に翻訳するデスクトップアプリ。</strong><br>
+  ライブラリからゲームを選択し、言語を選び、翻訳をクリックするだけ — 完了。
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-gamestringerとは">GameStringerとは</a> ·
+  <a href="#-ダウンロード">ダウンロード</a> ·
+  <a href="#-動作の仕組み">動作の仕組み</a> ·
+  <a href="#-prediction-tool-pt">P.T.</a> ·
+  <a href="#-対応ゲームエンジン">エンジン</a> ·
+  <a href="#-機能">機能</a> ·
+  <a href="#-ソースからのビルド">ビルド</a>
+</p>
+
+<p align="center">
+  <strong>🌍 あなたの言語で読む:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  🇯🇵 日本語 ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## デモ
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 ゲームライブラリ — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.ioの自動検出</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 AI翻訳 — 20以上のプロバイダー、Quality Badges 0-100、Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 ワンクリックパッチャー — BepInEx、XUnity、UnrealLocres、Bethesda BSA/BA2、CRI CPK、自動バックアップ</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime、カスタムルーム、オンラインプレゼンス</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — クイックアクション、Ollamaステータスのライブ表示、ツールサブメニュー</em>
+</p>
+
+---
+
+## 🎮 GameStringerとは？
+
+GameStringerは、あなたの言語に対応していないビデオゲームを翻訳できる**デスクトップアプリケーション**（WindowsとLinux）です。
+
+ほとんどのゲームはテキストをファイルに保存しています — JSON、XML、CSV、`.locres`、`.rpy`、BSA/BA2、CPK、Unity LocalizationのStringTable、その他多くのフォーマット。GameStringerは**ゲームフォルダをスキャン**し、それらのファイルを見つけ、お好みの**AI翻訳プロバイダー**（OpenAI、Claude、Gemini、DeepSeek、Ollama、他20以上）を通してテキストを送信し、翻訳されたテキストをゲームに**パッチして戻します**。ワンクリック、技術知識不要です。
+
+**Unityゲーム**でコンパイル済みアセットにテキストがロックされている場合、GameStringerは**BepInEx + XUnity.AutoTranslatorを自動的にインストール**します — 手動セットアップは不要です。**Bethesdaのゲーム**（Skyrim、Fallout、Starfield）では、BSA/BA2/ESPをネイティブにパースします。**CRI Middlewareのゲーム**（ペルソナ、龍が如く）では、CPK/CRILAYLA/MSG/BMDを処理します。**Unreal Engine**では、`.locres`を直接編集します。
+
+**機械翻訳ウェブサイトではありません。** 完全なパイプラインです：**P.T.で分析 → エンジン検出 → テキスト抽出 → AIで翻訳 → 品質チェック → パッチを戻す → プレイ。**
+
+---
+
+## 📥 ダウンロード
+
+最新リリースは**[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**から入手してください：
+
+| プラットフォーム | ファイル | 備考 |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | インストーラー（推奨） |
+| **Windows** | `GameStringer-Portable.zip` | インストール不要 |
+| **Linux** | `GameStringer.AppImage` | ユニバーサル（推奨） |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**要件：** Windows 10+またはLinux（Ubuntu 22.04+、Fedora 38+）、4 GB RAM（ローカルAIには8 GB+）、500 MBのディスク容量。リリースは**コード署名**され、Tauri Updater経由で**自動更新**されます。
+
+---
+
+## 🚀 動作の仕組み
+
+1. GameStringerを**インストール**して起動
+2. **ゲームライブラリが自動的に読み込まれます** — Steam、Epic、GOG、Origin、Ubisoft、Amazon、itch.io（数秒で800以上のゲームを検出）
+3. **ゲームを選択** → オプションで**P.T.（Prediction Tool）**を実行して、難易度、推定時間、最適なLLMチェーンを確認
+4. **「String it!」**をクリック — GameStringerが自動的にスキャン、抽出、翻訳、パッチ適用
+5. **あなたの言語でプレイ** — パッチ適用前に必ずバックアップが作成されます
+
+それだけです。コマンドラインも、手動でのファイル編集も、Modding経験も不要です。
+
+---
+
+## 🧠 Prediction Tool (P.T.)
+
+> **GameStringerで最も強力な機能。** 翻訳を闇雲に始めないでください — まず分析を。
+
+P.T.は、あらゆる翻訳の*前に*実行される深層分析エンジンです。ゲームフォルダをスキャンし、エンジンを検出し、翻訳可能なテキストの量を見積もり、次の情報を提供します：
+
+- **Difficulty Score 0–100** — 文字列の量、エンジンの複雑さ、DRM、エンコーディング、言語的課題の総合重み
+- **推定時間** を**18のLLMモデル**で算出 — Ollama（Gemma 4、Qwen 3、Llama）、OpenAI GPT-4/4o、Claude 3.5、Gemini、DeepL、DeepSeek、Groq
+- **5つの推奨LLMチェーン**：Local（プライバシー）、Cloud（品質）、Hybrid（バランス）、Budget、Premium — それぞれコストと品質のスコア付き
+- **DRM検出**：Denuvo、VMProtect、Steam DRM、EAC、BattlEye — 試す前に警告
+- **エンコーディング分析**：Shift-JIS、UTF-8、UTF-16、Big5、EUC-KRをファイルごとに検出
+- **翻訳の複雑さ**：敬語、性別の一致、RTL、ルビ/振り仮名、CJK固有の処理
+- **信頼度スコア**と**ワークフロー計画** — 「String it!」クリック時に実行される正確なステップ
+- **レポートエクスポート**（JSON + Markdown）共有やアーカイブ用
+
+### P.T.Rank — クイックランキング
+
+複数のゲームでP.T.を実行した後、**P.T.Rank**を開くと、分析されたすべてのタイトルを難易度順に表示できます。翻訳キューの計画に最適：簡単な勝利から始めて、80万文字列のRPGは最後まで取っておきましょう。
+
+### Dry Run Scanner
+
+一度に1つのゲームを分析したくない？ ライブラリページから**Dry Run**を実行すると、**Steamライブラリ全体（800以上のゲーム）を一括スキャン**でき、**ファイルの変更は一切ありません**。各ゲームを**Ready**（対応エンジン + 抽出可能な文字列）、**Errors**（マニフェストの問題 / DRMブロッカー）、**Unsupported**（不明なエンジン / テキストなし）に分類するJSONレポートを取得できます。進捗はリアルタイムで、何も触れないためバックアップは不要です。
+
+### String it! Smart Gate
+
+ゲーム詳細ページの**「String it!」**ボタンはスマートです：過去24時間以内にP.T.で分析されていれば、翻訳ウィザードを直接起動します。そうでない場合は、まずP.T.を実行することを提案します（ワンクリックで「Run P.T. first」/「String it! anyway」を選択）。DRMでロックされていたり5分で終わるゲームに対する無駄な実行はもうありません。
+
+---
+
+## 🎯 対応ゲームエンジン
+
+GameStringerは、さまざまな深度レベルで**20以上のエンジン**をサポートしています：
+
+| エンジン | サポート | 動作の仕組み |
+|--------|---------|--------------|
+| **Unity** | ✅ 完全 | BepInEx + XUnity.AutoTranslator + Unity Localization Packageパイプライン（StringTable、SharedTableData、Addressables、Smart Strings）を自動インストール |
+| **Unreal Engine** | ✅ 完全 | UnrealLocresによる`.locres`の抽出とパッチ |
+| **Unreal _P.pak** | ✅ 完全 | `<GameStringer>_P.pak`としてModパッケージ化、Paksフォルダ経由でロード |
+| **Godot** | ✅ 完全 | ネイティブ`.translation`ファイルサポート |
+| **RPG Maker** | ✅ 完全 | MV/MZ JSON、VX/Ace（Trans経由）、XP（RMXP経由） |
+| **Ren'Py** | ✅ 完全 | ダイアログ検出機能付きのネイティブ`.rpy`スクリプトパース |
+| **GameMaker** | ⚡ 部分的 | UndertaleModTool統合経由 |
+| **Telltale** | ✅ 完全 | `.langdb` / `.dlog`サポート |
+| **Wolf RPG** | ✅ 完全 | WolfTrans統合 |
+| **Kirikiri** | ✅ 完全 | `.ks` / `.scn`パース |
+| **TyranoScript** | ✅ 完全 | JSONパッチ付きfast-path抽出器 |
+| **Electron** | ✅ 完全 | ASARアンパック + i18n JSON検出 |
+| **Bethesda（Skyrim/Fallout/Oblivion/Starfield）** | ✅ **NEW v1.6.0** | BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM（FULL/DESC/NAM1）パーサー、STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware（ペルソナ/龍が如く/テイルズ/ドラゴンボール）** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTDとShift-JIS/UTF-8/UTF-16の自動検出 |
+| **Visionaire Studio** | ✅ 完全 | Daedalicアドベンチャー（Deponia、Ednaなど） |
+| **Danganronpa WAD** | ✅ 完全 | WADアーカイブパーサー + STXダイアログパッチ |
+
+> **Unityゲーム**は特別な扱いを受けます：翻訳可能なファイルが見つからない場合、GameStringerはそれがUnityゲームであることを検出し、ワンクリックで**BepInEx + XUnity.AutoTranslatorを自動インストール**することを提案します。インストール後に一度ゲームを起動し、再スキャンするだけで、すべてのテキストが翻訳可能になります。
+>
+> ⚠️ **アンチチート警告**：BepInEx（DLLインジェクション）はアンチチートシステム（EAC、BattlEye、Vanguard）をトリガーする可能性があります。GameStringerにはアンチチート検出が含まれており、警告します。**シングルプレイヤー / オフラインゲームでのみ使用してください。** P.T.は変更前にDRMを検出します。
+
+---
+
+## ✨ 機能
+
+### 🤖 AI翻訳
+
+- **20以上のプロバイダー**：OpenAI、Claude、Gemini、DeepSeek、Mistral、Groq、DeepL、Ollama（ローカル）、LM Studio、TranslateGemma、HY-MT、Qwen 3、NLLB-200、Cerebras、Together AI、Fireworks、OpenRouter、Cohere、Lingva、MyMemory
+- **Context-aware**：ゲームのジャンル、キャラクターの声、トーン、ナラティブ vs UI vs ダイアログを理解
+- **Translation Memoryと用語集**：プロジェクト全体での一貫性、用語集の自動抽出
+- **Multi-LLM Compare**：複数のプロバイダーを並列実行し、文字列ごとに最高の結果を選択
+- **Quality gates**：翻訳された各文字列に対する自動QAスコアリング（0-100）とContentTypeBadge
+- **Vision LLM Translator**：コンテキストにゲーム内スクリーンショットを使用（Ollama、Gemini、GPT-4o）
+- **Live Quality Preview**：バッチ翻訳中にリアルタイムで品質スコアを表示
+- **RTLサポート**：方向の自動検出と`dir`属性の処理
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100**、重み付けされた要因（量、エンジン、DRM、エンコーディング、複雑さ）
+- **18のLLMモデルに対する時間推定**（Gemma 4 27B MoE A4B / E4B / E2Bを含む）
+- **5つのLLMチェーン**（Local / Cloud / Hybrid / Budget / Premium）、コストと品質の推定付き
+- **DRM / アンチチート検出**（Denuvo、VMProtect、Steam DRM、EAC、BattlEye、Vanguard）
+- **エンコーディング分析**ファイルごと（Shift-JIS、UTF-8/16、Big5、EUC-KR）
+- **翻訳の複雑さ分析**（敬語、性別、CJK、ルビ、RTL）
+- **P.T.Rank / Quick Ranking** — 分析されたすべてのゲームを難易度順にソート
+- **Dry Run Scanner** — Steamライブラリ全体（800以上のゲーム）を変更なしで一括スキャン
+- **Workflow Orchestrator** — 6以上のエンジンに対するユニバーサルfast pathを備えた実際の実行エンジンとリアルタイム進捗
+- **予測キャッシュ**（24時間）— 以前に分析したゲームの即座な再オープン
+- **レポートエクスポート**（JSON + Markdown）共有とアーカイブ用
+
+### 📚 ゲームライブラリ
+
+- **自動検出**：Steam（Family Sharing付き）、Epic、GOG Galaxy、Origin/EA、Ubisoft Connect、Amazon Games、itch.io
+- インストール済みライブラリから数秒で**800以上のゲーム**を認識
+- カバーアート、メタデータ、エンジンバッジ、VRバッジ、インストール状況付きの**ゲームカード**
+- **ホバークイックアクション**：String it!、Batch、Community、P.T. — すべてワンクリック
+- **Game Update Tracker**：Steamが翻訳済みゲームを更新したことを検出（`buildid`経由）、パッチの整合性を確認（BepInExファイル、`_P.pak`の存在）、再パッチが必要な場合は警告
+- 特定のゲームの追跡を解除する**「Stop monitoring」**ボタン
+
+### 🔧 翻訳ツール
+
+- **One-Click Translate**（「String it!」）：スキャン → 翻訳 → パッチを単一のフローで
+- **Batch Translation**：ゲーム全体やフォルダを一度に翻訳
+- **字幕翻訳**：SRT、VTT、ASS/SSAとタイミングの保持
+- **OCR Translator**：レトロゲーム（8-bit、16-bit、DOSのプリセット）から実際のTauri Tesseractバックエンドでテキストを抽出
+- **Voice Pipeline**：speech-to-text → 翻訳 → text-to-speech
+- **リアルタイムオーバーレイ**：VR/スクリーンオーバーレイ経由でプレイ中に翻訳を確認
+- **Auto-Translate Review**：プログレスバー付きの「Translate all untranslated」ボタン
+- **Lore Assistant**：ゲームのloreとダイアログを知るRAGチャット
+- **Character Voice Profiles**：キャラクターごとに性格、トーン、話し方を定義
+- **Translation Confidence Heatmap**：すべての翻訳の品質の視覚的な概要
+
+### 🎮 ゲームエンジンパッチャー
+
+- **Unity**：BepInEx + XUnity.AutoTranslator自動インストーラー、Unity Localization Package（StringTable、SharedTableData、Addressablesカタログ、Smart Stringsバリデーター）
+- **Unreal Engine**：`.locres`抽出 + `_P.pak` Modパッケージ化
+- **Bethesda Engine Patcher**（NEW v1.6.0）：Skyrim LE/SE/AE、Fallout 3/NV/4、Oblivion、Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM（FULL/DESC/NAM1）
+- **CRI Middleware Patcher**（NEW v1.6.0）：ペルソナ5 Royal、龍が如く、テイルズ、ドラゴンボール — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**、**RPG Maker**、**Godot**、**GameMaker**、**Kirikiri**、**Wolf RPG**、**Telltale**、**Visionaire**、**Danganronpa WAD** — すべてネイティブパーサー付き
+- **Wizard Stepper**：すべてのパッチャー用の共有マルチステップUI
+- すべてのパッチャー用の**Universal PO Export**（gettext `.po`）、プロジェクト/言語/ソース/エンジンメタデータ付き
+- **自動バックアップ**：各パッチの前、ワンクリック復元付き
+
+### 🔌 高度な機能
+
+- **Auto-Hook Scanner**：ハードコードされた文字列のプロセスメモリスキャン（Windows WinAPI）
+- **System Monitor**：ローカルLLMの計画用のリアルタイムVRAM/RAM使用状況
+- **Ollama Setup Wizard**：ローカルAIのステップバイステップインストール
+- **Ollama Manager**：ollama.comレジストリからのモデルの自動発見 + フォーカス/ナビゲーション時の自動更新
+- **Debug Console**：ログインターセプト付きの統合コンソール
+- **Plugin System**：サードパーティプラグインの設計ドキュメント（`PLUGIN_SYSTEM.md`を参照）
+- **Community Hub**：Translation Memoriesの共有とダウンロード + GitHub Discussions統合
+- **Public API v1**：統合用のRESTエンドポイント（`/api/v1/translate`、`/api/v1/batch`）
+
+### 💬 Community Chat
+
+- Supabase Realtime経由で他の翻訳者との**リアルタイムチャット**
+- **4つのデフォルトルーム**：General、Translations、Feedback & Bugs、Announcements
+- **カスタムルーム**：特定のゲームやプロジェクト用のルームを作成
+- **Auto-Bridge Auth**：GameStringerプロファイルがSupabaseに自動同期 — 追加ログイン不要
+- **オンラインプレゼンス**：各ルームで誰がオンラインかを確認
+- RLSによって所有権が強制されたメッセージの**返信 / 編集 / 削除**
+- 右下隅の**拡張可能なドロワーウィジェット**
+
+### ♿ アクセシビリティ (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — アイコンボタンの`aria-label`、セマンティックな`CardTitle`見出し、すべてのプリミティブの`focus-visible`、skip-to-contentリンク、`main`ランドマーク、イタリア語の`sr-only`ヘルパー
+- アニメーション全体で**`prefers-reduced-motion`**を尊重
+- **`forced-colors`**（Windows High Contrastモード）を尊重
+- **11言語UI**：IT、EN、ES、FR、DE、JA、ZH、KO、PT、RU、PL
+- 方向の自動検出を伴う**RTLレイアウトサポート**
+
+### 🎨 Design System (v1.6.0)
+
+- `cva`経由の**Cardバリアント**：default、muted、highlight、success、error、warning
+- `xs`と`icon-sm`を含む**Buttonサイズ**
+- **Text utilities**：`text-micro`（9px）、`text-2xs`（10px） — 任意のTailwind値はもう不要
+- **Radix UI統合**：37ファイルを`@radix-ui/react-*`から`radix-ui`に移行、27パッケージを削除
+- **最適化されたバンドル**：radix-ui、framer-motion、recharts、cmdkの`optimizePackageImports`
+
+### 🖥️ アプリ
+
+- **署名付き自動更新**：Tauri Updater経由でアプリからワンクリックで更新
+- **プロファイル**：リカバリーキー付きの複数のユーザープロファイル
+- **Global Hotkeys**：`Ctrl+Shift+T` OCR、`Ctrl+Shift+Q` Quick Translate、`Ctrl+Alt+O` Overlay、`Alt+T` XUnityトグル
+- **System Tray**：クイックアクション、Ollamaステータスのライブ表示、ツールサブメニュー
+- **クロスプラットフォーム**：ネイティブビルドでのWindowsとLinux
+- **Windowsトレイ修正**：子プロセスのスポーン時のコンソールフラッシュループを防止
+
+---
+
+## 🔧 AIプロバイダー
+
+| プロバイダー | APIキー | Free Tier | 最適な用途 |
+|----------|---------|-----------|----------|
+| **Ollama** | 不要（ローカル） | ✅ 無制限 | プライバシー、オフライン |
+| **LM Studio** | 不要（ローカル） | ✅ 無制限 | プライバシー、GGUFモデル |
+| **TranslateGemma** | 不要（Ollama） | ✅ 無制限 — 55言語、Google | **推奨スタート** |
+| **HY-MT1.5** | 不要（Ollama） | ✅ 無制限 — 約1GB RAM、Tencent | 低RAMマシン |
+| **Qwen 3** | 不要（Ollama） | ✅ 無制限 — 多言語 | CJK言語 |
+| **Gemma 4** | 不要（Ollama） | ✅ 無制限 — 27B MoE A4B/E4B/E2B | ローカル品質 |
+| **Gemini** | 必要 | ✅ 無料枠（15 RPM） | **推奨クラウド** |
+| **DeepSeek** | 必要 | ✅ $0.14/1M input | 低コストクラウド |
+| **Groq** | 必要 | ✅ 14,400リクエスト/日 | 速度 |
+| **Mistral** | 必要 | ✅ 無料枠 | EUクラウド |
+| **OpenAI** | 必要 | 有料 | GPT-4o品質 |
+| **Claude** | 必要 | 有料 | ニュアンス、長いコンテキスト |
+| **DeepL** | 必要 | ✅ 500k文字/月 | ヨーロッパ言語 |
+| **MyMemory** | 不要 | ✅ 無制限 | フォールバック |
+| **Lingva** | 不要 | ✅ 無制限 | Google MTミラー |
+| **Cerebras** | 必要 | ✅ 無料枠 | 速度 |
+| **Together AI** | 必要 | ✅ $25無料クレジット | オープンモデル |
+| **Fireworks** | 必要 | ✅ 無料枠 | オープンモデル |
+| **OpenRouter** | 必要 | ✅ 無料モデル | モデルの多様性 |
+| **NLLB-200** | 必要 | ✅ 200言語 | 希少言語 |
+| **Cohere** | 必要 | ✅ 無料トライアル | RAG |
+
+**スタートに推奨**：Ollama経由の**TranslateGemma**（無料、ローカル、55言語）または**Gemini**（無料枠、クラウド）。低RAM：**HY-MT1.5**（約1GB）。最高品質：**Claude 3.5**または**GPT-4o**。最高のCJK：**Qwen 3**。
+
+---
+
+## 📖 ドキュメント
+
+### ユーザーガイド（11言語）
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### プロジェクトドキュメント
+
+- **[CHANGELOG.md](CHANGELOG.md)** — 完全なバージョン履歴
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — バージョニングポリシー
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — 現在のロードマップ
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — プラグインアーキテクチャ設計
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ ソースからのビルド
+
+**前提条件**：Node.js 18+、Rust 1.70+、npm。Linuxの場合は追加で：`libwebkit2gtk-4.1-dev`、`libayatana-appindicator3-dev`、`librsvg2-dev`。
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # 開発
+npm run tauri:build  # プロダクションビルド
+```
+
+Rustバックエンド：`cd src-tauri && cargo check`でプラットフォーム上でTauriコマンドがコンパイルされることを確認してください。
+
+---
+
+## 💖 サポート
+
+GameStringerがあなたの言語でゲームをプレイするのに役立った場合：
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 ライセンス
+
+**Source-Available License v1.1** — ソースコードは公開されており、自分でビルドできますが、OSI承認の「Open Source」ではありません。
+
+- ✅ 個人利用無料
+- ✅ 自分自身のために検査、ビルド、変更可能
+- ❌ 商用利用には書面による許可が必要
+- ❌ 変更版の再配布には書面による許可が必要
+
+詳細は[LICENSE](LICENSE)を参照してください。質問は[Discussion](https://github.com/rouges78/GameStringer/discussions)を開いてください。
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — Unity moddingフレームワーク（BepInEx Team）
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Unity翻訳フレームワーク（bbepis）
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — Unreal `.locres`パーサー（akintos）
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — GameMaker modding（krzys-h）
+- **[Tauri](https://tauri.app)** — デスクトップアプリフレームワーク
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCRエンジン
+- **[Ollama](https://ollama.com)** — ローカルLLMランタイム
+- **[Supabase](https://supabase.com)** — Community Chat用のリアルタイムバックエンド
+
+---
+
+<p align="center">
+  自分の言語でプレイしたいゲーマーのために❤️で作られました<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>AI를 사용해 비디오 게임을 어떤 언어로든 번역하는 데스크톱 앱.</strong><br>
+  라이브러리에서 게임을 선택하고, 언어를 고르고, 번역을 클릭하세요 — 완료.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-gamestringer란">GameStringer란</a> ·
+  <a href="#-다운로드">다운로드</a> ·
+  <a href="#-작동-방식">작동 방식</a> ·
+  <a href="#-prediction-tool-pt">P.T.</a> ·
+  <a href="#-지원되는-게임-엔진">엔진</a> ·
+  <a href="#-기능">기능</a> ·
+  <a href="#-소스에서-빌드">빌드</a>
+</p>
+
+<p align="center">
+  <strong>🌍 원하는 언어로 읽기:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  🇰🇷 한국어 ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## 데모
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 게임 라이브러리 — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io 자동 감지</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 AI 번역기 — 20개 이상의 제공자, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 원클릭 패처 — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, 자동 백업</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, 사용자 지정 룸, 온라인 프레젠스</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — 빠른 작업, 실시간 Ollama 상태, 도구 하위 메뉴</em>
+</p>
+
+---
+
+## 🎮 GameStringer란?
+
+GameStringer는 원하는 언어가 없는 비디오 게임을 번역할 수 있는 **데스크톱 애플리케이션**(Windows 및 Linux)입니다.
+
+대부분의 게임은 텍스트를 파일에 저장합니다 — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, Unity Localization StringTable 및 기타 많은 형식. GameStringer는 **게임 폴더를 스캔**하고, 해당 파일을 찾아, 선택한 **AI 번역 제공자**(OpenAI, Claude, Gemini, DeepSeek, Ollama 및 20개 이상)를 통해 텍스트를 보내고, **번역된 텍스트를 게임에 패치**합니다. 원클릭, 기술 지식 불필요.
+
+컴파일된 에셋 안에 텍스트가 잠긴 **Unity 게임**의 경우, GameStringer는 **BepInEx + XUnity.AutoTranslator를 자동으로 설치**합니다 — 수동 설정 없음. **Bethesda 게임**(Skyrim, Fallout, Starfield)의 경우 BSA/BA2/ESP를 네이티브로 파싱합니다. **CRI Middleware 게임**(Persona, Yakuza)의 경우 CPK/CRILAYLA/MSG/BMD를 처리합니다. **Unreal Engine**의 경우 `.locres`를 직접 편집합니다.
+
+**기계 번역 웹사이트가 아닙니다.** 완전한 파이프라인입니다: **P.T.로 분석 → 엔진 감지 → 텍스트 추출 → AI로 번역 → 품질 검사 → 다시 패치 → 플레이.**
+
+---
+
+## 📥 다운로드
+
+**[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**에서 최신 릴리스를 받으세요:
+
+| 플랫폼 | 파일 | 비고 |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | 설치 프로그램 (권장) |
+| **Windows** | `GameStringer-Portable.zip` | 설치 불필요 |
+| **Linux** | `GameStringer.AppImage` | 범용 (권장) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**요구 사항:** Windows 10+ 또는 Linux(Ubuntu 22.04+, Fedora 38+), 4GB RAM(로컬 AI의 경우 8GB+), 500MB 디스크 공간. 릴리스는 **코드 서명**되어 있으며 Tauri Updater를 통해 **자동 업데이트**됩니다.
+
+---
+
+## 🚀 작동 방식
+
+1. GameStringer를 **설치**하고 실행
+2. **게임 라이브러리가 자동으로 로드됨** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (몇 초 만에 800개 이상의 게임 감지)
+3. **게임 선택** → 선택적으로 **P.T.(Prediction Tool)**를 실행하여 난이도, 예상 시간, 최상의 LLM 체인 확인
+4. **"String it!"** 클릭 — GameStringer가 자동으로 스캔, 추출, 번역, 패치
+5. **원하는 언어로 플레이** — 패치 전에 항상 백업이 생성됨
+
+그게 전부입니다. 명령줄, 수동 파일 편집, modding 경험이 필요하지 않습니다.
+
+---
+
+## 🧠 Prediction Tool (P.T.)
+
+> **GameStringer의 가장 강력한 기능.** 번역을 맹목적으로 시작하지 마세요 — 먼저 분석하세요.
+
+P.T.는 모든 번역 *전에* 실행되는 심층 분석 엔진입니다. 게임 폴더를 스캔하고, 엔진을 감지하고, 번역 가능한 텍스트의 양을 추정하며 다음을 알려줍니다:
+
+- **Difficulty Score 0–100** — 문자열 양, 엔진 복잡도, DRM, 인코딩, 언어적 도전의 결합 가중치
+- **18개의 LLM 모델**에 걸친 **예상 시간** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5가지 권장 LLM 체인**: Local (개인정보 보호), Cloud (품질), Hybrid (균형), Budget, Premium — 각각 비용 및 품질 점수 포함
+- **DRM 감지**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — 시도하기 전에 경고
+- **인코딩 분석**: 파일별로 Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR 감지
+- **번역 복잡도**: 경어법, 성별 일치, RTL, 루비/후리가나, CJK 특화 처리
+- **신뢰도 점수** 및 **workflow 계획** — "String it!" 클릭 시 실행될 정확한 단계
+- **보고서 내보내기** (JSON + Markdown) 공유 또는 보관용
+
+### P.T.Rank — 빠른 순위
+
+여러 게임에서 P.T.를 실행한 후 **P.T.Rank**를 열어 난이도별로 정렬된 모든 분석된 타이틀을 볼 수 있습니다. 번역 큐를 계획하는 데 완벽함: 쉬운 승리부터 시작하고, 80만 문자열 RPG는 마지막으로 남겨두세요.
+
+### Dry Run Scanner
+
+한 번에 하나의 게임을 분석하고 싶지 않으신가요? 라이브러리 페이지에서 **Dry Run**을 실행하여 **전체 Steam 라이브러리 (800개 이상의 게임)를 일괄 스캔**하세요. **파일 수정은 전혀 없습니다**. 각 게임을 **Ready**(엔진 지원 + 문자열 추출 가능), **Errors**(manifest 문제 / DRM 차단) 또는 **Unsupported**(알 수 없는 엔진 / 텍스트 없음)로 분류하는 JSON 보고서를 받게 됩니다. 진행 상황은 실시간이며 아무것도 건드리지 않기 때문에 백업이 필요 없습니다.
+
+### String it! Smart Gate
+
+게임 세부 페이지의 **"String it!"** 버튼은 스마트합니다: 게임이 지난 24시간 이내에 P.T.에서 이미 분석된 경우 번역 마법사를 직접 실행합니다. 그렇지 않으면 P.T.를 먼저 실행하도록 제안합니다(원클릭 "Run P.T. first" / "String it! anyway" 선택). DRM 잠금이 되어 있거나 5분이면 끝나는 게임에 대한 낭비되는 실행은 이제 없습니다.
+
+---
+
+## 🎯 지원되는 게임 엔진
+
+GameStringer는 다양한 깊이 수준으로 **20개 이상의 엔진**을 지원합니다:
+
+| 엔진 | 지원 | 작동 방식 |
+|--------|---------|--------------|
+| **Unity** | ✅ 완전 | BepInEx + XUnity.AutoTranslator + Unity Localization Package 파이프라인 자동 설치 (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ 완전 | UnrealLocres로 `.locres` 추출 및 패치 |
+| **Unreal _P.pak** | ✅ 완전 | Paks 폴더를 통해 로드되는 `<GameStringer>_P.pak`로 mod 패키징 |
+| **Godot** | ✅ 완전 | 네이티브 `.translation` 파일 지원 |
+| **RPG Maker** | ✅ 완전 | MV/MZ JSON, Trans를 통한 VX/Ace, RMXP를 통한 XP |
+| **Ren'Py** | ✅ 완전 | 대화 감지가 있는 네이티브 `.rpy` 스크립트 파싱 |
+| **GameMaker** | ⚡ 부분 | UndertaleModTool 통합을 통해 |
+| **Telltale** | ✅ 완전 | `.langdb` / `.dlog` 지원 |
+| **Wolf RPG** | ✅ 완전 | WolfTrans 통합 |
+| **Kirikiri** | ✅ 완전 | `.ks` / `.scn` 파싱 |
+| **TyranoScript** | ✅ 완전 | JSON 패치가 있는 fast-path 추출기 |
+| **Electron** | ✅ 완전 | ASAR 언패킹 + i18n JSON 감지 |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1) 파서, STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | Shift-JIS/UTF-8/UTF-16 자동 감지가 있는 CPK + CRILAYLA + MSG/BMD/FTD |
+| **Visionaire Studio** | ✅ 완전 | Daedalic 어드벤처 (Deponia, Edna 등) |
+| **Danganronpa WAD** | ✅ 완전 | WAD 아카이브 파서 + STX 대화 패치 |
+
+> **Unity 게임**은 특별한 취급을 받습니다: 번역 가능한 파일을 찾을 수 없는 경우 GameStringer는 Unity 게임임을 감지하고 원클릭으로 **BepInEx + XUnity.AutoTranslator를 자동으로 설치**할 것을 제안합니다. 설치 후 게임을 한 번 실행한 다음 다시 스캔하기만 하면 모든 텍스트가 번역 가능해집니다.
+>
+> ⚠️ **안티 치트 경고**: BepInEx(DLL 주입)는 안티 치트 시스템(EAC, BattlEye, Vanguard)을 트리거할 수 있습니다. GameStringer에는 안티 치트 감지가 포함되어 있으며 경고합니다. **싱글 플레이어 / 오프라인 게임에서만 사용하세요.** P.T.는 수정 전에 DRM을 감지합니다.
+
+---
+
+## ✨ 기능
+
+### 🤖 AI 번역
+
+- **20개 이상의 제공자**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (로컬), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: 게임 장르, 캐릭터 음성, 톤, 내러티브 vs UI vs 대화 이해
+- **Translation Memory 및 용어집**: 자동 용어집 추출을 통한 프로젝트 전체의 일관성
+- **Multi-LLM Compare**: 여러 제공자를 병렬로 실행하고, 문자열당 최상의 결과 선택
+- **Quality gates**: 각 번역된 문자열에 대한 자동 QA 점수 (0-100)와 ContentTypeBadge
+- **Vision LLM Translator**: 컨텍스트에 게임 내 스크린샷 사용 (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: 일괄 번역 중 실시간으로 품질 점수 확인
+- **RTL 지원**: 자동 방향 감지 및 `dir` 속성 처리
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- 가중 요소(양, 엔진, DRM, 인코딩, 복잡도)가 있는 **Difficulty Score 0-100**
+- Gemma 4 (27B MoE A4B / E4B / E2B)를 포함한 **18개 LLM 모델에 대한 시간 추정**
+- 비용 및 품질 추정이 있는 **5개 LLM 체인**(Local / Cloud / Hybrid / Budget / Premium)
+- **DRM / 안티 치트 감지** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- 파일별 **인코딩 분석** (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **번역 복잡도 분석** (경어법, 성별, CJK, 루비, RTL)
+- **P.T.Rank / Quick Ranking** — 분석된 모든 게임을 난이도별로 정렬
+- **Dry Run Scanner** — 수정 없이 전체 Steam 라이브러리 (800개 이상의 게임) 일괄 스캔
+- **Workflow Orchestrator** — 6개 이상의 엔진에 대한 범용 fast path와 실시간 진행률이 있는 실제 실행 엔진
+- **예측 캐시** (24시간) — 이전에 분석된 게임의 즉각적인 재오픈
+- 공유 및 보관을 위한 **보고서 내보내기** (JSON + Markdown)
+
+### 📚 게임 라이브러리
+
+- **자동 감지**: Steam (Family Sharing 포함), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- 몇 초 만에 설치된 라이브러리에서 **800개 이상의 게임** 인식
+- 커버 아트, 메타데이터, 엔진 배지, VR 배지, 설치 상태가 있는 **게임 카드**
+- **호버 빠른 작업**: String it!, Batch, Community, P.T. — 모두 원클릭
+- **Game Update Tracker**: Steam이 번역된 게임을 업데이트할 때 감지(`buildid` 통해), 패치 무결성 확인(BepInEx 파일, `_P.pak` 존재), 재패치가 필요한 경우 경고
+- 특정 게임 추적을 중지하는 **"Stop monitoring"** 버튼
+
+### 🔧 번역 도구
+
+- **One-Click Translate** ("String it!"): 단일 흐름으로 스캔 → 번역 → 패치
+- **Batch Translation**: 전체 게임 또는 폴더를 한 번에 번역
+- **자막 번역기**: 타이밍 보존이 있는 SRT, VTT, ASS/SSA
+- **OCR Translator**: 실제 Tauri Tesseract 백엔드로 레트로 게임(8-bit, 16-bit, DOS 프리셋)에서 텍스트 추출
+- **Voice Pipeline**: speech-to-text → 번역 → text-to-speech
+- **실시간 오버레이**: VR/스크린 오버레이를 통해 플레이하면서 번역 확인
+- **Auto-Translate Review**: 진행률 표시줄이 있는 "Translate all untranslated" 버튼
+- **Lore Assistant**: 게임의 배경과 대화를 아는 RAG 채팅
+- **Character Voice Profiles**: 캐릭터별 성격, 톤, 말투 정의
+- **Translation Confidence Heatmap**: 모든 번역의 품질에 대한 시각적 개요
+
+### 🎮 게임 엔진 패처
+
+- **Unity**: BepInEx + XUnity.AutoTranslator 자동 설치 프로그램, Unity Localization Package (StringTable, SharedTableData, Addressables 카탈로그, Smart Strings 검증기)
+- **Unreal Engine**: `.locres` 추출 + `_P.pak` mod 패키징
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — 모두 네이티브 파서 포함
+- **Wizard Stepper**: 모든 패처용 공유 다단계 UI
+- 프로젝트/언어/소스/엔진 메타데이터가 있는 모든 패처용 **Universal PO Export** (gettext `.po`)
+- **자동 백업**: 각 패치 전에 원클릭 복원 포함
+
+### 🔌 고급
+
+- **Auto-Hook Scanner**: 하드코딩된 문자열을 위한 프로세스 메모리 스캐닝 (Windows WinAPI)
+- **System Monitor**: 로컬 LLM 계획을 위한 실시간 VRAM/RAM 사용
+- **Ollama Setup Wizard**: 로컬 AI 단계별 설치
+- **Ollama Manager**: ollama.com 레지스트리에서 모델 자동 검색 + 포커스/탐색 시 자동 새로 고침
+- **Debug Console**: 로그 인터셉트가 있는 통합 콘솔
+- **Plugin System**: 타사 플러그인을 위한 설계 문서 (`PLUGIN_SYSTEM.md` 참조)
+- **Community Hub**: Translation Memories 공유 및 다운로드 + GitHub Discussions 통합
+- **Public API v1**: 통합을 위한 REST 엔드포인트 (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- Supabase Realtime을 통해 다른 번역자들과 **실시간 채팅**
+- **4개의 기본 룸**: General, Translations, Feedback & Bugs, Announcements
+- **사용자 지정 룸**: 특정 게임이나 프로젝트를 위한 룸 생성
+- **Auto-Bridge Auth**: GameStringer 프로필이 Supabase와 자동 동기화 — 추가 로그인 필요 없음
+- **온라인 프레젠스**: 각 룸에서 누가 온라인인지 확인
+- RLS로 강제된 소유권과 함께 메시지 **답장 / 편집 / 삭제**
+- 오른쪽 하단 모서리의 **확장 가능한 드로어 위젯**
+
+### ♿ 접근성 (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — 아이콘 버튼의 `aria-label`, 의미론적 `CardTitle` 제목, 모든 프리미티브의 `focus-visible`, skip-to-content 링크, `main` 랜드마크, 이탈리아어 `sr-only` 헬퍼
+- 모든 애니메이션에서 **`prefers-reduced-motion`** 존중
+- **`forced-colors`** (Windows 고대비 모드) 존중
+- **11개 언어 UI**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- 자동 방향 감지가 있는 **RTL 레이아웃 지원**
+
+### 🎨 Design System (v1.6.0)
+
+- `cva`를 통한 **Card 변형**: default, muted, highlight, success, error, warning
+- `xs` 및 `icon-sm`을 포함한 **Button 크기**
+- **텍스트 유틸리티**: `text-micro` (9px), `text-2xs` (10px) — 더 이상 임의의 Tailwind 없음
+- **Radix UI 통합**: `@radix-ui/react-*`에서 `radix-ui`로 37개 파일 마이그레이션, 27개 패키지 제거
+- **최적화된 번들**: radix-ui, framer-motion, recharts, cmdk를 위한 `optimizePackageImports`
+
+### 🖥️ 앱
+
+- **서명된 자동 업데이트**: Tauri Updater를 통해 앱에서 원클릭 업데이트
+- **프로필**: 복구 키가 있는 여러 사용자 프로필
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` XUnity 토글
+- **System Tray**: 빠른 작업, 실시간 Ollama 상태, 도구 하위 메뉴
+- **크로스 플랫폼**: 네이티브 빌드가 있는 Windows 및 Linux
+- **Windows 트레이 수정**: 자식 프로세스 생성 시 콘솔 플래시 루프 방지
+
+---
+
+## 🔧 AI 제공자
+
+| 제공자 | API 키 | Free Tier | 최적 용도 |
+|----------|---------|-----------|----------|
+| **Ollama** | 아니오 (로컬) | ✅ 무제한 | 개인정보 보호, 오프라인 |
+| **LM Studio** | 아니오 (로컬) | ✅ 무제한 | 개인정보 보호, GGUF 모델 |
+| **TranslateGemma** | 아니오 (Ollama) | ✅ 무제한 — 55개 언어, Google | **권장 시작** |
+| **HY-MT1.5** | 아니오 (Ollama) | ✅ 무제한 — 약 1GB RAM, Tencent | 낮은 RAM 머신 |
+| **Qwen 3** | 아니오 (Ollama) | ✅ 무제한 — 다국어 | CJK 언어 |
+| **Gemma 4** | 아니오 (Ollama) | ✅ 무제한 — 27B MoE A4B/E4B/E2B | 로컬 품질 |
+| **Gemini** | 예 | ✅ 무료 티어 (15 RPM) | **권장 클라우드** |
+| **DeepSeek** | 예 | ✅ $0.14/1M input | 저렴한 클라우드 |
+| **Groq** | 예 | ✅ 일일 14,400 요청 | 속도 |
+| **Mistral** | 예 | ✅ 무료 티어 | EU 클라우드 |
+| **OpenAI** | 예 | 유료 | GPT-4o 품질 |
+| **Claude** | 예 | 유료 | 뉘앙스, 긴 컨텍스트 |
+| **DeepL** | 예 | ✅ 월 500k 문자 | 유럽 언어 |
+| **MyMemory** | 아니오 | ✅ 무제한 | 폴백 |
+| **Lingva** | 아니오 | ✅ 무제한 | Google MT 미러 |
+| **Cerebras** | 예 | ✅ 무료 티어 | 속도 |
+| **Together AI** | 예 | ✅ $25 무료 크레딧 | 오픈 모델 |
+| **Fireworks** | 예 | ✅ 무료 티어 | 오픈 모델 |
+| **OpenRouter** | 예 | ✅ 무료 모델 | 모델 다양성 |
+| **NLLB-200** | 예 | ✅ 200개 언어 | 희귀 언어 |
+| **Cohere** | 예 | ✅ 무료 체험 | RAG |
+
+**시작 권장**: Ollama를 통한 **TranslateGemma** (무료, 로컬, 55개 언어) 또는 **Gemini** (무료 티어, 클라우드). 낮은 RAM: **HY-MT1.5** (약 1GB). 최고 품질: **Claude 3.5** 또는 **GPT-4o**. 최고의 CJK: **Qwen 3**.
+
+---
+
+## 📖 문서
+
+### 사용자 가이드 (11개 언어)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### 프로젝트 문서
+
+- **[CHANGELOG.md](CHANGELOG.md)** — 전체 버전 기록
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — 버전 관리 정책
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — 현재 로드맵
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — 플러그인 아키텍처 설계
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ 소스에서 빌드
+
+**전제 조건**: Node.js 18+, Rust 1.70+, npm. Linux에서는 추가로: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # 개발
+npm run tauri:build  # 프로덕션 빌드
+```
+
+Rust 백엔드: `cd src-tauri && cargo check`로 Tauri 명령이 플랫폼에서 컴파일되는지 확인합니다.
+
+---
+
+## 💖 지원
+
+GameStringer가 원하는 언어로 게임을 플레이하는 데 도움이 되었다면:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 라이선스
+
+**Source-Available License v1.1** — 소스 코드는 공개되어 있으며 직접 빌드할 수 있지만, OSI 승인 "오픈 소스"는 아닙니다.
+
+- ✅ 개인 사용 무료
+- ✅ 자신을 위해 자유롭게 검사, 빌드, 수정
+- ❌ 상업적 사용에는 서면 허가 필요
+- ❌ 수정된 버전의 재배포에는 서면 허가 필요
+
+자세한 내용은 [LICENSE](LICENSE)를 참조하세요. 질문이 있으신가요? [Discussion](https://github.com/rouges78/GameStringer/discussions)을 여세요.
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — Unity modding 프레임워크 (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Unity 번역 프레임워크 (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — Unreal `.locres` 파서 (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — GameMaker modding (krzys-h)
+- **[Tauri](https://tauri.app)** — 데스크톱 앱 프레임워크
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCR 엔진
+- **[Ollama](https://ollama.com)** — 로컬 LLM 런타임
+- **[Supabase](https://supabase.com)** — Community Chat용 실시간 백엔드
+
+---
+
+<p align="center">
+  자신의 언어로 게임을 플레이하고 싶은 게이머를 위해 ❤️로 제작됨<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_PL.md
+++ b/README_PL.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Aplikacja desktopowa, która tłumaczy gry wideo na dowolny język za pomocą SI.</strong><br>
+  Wybierz grę ze swojej biblioteki, wybierz język, kliknij przetłumacz — gotowe.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-czym-jest-gamestringer">Czym jest</a> ·
+  <a href="#-pobieranie">Pobieranie</a> ·
+  <a href="#-jak-to-działa">Jak to działa</a> ·
+  <a href="#-prediction-tool-pt">P.T.</a> ·
+  <a href="#-wspierane-silniki-gier">Silniki</a> ·
+  <a href="#-funkcje">Funkcje</a> ·
+  <a href="#-budowanie-ze-źródeł">Build</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Czytaj w swoim języku:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  🇵🇱 Polski
+</p>
+
+---
+
+## Demo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Biblioteka gier — automatyczne wykrywanie Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Tłumacz SI — 20+ dostawców, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Patcher jednego kliknięcia — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, automatyczna kopia zapasowa</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, niestandardowe pokoje, obecność online</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — szybkie akcje, status Ollama na żywo, podmenu narzędzi</em>
+</p>
+
+---
+
+## 🎮 Czym jest GameStringer?
+
+GameStringer to **aplikacja desktopowa** (Windows i Linux), która pozwala tłumaczyć gry wideo niedostępne w Twoim języku.
+
+Większość gier przechowuje swój tekst w plikach — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTable z Unity Localization i wielu innych formatach. GameStringer **skanuje folder gry**, znajduje te pliki, wysyła tekst przez wybrany **dostawcę tłumaczenia SI** (OpenAI, Claude, Gemini, DeepSeek, Ollama, 20+ innych) i **wprowadza przetłumaczony tekst** z powrotem do gry. Jedno kliknięcie, bez wiedzy technicznej.
+
+Dla **gier Unity**, które blokują tekst wewnątrz skompilowanych zasobów, GameStringer **automatycznie instaluje BepInEx + XUnity.AutoTranslator** — bez ręcznej konfiguracji. Dla **gier Bethesdy** (Skyrim, Fallout, Starfield) natywnie parsuje BSA/BA2/ESP. Dla **gier z CRI Middleware** (Persona, Yakuza) obsługuje CPK/CRILAYLA/MSG/BMD. Dla **Unreal Engine** edytuje `.locres` bezpośrednio.
+
+**To nie jest strona tłumaczenia maszynowego.** To kompletny potok: **analiza z P.T. → wykrycie silnika → wyodrębnienie tekstu → tłumaczenie SI → kontrola jakości → patch z powrotem → graj.**
+
+---
+
+## 📥 Pobieranie
+
+Pobierz najnowszą wersję z **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+
+| Platforma | Plik | Uwagi |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Instalator (zalecany) |
+| **Windows** | `GameStringer-Portable.zip` | Bez instalacji |
+| **Linux** | `GameStringer.AppImage` | Uniwersalny (zalecany) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Wymagania:** Windows 10+ lub Linux (Ubuntu 22.04+, Fedora 38+), 4 GB RAM (8 GB+ dla lokalnego SI), 500 MB dysku. Wydania są **podpisane kryptograficznie** i **automatycznie aktualizowane** przez Tauri Updater.
+
+---
+
+## 🚀 Jak to działa
+
+1. **Zainstaluj** GameStringer i uruchom go
+2. **Twoja biblioteka gier ładuje się automatycznie** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ gier wykrywanych w sekundy)
+3. **Wybierz grę** → opcjonalnie uruchom **P.T. (Prediction Tool)**, aby zobaczyć trudność, szacowany czas, najlepszy łańcuch LLM
+4. Kliknij **„String it!"** — GameStringer automatycznie skanuje, wyodrębnia, tłumaczy i patchuje
+5. **Graj w swoim języku** — kopie zapasowe są zawsze tworzone przed patchowaniem
+
+To wszystko. Bez wiersza poleceń, bez ręcznej edycji plików, bez doświadczenia z moddingiem.
+
+---
+
+## 🧠 Prediction Tool (P.T.)
+
+> **Najpotężniejsza funkcja w GameStringer.** Nie rozpoczynaj tłumaczenia na ślepo — najpierw przeanalizuj.
+
+P.T. to silnik głębokiej analizy, który działa *przed* jakimkolwiek tłumaczeniem. Skanuje folder gry, wykrywa silnik, szacuje objętość tekstu do tłumaczenia i mówi Ci:
+
+- **Difficulty Score 0–100** — łączna waga objętości ciągów, złożoności silnika, DRM, kodowania, wyzwań językowych
+- **Szacowany czas** na **18 modelach LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 zalecanych łańcuchów LLM**: Local (prywatność), Cloud (jakość), Hybrid (zrównoważony), Budget, Premium — każdy z oceną kosztów i jakości
+- **Wykrywanie DRM**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — ostrzega przed próbą
+- **Analiza kodowania**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR wykrywane dla każdego pliku
+- **Złożoność tłumaczenia**: formy grzecznościowe, zgodność rodzaju, RTL, ruby/furigana, specyficzne traktowanie CJK
+- **Ocena pewności** i **plan workflow** — dokładne kroki, które zostaną wykonane po kliknięciu „String it!"
+- **Eksport raportu** (JSON + Markdown) do udostępniania lub archiwizacji
+
+### P.T.Rank — Szybki ranking
+
+Po uruchomieniu P.T. na wielu grach otwórz **P.T.Rank**, aby zobaczyć wszystkie przeanalizowane tytuły posortowane według trudności. Idealne do planowania kolejki tłumaczeń: zacznij od łatwych zwycięstw, RPG-i z 800 tys. ciągów zostaw na koniec.
+
+### Dry Run Scanner
+
+Nie chcesz analizować jednej gry na raz? Uruchom **Dry Run** ze strony Biblioteki, aby skanować **całą bibliotekę Steam (800+ gier) wsadowo**, z **zerową modyfikacją plików**. Otrzymasz raport JSON kategoryzujący każdą grę jako **Ready** (silnik wspierany + ciągi do wyodrębnienia), **Errors** (problemy z manifestem / blokada DRM) lub **Unsupported** (nieznany silnik / brak tekstu). Postęp jest w czasie rzeczywistym, a kopia zapasowa nie jest potrzebna, ponieważ niczego się nie dotyka.
+
+### String it! Smart Gate
+
+Przycisk **„String it!"** na stronie szczegółów gry jest inteligentny: jeśli gra została już przeanalizowana przez P.T. w ciągu ostatnich 24h, uruchamia bezpośrednio kreator tłumaczenia. W przeciwnym razie sugeruje uruchomienie P.T. najpierw (z wyborem jednego kliknięcia „Run P.T. first" / „String it! anyway"). Koniec z marnowanymi uruchomieniami na grach, które okazują się zablokowane przez DRM lub sprawami 5-minutowymi.
+
+---
+
+## 🎯 Wspierane silniki gier
+
+GameStringer wspiera **20+ silników** z różnym poziomem głębokości:
+
+| Silnik | Wsparcie | Jak to działa |
+|--------|---------|--------------|
+| **Unity** | ✅ Pełne | Automatycznie instaluje BepInEx + XUnity.AutoTranslator + potok Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Pełne | Wyodrębnianie i patchowanie `.locres` z UnrealLocres |
+| **Unreal _P.pak** | ✅ Pełne | Pakowanie moda jako `<GameStringer>_P.pak` ładowanego przez folder Paks |
+| **Godot** | ✅ Pełne | Natywne wsparcie plików `.translation` |
+| **RPG Maker** | ✅ Pełne | MV/MZ JSON, VX/Ace przez Trans, XP przez RMXP |
+| **Ren'Py** | ✅ Pełne | Natywne parsowanie skryptów `.rpy` z wykrywaniem dialogów |
+| **GameMaker** | ⚡ Częściowe | Przez integrację UndertaleModTool |
+| **Telltale** | ✅ Pełne | Wsparcie `.langdb` / `.dlog` |
+| **Wolf RPG** | ✅ Pełne | Integracja WolfTrans |
+| **Kirikiri** | ✅ Pełne | Parsowanie `.ks` / `.scn` |
+| **TyranoScript** | ✅ Pełne | Ekstraktor fast-path z patchowaniem JSON |
+| **Electron** | ✅ Pełne | Rozpakowywanie ASAR + wykrywanie JSON i18n |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD z auto-wykrywaniem Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Pełne | Przygodówki Daedalic (Deponia, Edna itp.) |
+| **Danganronpa WAD** | ✅ Pełne | Parser archiwum WAD + patchowanie dialogów STX |
+
+> **Gry Unity** otrzymują specjalne traktowanie: jeśli nie znaleziono żadnych plików do tłumaczenia, GameStringer wykrywa, że to gra Unity i oferuje **automatyczne zainstalowanie BepInEx + XUnity.AutoTranslator** jednym kliknięciem. Wystarczy uruchomić grę raz po instalacji, następnie ponownie skanować — cały tekst staje się możliwy do tłumaczenia.
+>
+> ⚠️ **Ostrzeżenie Anti-Cheat**: BepInEx (iniekcja DLL) może wyzwalać systemy anti-cheat (EAC, BattlEye, Vanguard). GameStringer zawiera wykrywanie anti-cheat i ostrzeże Cię. **Używaj tylko w grach single-player / offline.** P.T. wykrywa DRM przed jakąkolwiek modyfikacją.
+
+---
+
+## ✨ Funkcje
+
+### 🤖 Tłumaczenie SI
+
+- **20+ dostawców**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (lokalny), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: rozumie gatunek gry, głos postaci, ton, narrację vs UI vs dialog
+- **Translation Memory i glosariusz**: spójność w całym projekcie z automatycznym wyodrębnianiem glosariusza
+- **Multi-LLM Compare**: uruchamia wielu dostawców równolegle, wybierz najlepszy wynik dla każdego ciągu
+- **Quality gates**: automatyczne ocenianie QA każdego przetłumaczonego ciągu (0-100) z ContentTypeBadge
+- **Vision LLM Translator**: używa zrzutów ekranu z gry jako kontekstu (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: zobacz oceny jakości w czasie rzeczywistym podczas tłumaczenia wsadowego
+- **Wsparcie RTL**: automatyczne wykrywanie kierunku i obsługa atrybutu `dir`
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** z ważonymi czynnikami (objętość, silnik, DRM, kodowanie, złożoność)
+- **Szacunki czasu dla 18 modeli LLM**, w tym Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 łańcuchów LLM** (Local / Cloud / Hybrid / Budget / Premium) z szacunkami kosztów i jakości
+- **Wykrywanie DRM / Anti-Cheat** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Analiza kodowania** dla każdego pliku (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Analiza złożoności tłumaczenia** (formy grzecznościowe, rodzaj, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — sortuje wszystkie przeanalizowane gry według trudności
+- **Dry Run Scanner** — wsadowe skanowanie całej biblioteki Steam (800+ gier) bez modyfikacji
+- **Workflow Orchestrator** — rzeczywisty silnik wykonania z uniwersalnym fast path dla 6+ silników i postępem w czasie rzeczywistym
+- **Cache predykcji** (24h) — natychmiastowe ponowne otwieranie wcześniej przeanalizowanych gier
+- **Eksport raportu** (JSON + Markdown) do udostępniania i archiwizacji
+
+### 📚 Biblioteka gier
+
+- **Auto-detect**: Steam (z Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ gier** rozpoznawanych z zainstalowanych bibliotek w sekundy
+- **Karty gier** z okładkami, metadanymi, odznaką silnika, odznaką VR, statusem instalacji
+- **Szybkie akcje przy najechaniu**: String it!, Batch, Community, P.T. — wszystkie jednym kliknięciem
+- **Game Update Tracker**: wykrywa, gdy Steam aktualizuje przetłumaczoną grę (przez `buildid`), weryfikuje integralność patcha (pliki BepInEx, obecność `_P.pak`), ostrzega, jeśli wymagane jest ponowne patchowanie
+- Przycisk **„Stop monitoring"**, aby zaprzestać śledzenia konkretnej gry
+
+### 🔧 Narzędzia tłumaczeniowe
+
+- **One-Click Translate** („String it!"): skanowanie → tłumaczenie → patch w jednym przepływie
+- **Batch Translation**: tłumacz całe gry lub foldery naraz
+- **Tłumacz napisów**: SRT, VTT, ASS/SSA z zachowaniem taktowania
+- **OCR Translator**: wyodrębnia tekst z gier retro (presety 8-bit, 16-bit, DOS) z prawdziwym backendem Tauri Tesseract
+- **Voice Pipeline**: speech-to-text → tłumacz → text-to-speech
+- **Overlay w czasie rzeczywistym**: zobacz tłumaczenia podczas gry przez VR/screen overlay
+- **Auto-Translate Review**: przycisk „Translate all untranslated" z paskiem postępu
+- **Lore Assistant**: czat RAG, który zna lore i dialogi gry
+- **Character Voice Profiles**: zdefiniuj osobowość, ton, wzorce mowy dla każdej postaci
+- **Translation Confidence Heatmap**: wizualny przegląd jakości wszystkich tłumaczeń
+
+### 🎮 Patchery silników gier
+
+- **Unity**: auto-instalator BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, katalog Addressables, walidator Smart Strings)
+- **Unreal Engine**: wyodrębnianie `.locres` + pakowanie moda `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — wszystkie z natywnymi parserami
+- **Wizard Stepper**: wspólny wieloetapowy UI dla wszystkich patcherów
+- **Universal PO Export** (gettext `.po`) dla każdego patchera z metadanymi projektu/języka/źródła/silnika
+- **Automatyczna kopia zapasowa**: przed każdym patchem, z przywracaniem jednym kliknięciem
+
+### 🔌 Zaawansowane
+
+- **Auto-Hook Scanner**: skanowanie pamięci procesu (Windows WinAPI) dla ciągów hardcoded
+- **System Monitor**: użycie VRAM/RAM w czasie rzeczywistym do planowania lokalnego LLM
+- **Ollama Setup Wizard**: krok po kroku instalacja lokalnego SI
+- **Ollama Manager**: auto-discovery modeli z rejestru ollama.com + auto-odświeżanie przy fokusie/nawigacji
+- **Debug Console**: zintegrowana konsola z przechwytywaniem logów
+- **Plugin System**: dokument projektowy dla wtyczek innych firm (zobacz `PLUGIN_SYSTEM.md`)
+- **Community Hub**: udostępniaj i pobieraj Translation Memories + integracja z GitHub Discussions
+- **Public API v1**: punkty końcowe REST do integracji (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Czat w czasie rzeczywistym** z innymi tłumaczami przez Supabase Realtime
+- **4 domyślne pokoje**: General, Translations, Feedback & Bugs, Announcements
+- **Niestandardowe pokoje**: twórz pokoje dla konkretnych gier lub projektów
+- **Auto-Bridge Auth**: Twój profil GameStringer automatycznie synchronizuje się z Supabase — bez dodatkowego logowania
+- **Obecność online**: zobacz, kto jest online w każdym pokoju
+- **Odpowiedz / edytuj / usuń** wiadomości z własnością wymuszoną przez RLS
+- **Rozszerzalny widget drawer** w prawym dolnym rogu
+
+### ♿ Dostępność (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` na przyciskach ikon, semantyczne nagłówki `CardTitle`, `focus-visible` na wszystkich prymitywach, link skip-to-content, landmark `main`, włoskie helpery `sr-only`
+- **`prefers-reduced-motion`** respektowane we wszystkich animacjach
+- **`forced-colors`** (tryb wysokiego kontrastu Windows) respektowany
+- **UI w 11 językach**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **Wsparcie układu RTL** z automatycznym wykrywaniem kierunku
+
+### 🎨 Design System (v1.6.0)
+
+- **Warianty Card** przez `cva`: default, muted, highlight, success, error, warning
+- **Rozmiary Button**, w tym `xs` i `icon-sm`
+- **Narzędzia tekstowe**: `text-micro` (9px), `text-2xs` (10px) — koniec z dowolnymi wartościami Tailwind
+- **Ujednolicone Radix UI**: zmigrowano 37 plików z `@radix-ui/react-*` do `radix-ui`, usunięto 27 pakietów
+- **Zoptymalizowany bundle**: `optimizePackageImports` dla radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ Aplikacja
+
+- **Podpisane auto-aktualizacje**: aktualizacja jednym kliknięciem z aplikacji przez Tauri Updater
+- **Profile**: wiele profili użytkownika z kluczami odzyskiwania
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` przełącznik XUnity
+- **System Tray**: szybkie akcje, status Ollama na żywo, podmenu narzędzi
+- **Cross-platform**: Windows i Linux z natywnymi buildami
+- **Poprawka tray Windows**: zapobiega pętli błysków konsoli przy spawnie procesów potomnych
+
+---
+
+## 🔧 Dostawcy SI
+
+| Dostawca | Klucz API | Free Tier | Najlepszy do |
+|----------|---------|-----------|----------|
+| **Ollama** | Nie (lokalny) | ✅ Bez limitu | Prywatność, offline |
+| **LM Studio** | Nie (lokalny) | ✅ Bez limitu | Prywatność, modele GGUF |
+| **TranslateGemma** | Nie (Ollama) | ✅ Bez limitu — 55 języków, Google | **Zalecany start** |
+| **HY-MT1.5** | Nie (Ollama) | ✅ Bez limitu — ~1GB RAM, Tencent | Maszyny z małym RAM |
+| **Qwen 3** | Nie (Ollama) | ✅ Bez limitu — wielojęzyczny | Języki CJK |
+| **Gemma 4** | Nie (Ollama) | ✅ Bez limitu — 27B MoE A4B/E4B/E2B | Lokalna jakość |
+| **Gemini** | Tak | ✅ Free tier (15 RPM) | **Zalecana chmura** |
+| **DeepSeek** | Tak | ✅ $0.14/1M input | Tania chmura |
+| **Groq** | Tak | ✅ 14 400 zapytań/dzień | Szybkość |
+| **Mistral** | Tak | ✅ Free tier | Chmura UE |
+| **OpenAI** | Tak | Płatne | Jakość GPT-4o |
+| **Claude** | Tak | Płatne | Niuanse, długi kontekst |
+| **DeepL** | Tak | ✅ 500k znaków/miesiąc | Języki europejskie |
+| **MyMemory** | Nie | ✅ Bez limitu | Fallback |
+| **Lingva** | Nie | ✅ Bez limitu | Lustro Google MT |
+| **Cerebras** | Tak | ✅ Free tier | Szybkość |
+| **Together AI** | Tak | ✅ $25 darmowego kredytu | Modele otwarte |
+| **Fireworks** | Tak | ✅ Free tier | Modele otwarte |
+| **OpenRouter** | Tak | ✅ Darmowe modele | Różnorodność modeli |
+| **NLLB-200** | Tak | ✅ 200 języków | Rzadkie języki |
+| **Cohere** | Tak | ✅ Darmowy trial | RAG |
+
+**Zalecane na start**: **TranslateGemma** przez Ollama (darmowe, lokalne, 55 języków) lub **Gemini** (free tier, chmura). Mały RAM: **HY-MT1.5** (~1GB). Najlepsza jakość: **Claude 3.5** lub **GPT-4o**. Najlepsze CJK: **Qwen 3**.
+
+---
+
+## 📖 Dokumentacja
+
+### Przewodniki użytkownika (11 języków)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Dokumentacja projektu
+
+- **[CHANGELOG.md](CHANGELOG.md)** — pełna historia wersji
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — polityka wersjonowania
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — aktualna roadmapa
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — projekt architektury wtyczek
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Budowanie ze źródeł
+
+**Wymagania wstępne**: Node.js 18+, Rust 1.70+, npm. W Linuksie także: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # rozwój
+npm run tauri:build  # build produkcyjny
+```
+
+Backend Rust: `cd src-tauri && cargo check`, aby zweryfikować, że polecenia Tauri kompilują się na Twojej platformie.
+
+---
+
+## 💖 Wsparcie
+
+Jeśli GameStringer pomógł Ci grać w gry w Twoim języku:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Licencja
+
+**Source-Available License v1.1** — kod źródłowy jest publiczny i możesz go zbudować samodzielnie, ale nie jest to „Open Source" zatwierdzony przez OSI.
+
+- ✅ Darmowy do użytku osobistego
+- ✅ Swobodnie do inspekcji, budowania i modyfikowania dla siebie
+- ❌ Użytek komercyjny wymaga pisemnej zgody
+- ❌ Redystrybucja zmodyfikowanych wersji wymaga pisemnej zgody
+
+Zobacz [LICENSE](LICENSE) po szczegóły. Pytania? Otwórz [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — framework moddingowy Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — framework tłumaczeniowy Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — parser Unreal `.locres` (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — modding GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — framework aplikacji desktopowych
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — silnik OCR
+- **[Ollama](https://ollama.com)** — lokalny runtime LLM
+- **[Supabase](https://supabase.com)** — backend realtime dla Community Chat
+
+---
+
+<p align="center">
+  Stworzone z ❤️ dla graczy, którzy chcą grać w swoim własnym języku<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_PT.md
+++ b/README_PT.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Aplicativo de desktop que traduz videogames para qualquer idioma usando IA.</strong><br>
+  Escolha um jogo da sua biblioteca, selecione um idioma, clique em traduzir — pronto.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-o-que-é-o-gamestringer">O que é</a> ·
+  <a href="#-download">Download</a> ·
+  <a href="#-como-funciona">Como funciona</a> ·
+  <a href="#-o-prediction-tool-pt">P.T.</a> ·
+  <a href="#-motores-de-jogo-suportados">Motores</a> ·
+  <a href="#-recursos">Recursos</a> ·
+  <a href="#-compilar-a-partir-do-código-fonte">Build</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Leia no seu idioma:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  🇧🇷 Português ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Demo
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Biblioteca de Jogos — detecção automática de Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Tradutor IA — 20+ provedores, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Patcher de um clique — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, backup automático</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, salas personalizadas, presença online</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — ações rápidas, status do Ollama ao vivo, submenu de ferramentas</em>
+</p>
+
+---
+
+## 🎮 O que é o GameStringer?
+
+GameStringer é um **aplicativo de desktop** (Windows e Linux) que permite traduzir videogames que não têm o seu idioma.
+
+A maioria dos jogos armazena seu texto em arquivos — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTables do Unity Localization e muitos outros formatos. O GameStringer **escaneia a pasta do jogo**, encontra esses arquivos, envia o texto por um **provedor de tradução de IA** de sua escolha (OpenAI, Claude, Gemini, DeepSeek, Ollama, 20+ outros) e **aplica o texto traduzido** de volta no jogo. Um clique, sem necessidade de conhecimento técnico.
+
+Para **jogos Unity** que prendem o texto em assets compilados, o GameStringer **instala automaticamente o BepInEx + XUnity.AutoTranslator** — sem configuração manual. Para **jogos da Bethesda** (Skyrim, Fallout, Starfield), ele faz parsing nativo de BSA/BA2/ESP. Para **jogos com CRI Middleware** (Persona, Yakuza), lida com CPK/CRILAYLA/MSG/BMD. Para **Unreal Engine**, edita `.locres` diretamente.
+
+**Não é um site de tradução automática.** É um pipeline completo: **analisar com P.T. → detectar motor → extrair texto → traduzir com IA → checar qualidade → aplicar patch → jogar.**
+
+---
+
+## 📥 Download
+
+Obtenha a última versão em **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+
+| Plataforma | Arquivo | Observações |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Instalador (recomendado) |
+| **Windows** | `GameStringer-Portable.zip` | Sem instalação |
+| **Linux** | `GameStringer.AppImage` | Universal (recomendado) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Requisitos:** Windows 10+ ou Linux (Ubuntu 22.04+, Fedora 38+), 4 GB de RAM (8 GB+ para IA local), 500 MB de disco. As releases são **assinadas digitalmente** e **atualizadas automaticamente** via Tauri Updater.
+
+---
+
+## 🚀 Como funciona
+
+1. **Instale** o GameStringer e inicie
+2. **Sua biblioteca de jogos carrega automaticamente** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ jogos detectados em segundos)
+3. **Escolha um jogo** → opcionalmente execute o **P.T. (Prediction Tool)** para ver dificuldade, tempo estimado, melhor cadeia LLM
+4. Clique em **"String it!"** — o GameStringer escaneia, extrai, traduz e aplica o patch automaticamente
+5. **Jogue no seu idioma** — backups são sempre criados antes de aplicar o patch
+
+É só isso. Sem linha de comando, sem edição manual de arquivos, sem experiência em modding.
+
+---
+
+## 🧠 O Prediction Tool (P.T.)
+
+> **O recurso mais poderoso do GameStringer.** Não comece uma tradução às cegas — analise primeiro.
+
+P.T. é um motor de análise profunda que roda *antes* de qualquer tradução. Ele escaneia a pasta do jogo, detecta o motor, estima o volume de texto traduzível e diz:
+
+- **Difficulty Score 0–100** — peso combinado de volume de strings, complexidade do motor, DRM, codificação, desafios linguísticos
+- **Tempo estimado** em **18 modelos LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 cadeias LLM recomendadas**: Local (privacidade), Cloud (qualidade), Hybrid (equilibrada), Budget, Premium — cada uma com pontuação de custo e qualidade
+- **Detecção de DRM**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — avisa antes de tentar
+- **Análise de codificação**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR detectados por arquivo
+- **Complexidade de tradução**: honoríficos, concordância de gênero, RTL, ruby/furigana, tratamento específico de CJK
+- **Pontuação de confiança** e **plano de workflow** — os passos exatos que serão executados ao clicar em "String it!"
+- **Exportar relatório** (JSON + Markdown) para compartilhar ou arquivar
+
+### P.T.Rank — Ranking Rápido
+
+Após executar o P.T. em vários jogos, abra o **P.T.Rank** para ver todos os títulos analisados ordenados por dificuldade. Perfeito para planejar sua fila de tradução: comece pelos fáceis, deixe os RPGs de 800k strings para o final.
+
+### Dry Run Scanner
+
+Não quer analisar um jogo de cada vez? Execute **Dry Run** na página da Biblioteca para escanear **sua biblioteca Steam inteira (800+ jogos) em lote**, com **zero modificação de arquivos**. Você recebe um relatório JSON que categoriza cada jogo como **Ready** (motor suportado + strings extraíveis), **Errors** (problemas de manifest / bloqueio de DRM) ou **Unsupported** (motor desconhecido / sem texto). O progresso é em tempo real e nenhum backup é necessário porque nada é tocado.
+
+### String it! Smart Gate
+
+O botão **"String it!"** na página de detalhes do jogo é inteligente: se o jogo já foi analisado pelo P.T. nas últimas 24h, ele inicia o wizard de tradução diretamente. Caso contrário, sugere executar o P.T. primeiro (com escolha de um clique "Run P.T. first" / "String it! anyway"). Chega de execuções desperdiçadas em jogos que acabam sendo bloqueados por DRM ou questão de 5 minutos.
+
+---
+
+## 🎯 Motores de jogo suportados
+
+O GameStringer suporta **20+ motores** com diferentes níveis de profundidade:
+
+| Motor | Suporte | Como funciona |
+|--------|---------|--------------|
+| **Unity** | ✅ Completo | Instala automaticamente BepInEx + XUnity.AutoTranslator + pipeline Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Completo | Extração e patch de `.locres` com UnrealLocres |
+| **Unreal _P.pak** | ✅ Completo | Empacotamento de mod como `<GameStringer>_P.pak` carregado via pasta Paks |
+| **Godot** | ✅ Completo | Suporte nativo a arquivos `.translation` |
+| **RPG Maker** | ✅ Completo | MV/MZ JSON, VX/Ace via Trans, XP via RMXP |
+| **Ren'Py** | ✅ Completo | Parsing nativo de scripts `.rpy` com detecção de diálogos |
+| **GameMaker** | ⚡ Parcial | Via integração UndertaleModTool |
+| **Telltale** | ✅ Completo | Suporte `.langdb` / `.dlog` |
+| **Wolf RPG** | ✅ Completo | Integração WolfTrans |
+| **Kirikiri** | ✅ Completo | Parsing `.ks` / `.scn` |
+| **TyranoScript** | ✅ Completo | Extrator fast-path com patch JSON |
+| **Electron** | ✅ Completo | Desempacotamento ASAR + detecção de JSON i18n |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Parser BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD com autodetecção de Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Completo | Aventuras Daedalic (Deponia, Edna, etc.) |
+| **Danganronpa WAD** | ✅ Completo | Parser de arquivo WAD + patch de diálogos STX |
+
+> **Jogos Unity** recebem tratamento especial: se nenhum arquivo traduzível for encontrado, o GameStringer detecta que é um jogo Unity e oferece **instalar automaticamente BepInEx + XUnity.AutoTranslator** com um clique. Basta iniciar o jogo uma vez após a instalação, depois escanear novamente — todo o texto se torna traduzível.
+>
+> ⚠️ **Aviso Anti-Cheat**: BepInEx (injeção de DLL) pode acionar sistemas anti-cheat (EAC, BattlEye, Vanguard). O GameStringer inclui detecção anti-cheat e irá avisá-lo. **Use apenas em jogos single-player / offline.** O P.T. detecta DRM antes de qualquer modificação.
+
+---
+
+## ✨ Recursos
+
+### 🤖 Tradução por IA
+
+- **20+ provedores**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (local), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: entende o gênero do jogo, a voz do personagem, o tom, narrativa vs UI vs diálogo
+- **Translation Memory e Glossário**: consistência em todo o projeto com extração automática de glossário
+- **Multi-LLM Compare**: executa múltiplos provedores em paralelo, escolha o melhor resultado por string
+- **Quality gates**: pontuação QA automática em cada string traduzida (0-100) com ContentTypeBadge
+- **Vision LLM Translator**: usa capturas de tela in-game para contexto (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: veja pontuações de qualidade em tempo real durante a tradução em lote
+- **Suporte RTL**: detecção automática de direção e manipulação do atributo `dir`
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** com fatores ponderados (volume, motor, DRM, codificação, complexidade)
+- **Estimativas de tempo para 18 modelos LLM** incluindo Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 cadeias LLM** (Local / Cloud / Hybrid / Budget / Premium) com estimativas de custo e qualidade
+- **Detecção DRM / Anti-Cheat** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Análise de codificação** por arquivo (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Análise de complexidade de tradução** (honoríficos, gênero, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — ordena todos os jogos analisados por dificuldade
+- **Dry Run Scanner** — scan em lote da biblioteca Steam inteira (800+ jogos) sem modificação
+- **Workflow Orchestrator** — motor de execução real com fast path universal para 6+ motores e progresso em tempo real
+- **Cache de predição** (24h) — reabertura instantânea de jogos já analisados
+- **Exportar relatório** (JSON + Markdown) para compartilhar e arquivar
+
+### 📚 Biblioteca de Jogos
+
+- **Auto-detect**: Steam (com Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ jogos** reconhecidos das bibliotecas instaladas em segundos
+- **Cards de jogos** com capas, metadados, badge do motor, badge VR, status de instalação
+- **Ações rápidas ao passar o mouse**: String it!, Batch, Community, P.T. — todas com um clique
+- **Game Update Tracker**: detecta quando a Steam atualiza um jogo traduzido (via `buildid`), verifica a integridade do patch (arquivos BepInEx, presença de `_P.pak`), avisa se é necessário reaplicar o patch
+- Botão **"Stop monitoring"** para parar de monitorar um jogo específico
+
+### 🔧 Ferramentas de Tradução
+
+- **One-Click Translate** ("String it!"): escanear → traduzir → aplicar patch em um único fluxo
+- **Batch Translation**: traduza jogos ou pastas inteiras de uma vez
+- **Tradutor de Legendas**: SRT, VTT, ASS/SSA com preservação do timing
+- **OCR Translator**: extrai texto de jogos retrô (presets 8-bit, 16-bit, DOS) com backend real Tauri Tesseract
+- **Voice Pipeline**: speech-to-text → traduzir → text-to-speech
+- **Overlay em tempo real**: veja as traduções enquanto joga via VR/screen overlay
+- **Auto-Translate Review**: botão "Translate all untranslated" com barra de progresso
+- **Lore Assistant**: chat RAG que conhece o lore e os diálogos do jogo
+- **Character Voice Profiles**: defina personalidade, tom, padrões de fala por personagem
+- **Translation Confidence Heatmap**: visão geral visual da qualidade de todas as traduções
+
+### 🎮 Patchers de Motores de Jogo
+
+- **Unity**: auto-instalador BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, catálogo Addressables, validador Smart Strings)
+- **Unreal Engine**: extração `.locres` + empacotamento de mod `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — todos com parsers nativos
+- **Wizard Stepper**: UI multi-step compartilhada para todos os patchers
+- **Universal PO Export** (gettext `.po`) para cada patcher com metadados de projeto/idioma/fonte/motor
+- **Backup automático**: antes de cada patch, com restauração em um clique
+
+### 🔌 Avançado
+
+- **Auto-Hook Scanner**: escaneamento de memória de processo (Windows WinAPI) para strings hardcoded
+- **System Monitor**: uso VRAM/RAM em tempo real para planejamento de LLM local
+- **Ollama Setup Wizard**: instalação passo a passo de IA local
+- **Ollama Manager**: auto-discovery de modelos do registro ollama.com + auto-refresh em foco/navegação
+- **Debug Console**: console integrado com log intercept
+- **Plugin System**: doc de design para plugins de terceiros (veja `PLUGIN_SYSTEM.md`)
+- **Community Hub**: compartilhe e baixe translation memories + integração com GitHub Discussions
+- **Public API v1**: endpoints REST para integração (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Chat em tempo real** com outros tradutores via Supabase Realtime
+- **4 salas padrão**: General, Translations, Feedback & Bugs, Announcements
+- **Salas personalizadas**: crie salas para jogos ou projetos específicos
+- **Auto-Bridge Auth**: seu perfil do GameStringer sincroniza automaticamente com o Supabase — sem login extra
+- **Presença online**: veja quem está online em cada sala
+- **Responder / editar / excluir** mensagens com ownership aplicada via RLS
+- **Widget drawer expansível** no canto inferior direito
+
+### ♿ Acessibilidade (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` em botões de ícone, headings semânticos `CardTitle`, `focus-visible` em todas as primitivas, link skip-to-content, landmark `main`, helpers `sr-only` em italiano
+- **`prefers-reduced-motion`** respeitado em todas as animações
+- **`forced-colors`** (Modo de Alto Contraste do Windows) respeitado
+- **UI em 11 idiomas**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **Suporte a layout RTL** com detecção automática de direção
+
+### 🎨 Design System (v1.6.0)
+
+- **Variantes de Card** via `cva`: default, muted, highlight, success, error, warning
+- **Tamanhos de Button** incluindo `xs` e `icon-sm`
+- **Utilitários de texto**: `text-micro` (9px), `text-2xs` (10px) — acabou o Tailwind arbitrário
+- **Radix UI unificado**: migrados 37 arquivos de `@radix-ui/react-*` para `radix-ui`, 27 pacotes removidos
+- **Bundle otimizado**: `optimizePackageImports` para radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ App
+
+- **Auto-atualizações assinadas**: atualização em um clique dentro do app via Tauri Updater
+- **Perfis**: múltiplos perfis de usuário com chaves de recuperação
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` toggle XUnity
+- **System Tray**: ações rápidas, status do Ollama ao vivo, submenu de ferramentas
+- **Cross-platform**: Windows e Linux com builds nativos
+- **Correção de tray Windows**: previne loop de flash de console no spawn de processos filhos
+
+---
+
+## 🔧 Provedores de IA
+
+| Provedor | API Key | Free Tier | Melhor para |
+|----------|---------|-----------|----------|
+| **Ollama** | Não (local) | ✅ Ilimitado | Privacidade, offline |
+| **LM Studio** | Não (local) | ✅ Ilimitado | Privacidade, modelos GGUF |
+| **TranslateGemma** | Não (Ollama) | ✅ Ilimitado — 55 idiomas, Google | **Início recomendado** |
+| **HY-MT1.5** | Não (Ollama) | ✅ Ilimitado — ~1GB RAM, Tencent | Máquinas com pouca RAM |
+| **Qwen 3** | Não (Ollama) | ✅ Ilimitado — multilíngue | Idiomas CJK |
+| **Gemma 4** | Não (Ollama) | ✅ Ilimitado — 27B MoE A4B/E4B/E2B | Qualidade local |
+| **Gemini** | Sim | ✅ Free tier (15 RPM) | **Cloud recomendada** |
+| **DeepSeek** | Sim | ✅ $0.14/1M input | Cloud barata |
+| **Groq** | Sim | ✅ 14.400 req/dia | Velocidade |
+| **Mistral** | Sim | ✅ Free tier | Cloud da UE |
+| **OpenAI** | Sim | Pago | Qualidade GPT-4o |
+| **Claude** | Sim | Pago | Nuance, contexto longo |
+| **DeepL** | Sim | ✅ 500k caracteres/mês | Idiomas europeus |
+| **MyMemory** | Não | ✅ Ilimitado | Fallback |
+| **Lingva** | Não | ✅ Ilimitado | Mirror do Google MT |
+| **Cerebras** | Sim | ✅ Free tier | Velocidade |
+| **Together AI** | Sim | ✅ $25 de crédito grátis | Modelos abertos |
+| **Fireworks** | Sim | ✅ Free tier | Modelos abertos |
+| **OpenRouter** | Sim | ✅ Modelos grátis | Variedade de modelos |
+| **NLLB-200** | Sim | ✅ 200 idiomas | Idiomas raros |
+| **Cohere** | Sim | ✅ Teste grátis | RAG |
+
+**Recomendados para começar**: **TranslateGemma** via Ollama (grátis, local, 55 idiomas) ou **Gemini** (free tier, cloud). Pouca RAM: **HY-MT1.5** (~1GB). Melhor qualidade: **Claude 3.5** ou **GPT-4o**. Melhor CJK: **Qwen 3**.
+
+---
+
+## 📖 Documentação
+
+### Guias do Usuário (11 idiomas)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Documentação do Projeto
+
+- **[CHANGELOG.md](CHANGELOG.md)** — histórico completo de versões
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — política de versionamento
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — roadmap atual
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — design da arquitetura de plugins
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Compilar a partir do código-fonte
+
+**Pré-requisitos**: Node.js 18+, Rust 1.70+, npm. No Linux também: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # desenvolvimento
+npm run tauri:build  # build de produção
+```
+
+Backend Rust: `cd src-tauri && cargo check` para verificar que os comandos Tauri compilam na sua plataforma.
+
+---
+
+## 💖 Apoio
+
+Se o GameStringer te ajudou a jogar no seu idioma:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Licença
+
+**Source-Available License v1.1** — o código-fonte é público e você pode compilá-lo por conta própria, mas não é "Open Source" aprovado pela OSI.
+
+- ✅ Grátis para uso pessoal
+- ✅ Livre para inspecionar, compilar e modificar para si mesmo
+- ❌ Uso comercial requer permissão por escrito
+- ❌ Redistribuição de versões modificadas requer permissão por escrito
+
+Veja [LICENSE](LICENSE) para detalhes. Dúvidas? Abra uma [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — framework de modding Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — framework de tradução Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — parser `.locres` do Unreal (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — modding GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — framework de app desktop
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — motor OCR
+- **[Ollama](https://ollama.com)** — runtime LLM local
+- **[Supabase](https://supabase.com)** — backend em tempo real para o Community Chat
+
+---
+
+<p align="center">
+  Feito com ❤️ para gamers que querem jogar no seu próprio idioma<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>Настольное приложение, которое переводит видеоигры на любой язык с помощью ИИ.</strong><br>
+  Выберите игру из вашей библиотеки, выберите язык, нажмите «перевести» — готово.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-что-такое-gamestringer">Что это</a> ·
+  <a href="#-загрузка">Загрузка</a> ·
+  <a href="#-как-это-работает">Как это работает</a> ·
+  <a href="#-prediction-tool-pt">P.T.</a> ·
+  <a href="#-поддерживаемые-игровые-движки">Движки</a> ·
+  <a href="#-возможности">Возможности</a> ·
+  <a href="#-сборка-из-исходников">Сборка</a>
+</p>
+
+<p align="center">
+  <strong>🌍 Читать на вашем языке:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  <a href="README_ZH.md">🇨🇳 中文</a> ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  🇷🇺 Русский ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## Демо
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 Библиотека игр — автоматическое обнаружение Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 Переводчик ИИ — 20+ провайдеров, Quality Badges 0-100, Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 Патчер в один клик — BepInEx, XUnity, UnrealLocres, Bethesda BSA/BA2, CRI CPK, автоматическое резервное копирование</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime, пользовательские комнаты, онлайн-присутствие</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — быстрые действия, статус Ollama в реальном времени, подменю инструментов</em>
+</p>
+
+---
+
+## 🎮 Что такое GameStringer?
+
+GameStringer — это **настольное приложение** (Windows и Linux), которое позволяет переводить видеоигры, не имеющие вашего языка.
+
+Большинство игр хранят свой текст в файлах — JSON, XML, CSV, `.locres`, `.rpy`, BSA/BA2, CPK, StringTables из Unity Localization и многих других форматах. GameStringer **сканирует папку игры**, находит эти файлы, отправляет текст через **провайдера ИИ-перевода** на ваш выбор (OpenAI, Claude, Gemini, DeepSeek, Ollama и 20+ других) и **применяет патч с переведённым текстом** к игре. Один клик, никаких технических знаний не требуется.
+
+Для **игр на Unity**, которые прячут текст внутри скомпилированных ассетов, GameStringer **автоматически устанавливает BepInEx + XUnity.AutoTranslator** — без ручной настройки. Для **игр Bethesda** (Skyrim, Fallout, Starfield) он нативно парсит BSA/BA2/ESP. Для **игр на CRI Middleware** (Persona, Yakuza) он обрабатывает CPK/CRILAYLA/MSG/BMD. Для **Unreal Engine** он редактирует `.locres` напрямую.
+
+**Это не сайт машинного перевода.** Это полный конвейер: **анализ с P.T. → определение движка → извлечение текста → перевод с ИИ → проверка качества → патч обратно → играйте.**
+
+---
+
+## 📥 Загрузка
+
+Получите последнюю версию из **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)**:
+
+| Платформа | Файл | Примечания |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | Установщик (рекомендуется) |
+| **Windows** | `GameStringer-Portable.zip` | Без установки |
+| **Linux** | `GameStringer.AppImage` | Универсальный (рекомендуется) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**Требования:** Windows 10+ или Linux (Ubuntu 22.04+, Fedora 38+), 4 ГБ ОЗУ (8 ГБ+ для локального ИИ), 500 МБ дискового пространства. Релизы **подписаны цифровой подписью** и **автоматически обновляются** через Tauri Updater.
+
+---
+
+## 🚀 Как это работает
+
+1. **Установите** GameStringer и запустите его
+2. **Ваша игровая библиотека загружается автоматически** — Steam, Epic, GOG, Origin, Ubisoft, Amazon, itch.io (800+ игр обнаруживаются за секунды)
+3. **Выберите игру** → при желании запустите **P.T. (Prediction Tool)**, чтобы увидеть сложность, расчётное время, лучшую LLM-цепочку
+4. Нажмите **«String it!»** — GameStringer автоматически сканирует, извлекает, переводит и применяет патч
+5. **Играйте на вашем языке** — резервные копии всегда создаются перед применением патча
+
+Вот и всё. Никакой командной строки, никакого ручного редактирования файлов, никакого опыта моддинга.
+
+---
+
+## 🧠 Prediction Tool (P.T.)
+
+> **Самая мощная функция в GameStringer.** Не начинайте перевод вслепую — сначала проанализируйте.
+
+P.T. — это движок глубокого анализа, который запускается *перед* любым переводом. Он сканирует папку игры, определяет движок, оценивает объём переводимого текста и сообщает вам:
+
+- **Difficulty Score 0–100** — комбинированный вес объёма строк, сложности движка, DRM, кодировки, языковых сложностей
+- **Расчётное время** на **18 моделях LLM** — Ollama (Gemma 4, Qwen 3, Llama), OpenAI GPT-4/4o, Claude 3.5, Gemini, DeepL, DeepSeek, Groq
+- **5 рекомендуемых LLM-цепочек**: Local (конфиденциальность), Cloud (качество), Hybrid (сбалансированная), Budget, Premium — каждая с оценкой стоимости и качества
+- **Обнаружение DRM**: Denuvo, VMProtect, Steam DRM, EAC, BattlEye — предупреждает до попытки
+- **Анализ кодировки**: Shift-JIS, UTF-8, UTF-16, Big5, EUC-KR определяются для каждого файла
+- **Сложность перевода**: формы вежливости, согласование по роду, RTL, ruby/furigana, обработка специфики CJK
+- **Оценка уверенности** и **план workflow** — точные шаги, которые будут выполнены при нажатии «String it!»
+- **Экспорт отчёта** (JSON + Markdown) для обмена или архивирования
+
+### P.T.Rank — Быстрый рейтинг
+
+После запуска P.T. на нескольких играх откройте **P.T.Rank**, чтобы увидеть все проанализированные тайтлы, отсортированные по сложности. Идеально для планирования очереди перевода: начните с лёгких побед, оставьте RPG на 800 000 строк напоследок.
+
+### Dry Run Scanner
+
+Не хотите анализировать игры по одной? Запустите **Dry Run** со страницы Библиотеки, чтобы сканировать **всю библиотеку Steam (800+ игр) пакетно**, с **нулевыми изменениями файлов**. Вы получите JSON-отчёт, категоризирующий каждую игру как **Ready** (движок поддерживается + строки извлекаемы), **Errors** (проблемы манифеста / блокировщик DRM) или **Unsupported** (неизвестный движок / нет текста). Прогресс в реальном времени, и резервная копия не нужна, потому что ничто не трогается.
+
+### String it! Smart Gate
+
+Кнопка **«String it!»** на странице деталей игры умная: если игра уже была проанализирована P.T. в последние 24 часа, она напрямую запускает мастер перевода. Иначе она предлагает сначала запустить P.T. (с выбором в один клик «Run P.T. first» / «String it! anyway»). Больше никаких потраченных впустую запусков на играх, которые оказываются заблокированы DRM или делами на 5 минут.
+
+---
+
+## 🎯 Поддерживаемые игровые движки
+
+GameStringer поддерживает **20+ движков** с различными уровнями глубины:
+
+| Движок | Поддержка | Как это работает |
+|--------|---------|--------------|
+| **Unity** | ✅ Полная | Автоматически устанавливает BepInEx + XUnity.AutoTranslator + конвейер Unity Localization Package (StringTable, SharedTableData, Addressables, Smart Strings) |
+| **Unreal Engine** | ✅ Полная | Извлечение и патчинг `.locres` с UnrealLocres |
+| **Unreal _P.pak** | ✅ Полная | Упаковка мода как `<GameStringer>_P.pak`, загружаемого через папку Paks |
+| **Godot** | ✅ Полная | Нативная поддержка файлов `.translation` |
+| **RPG Maker** | ✅ Полная | MV/MZ JSON, VX/Ace через Trans, XP через RMXP |
+| **Ren'Py** | ✅ Полная | Нативный парсинг скриптов `.rpy` с обнаружением диалогов |
+| **GameMaker** | ⚡ Частичная | Через интеграцию UndertaleModTool |
+| **Telltale** | ✅ Полная | Поддержка `.langdb` / `.dlog` |
+| **Wolf RPG** | ✅ Полная | Интеграция WolfTrans |
+| **Kirikiri** | ✅ Полная | Парсинг `.ks` / `.scn` |
+| **TyranoScript** | ✅ Полная | Fast-path экстрактор с JSON-патчингом |
+| **Electron** | ✅ Полная | Распаковка ASAR + обнаружение JSON i18n |
+| **Bethesda (Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | Парсер BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1), STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware (Persona/Yakuza/Tales of/Dragon Ball)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD с автоопределением Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ Полная | Приключения Daedalic (Deponia, Edna и др.) |
+| **Danganronpa WAD** | ✅ Полная | Парсер архива WAD + патчинг диалогов STX |
+
+> **Игры Unity** получают особое обращение: если переводимых файлов не найдено, GameStringer определяет, что это игра Unity, и предлагает **автоматически установить BepInEx + XUnity.AutoTranslator** в один клик. Просто запустите игру один раз после установки, затем пересканируйте — весь текст становится переводимым.
+>
+> ⚠️ **Предупреждение об анти-чите**: BepInEx (инъекция DLL) может срабатывать на анти-чит системах (EAC, BattlEye, Vanguard). GameStringer включает обнаружение анти-чита и предупредит вас. **Используйте только на однопользовательских / оффлайн играх.** P.T. обнаруживает DRM перед любой модификацией.
+
+---
+
+## ✨ Возможности
+
+### 🤖 ИИ-перевод
+
+- **20+ провайдеров**: OpenAI, Claude, Gemini, DeepSeek, Mistral, Groq, DeepL, Ollama (локально), LM Studio, TranslateGemma, HY-MT, Qwen 3, NLLB-200, Cerebras, Together AI, Fireworks, OpenRouter, Cohere, Lingva, MyMemory
+- **Context-aware**: понимает жанр игры, голос персонажа, тон, повествование vs UI vs диалог
+- **Translation Memory и глоссарий**: согласованность во всём проекте с автоматическим извлечением глоссария
+- **Multi-LLM Compare**: запуск нескольких провайдеров параллельно, выбор лучшего результата для каждой строки
+- **Quality gates**: автоматическая QA-оценка для каждой переведённой строки (0-100) с ContentTypeBadge
+- **Vision LLM Translator**: использует внутриигровые скриншоты для контекста (Ollama, Gemini, GPT-4o)
+- **Live Quality Preview**: видите оценки качества в реальном времени во время пакетного перевода
+- **Поддержка RTL**: автоматическое определение направления и обработка атрибута `dir`
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100** с взвешенными факторами (объём, движок, DRM, кодировка, сложность)
+- **Оценки времени для 18 моделей LLM**, включая Gemma 4 (27B MoE A4B / E4B / E2B)
+- **5 LLM-цепочек** (Local / Cloud / Hybrid / Budget / Premium) с оценками стоимости и качества
+- **Обнаружение DRM / анти-чита** (Denuvo, VMProtect, Steam DRM, EAC, BattlEye, Vanguard)
+- **Анализ кодировки** для каждого файла (Shift-JIS, UTF-8/16, Big5, EUC-KR)
+- **Анализ сложности перевода** (формы вежливости, род, CJK, ruby, RTL)
+- **P.T.Rank / Quick Ranking** — сортирует все проанализированные игры по сложности
+- **Dry Run Scanner** — пакетное сканирование всей библиотеки Steam (800+ игр) без изменений
+- **Workflow Orchestrator** — реальный движок выполнения с универсальным fast path для 6+ движков и прогрессом в реальном времени
+- **Кэш предсказаний** (24 часа) — мгновенное повторное открытие ранее проанализированных игр
+- **Экспорт отчёта** (JSON + Markdown) для обмена и архивирования
+
+### 📚 Игровая библиотека
+
+- **Автоопределение**: Steam (с Family Sharing), Epic, GOG Galaxy, Origin/EA, Ubisoft Connect, Amazon Games, itch.io
+- **800+ игр** распознаются из установленных библиотек за секунды
+- **Карточки игр** с обложками, метаданными, бейджем движка, VR-бейджем, статусом установки
+- **Быстрые действия при наведении**: String it!, Batch, Community, P.T. — все в один клик
+- **Game Update Tracker**: обнаруживает, когда Steam обновляет переведённую игру (через `buildid`), проверяет целостность патча (файлы BepInEx, наличие `_P.pak`), предупреждает, если требуется повторное патчирование
+- Кнопка **«Stop monitoring»**, чтобы перестать отслеживать конкретную игру
+
+### 🔧 Инструменты перевода
+
+- **One-Click Translate** («String it!»): сканирование → перевод → патч в едином потоке
+- **Batch Translation**: переводите целые игры или папки сразу
+- **Переводчик субтитров**: SRT, VTT, ASS/SSA с сохранением тайминга
+- **OCR Translator**: извлекает текст из ретро-игр (пресеты 8-бит, 16-бит, DOS) с реальным бэкендом Tauri Tesseract
+- **Voice Pipeline**: speech-to-text → перевод → text-to-speech
+- **Оверлей в реальном времени**: видите переводы во время игры через VR/экранный оверлей
+- **Auto-Translate Review**: кнопка «Translate all untranslated» с индикатором прогресса
+- **Lore Assistant**: RAG-чат, который знает лор и диалоги игры
+- **Character Voice Profiles**: определяйте личность, тон, речевые шаблоны для каждого персонажа
+- **Translation Confidence Heatmap**: визуальный обзор качества всех переводов
+
+### 🎮 Патчеры игровых движков
+
+- **Unity**: автоустановщик BepInEx + XUnity.AutoTranslator, Unity Localization Package (StringTable, SharedTableData, каталог Addressables, валидатор Smart Strings)
+- **Unreal Engine**: извлечение `.locres` + упаковка мода `_P.pak`
+- **Bethesda Engine Patcher** (NEW v1.6.0): Skyrim LE/SE/AE, Fallout 3/NV/4, Oblivion, Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM (FULL/DESC/NAM1)
+- **CRI Middleware Patcher** (NEW v1.6.0): Persona 5 Royal, Yakuza, Tales of, Dragon Ball — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**, **RPG Maker**, **Godot**, **GameMaker**, **Kirikiri**, **Wolf RPG**, **Telltale**, **Visionaire**, **Danganronpa WAD** — все с нативными парсерами
+- **Wizard Stepper**: общий многошаговый UI для всех патчеров
+- **Universal PO Export** (gettext `.po`) для каждого патчера с метаданными проекта/языка/источника/движка
+- **Автоматическое резервное копирование**: перед каждым патчем, с восстановлением в один клик
+
+### 🔌 Продвинутое
+
+- **Auto-Hook Scanner**: сканирование памяти процесса (Windows WinAPI) для жёстко закодированных строк
+- **System Monitor**: использование VRAM/RAM в реальном времени для планирования локальной LLM
+- **Ollama Setup Wizard**: пошаговая установка локального ИИ
+- **Ollama Manager**: автообнаружение моделей из реестра ollama.com + автообновление при фокусе/навигации
+- **Debug Console**: интегрированная консоль с перехватом логов
+- **Plugin System**: проектный документ для сторонних плагинов (см. `PLUGIN_SYSTEM.md`)
+- **Community Hub**: делитесь и скачивайте Translation Memories + интеграция с GitHub Discussions
+- **Public API v1**: REST-эндпоинты для интеграции (`/api/v1/translate`, `/api/v1/batch`)
+
+### 💬 Community Chat
+
+- **Чат в реальном времени** с другими переводчиками через Supabase Realtime
+- **4 комнаты по умолчанию**: General, Translations, Feedback & Bugs, Announcements
+- **Пользовательские комнаты**: создавайте комнаты для конкретных игр или проектов
+- **Auto-Bridge Auth**: ваш профиль GameStringer автоматически синхронизируется с Supabase — без дополнительного входа
+- **Онлайн-присутствие**: видите, кто в сети в каждой комнате
+- **Ответ / редактирование / удаление** сообщений с ownership, обеспеченным RLS
+- **Расширяемый виджет drawer** в правом нижнем углу
+
+### ♿ Доступность (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — `aria-label` на иконочных кнопках, семантические заголовки `CardTitle`, `focus-visible` на всех примитивах, ссылка skip-to-content, landmark `main`, итальянские хелперы `sr-only`
+- **`prefers-reduced-motion`** соблюдается во всех анимациях
+- **`forced-colors`** (режим высокой контрастности Windows) соблюдается
+- **UI на 11 языках**: IT, EN, ES, FR, DE, JA, ZH, KO, PT, RU, PL
+- **Поддержка RTL-макета** с автоматическим определением направления
+
+### 🎨 Design System (v1.6.0)
+
+- **Варианты Card** через `cva`: default, muted, highlight, success, error, warning
+- **Размеры Button**, включая `xs` и `icon-sm`
+- **Текстовые утилиты**: `text-micro` (9px), `text-2xs` (10px) — больше никаких произвольных значений Tailwind
+- **Radix UI унифицирован**: 37 файлов мигрированы с `@radix-ui/react-*` на `radix-ui`, удалены 27 пакетов
+- **Оптимизированный бандл**: `optimizePackageImports` для radix-ui, framer-motion, recharts, cmdk
+
+### 🖥️ Приложение
+
+- **Подписанные автообновления**: обновление в один клик из приложения через Tauri Updater
+- **Профили**: несколько профилей пользователя с ключами восстановления
+- **Global Hotkeys**: `Ctrl+Shift+T` OCR, `Ctrl+Shift+Q` Quick Translate, `Ctrl+Alt+O` Overlay, `Alt+T` переключение XUnity
+- **System Tray**: быстрые действия, статус Ollama в реальном времени, подменю инструментов
+- **Кроссплатформенность**: Windows и Linux с нативными сборками
+- **Исправление трея Windows**: предотвращает цикл вспышек консоли при запуске дочерних процессов
+
+---
+
+## 🔧 Провайдеры ИИ
+
+| Провайдер | API-ключ | Free Tier | Лучше всего для |
+|----------|---------|-----------|----------|
+| **Ollama** | Нет (локально) | ✅ Без ограничений | Конфиденциальность, оффлайн |
+| **LM Studio** | Нет (локально) | ✅ Без ограничений | Конфиденциальность, GGUF-модели |
+| **TranslateGemma** | Нет (Ollama) | ✅ Без ограничений — 55 языков, Google | **Рекомендуемый старт** |
+| **HY-MT1.5** | Нет (Ollama) | ✅ Без ограничений — ~1 ГБ ОЗУ, Tencent | Машины с малым ОЗУ |
+| **Qwen 3** | Нет (Ollama) | ✅ Без ограничений — многоязычный | Языки CJK |
+| **Gemma 4** | Нет (Ollama) | ✅ Без ограничений — 27B MoE A4B/E4B/E2B | Локальное качество |
+| **Gemini** | Да | ✅ Free tier (15 RPM) | **Рекомендуемый облачный** |
+| **DeepSeek** | Да | ✅ $0.14/1M input | Бюджетное облако |
+| **Groq** | Да | ✅ 14 400 запросов/день | Скорость |
+| **Mistral** | Да | ✅ Free tier | Облако ЕС |
+| **OpenAI** | Да | Платный | Качество GPT-4o |
+| **Claude** | Да | Платный | Нюансы, длинный контекст |
+| **DeepL** | Да | ✅ 500k символов/месяц | Европейские языки |
+| **MyMemory** | Нет | ✅ Без ограничений | Fallback |
+| **Lingva** | Нет | ✅ Без ограничений | Зеркало Google MT |
+| **Cerebras** | Да | ✅ Free tier | Скорость |
+| **Together AI** | Да | ✅ $25 бесплатного кредита | Открытые модели |
+| **Fireworks** | Да | ✅ Free tier | Открытые модели |
+| **OpenRouter** | Да | ✅ Бесплатные модели | Разнообразие моделей |
+| **NLLB-200** | Да | ✅ 200 языков | Редкие языки |
+| **Cohere** | Да | ✅ Бесплатный пробный | RAG |
+
+**Рекомендуется для начала**: **TranslateGemma** через Ollama (бесплатно, локально, 55 языков) или **Gemini** (free tier, облако). Мало ОЗУ: **HY-MT1.5** (~1 ГБ). Лучшее качество: **Claude 3.5** или **GPT-4o**. Лучший CJK: **Qwen 3**.
+
+---
+
+## 📖 Документация
+
+### Руководства пользователя (11 языков)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### Документация проекта
+
+- **[CHANGELOG.md](CHANGELOG.md)** — полная история версий
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — политика версионирования
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — текущая дорожная карта
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — проектирование архитектуры плагинов
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ Сборка из исходников
+
+**Предварительные требования**: Node.js 18+, Rust 1.70+, npm. В Linux также: `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`.
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # разработка
+npm run tauri:build  # production-сборка
+```
+
+Rust-бэкенд: `cd src-tauri && cargo check`, чтобы проверить, что команды Tauri компилируются на вашей платформе.
+
+---
+
+## 💖 Поддержка
+
+Если GameStringer помог вам играть в игры на вашем языке:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 Лицензия
+
+**Source-Available License v1.1** — исходный код открыт, и вы можете собрать его самостоятельно, но это не «Open Source», одобренный OSI.
+
+- ✅ Бесплатно для личного использования
+- ✅ Свободно для проверки, сборки и модификации для себя
+- ❌ Коммерческое использование требует письменного разрешения
+- ❌ Распространение модифицированных версий требует письменного разрешения
+
+См. [LICENSE](LICENSE) для деталей. Вопросы? Откройте [Discussion](https://github.com/rouges78/GameStringer/discussions).
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — фреймворк моддинга Unity (BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — фреймворк перевода Unity (bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — парсер Unreal `.locres` (akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — моддинг GameMaker (krzys-h)
+- **[Tauri](https://tauri.app)** — фреймворк для настольных приложений
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCR-движок
+- **[Ollama](https://ollama.com)** — локальный LLM-runtime
+- **[Supabase](https://supabase.com)** — realtime-бэкенд для Community Chat
+
+---
+
+<p align="center">
+  Сделано с ❤️ для геймеров, которые хотят играть на своём родном языке<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,411 @@
+<p align="center">
+  <img src="public/logo.png" alt="GameStringer Logo" width="180" />
+</p>
+
+<h1 align="center">GameStringer</h1>
+
+<p align="center">
+  <strong>使用 AI 将电子游戏翻译成任何语言的桌面应用。</strong><br>
+  从您的库中选择一款游戏,选择一种语言,点击翻译 — 完成。
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
+  <img src="https://img.shields.io/badge/license-Source--Available-green" alt="License" />
+  <img src="https://img.shields.io/badge/Tauri_2-24C8DB?logo=tauri&logoColor=white" alt="Tauri" />
+  <img src="https://img.shields.io/badge/Next.js_15-black?logo=next.js" alt="Next.js" />
+  <img src="https://img.shields.io/badge/Rust-orange?logo=rust&logoColor=white" alt="Rust" />
+</p>
+
+<p align="center">
+  <a href="#-什么是-gamestringer">什么是 GameStringer</a> ·
+  <a href="#-下载">下载</a> ·
+  <a href="#-工作原理">工作原理</a> ·
+  <a href="#-prediction-tool-pt">P.T.</a> ·
+  <a href="#-支持的游戏引擎">引擎</a> ·
+  <a href="#-功能">功能</a> ·
+  <a href="#-从源码构建">构建</a>
+</p>
+
+<p align="center">
+  <strong>🌍 用您的语言阅读:</strong><br>
+  <a href="README.md">🇬🇧 English</a> ·
+  <a href="README_IT.md">🇮🇹 Italiano</a> ·
+  <a href="README_ES.md">🇪🇸 Español</a> ·
+  <a href="README_FR.md">🇫🇷 Français</a> ·
+  <a href="README_DE.md">🇩🇪 Deutsch</a> ·
+  <a href="README_PT.md">🇧🇷 Português</a> ·
+  <a href="README_JA.md">🇯🇵 日本語</a> ·
+  🇨🇳 中文 ·
+  <a href="README_KO.md">🇰🇷 한국어</a> ·
+  <a href="README_RU.md">🇷🇺 Русский</a> ·
+  <a href="README_PL.md">🇵🇱 Polski</a>
+</p>
+
+---
+
+## 演示
+
+<p align="center">
+  <img src="docs/demo/demo-library.gif" alt="GameStringer Library Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🎮 游戏库 — 自动检测 Steam、Epic、GOG、Origin、Ubisoft、Amazon、itch.io</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-translator.gif" alt="GameStringer AI Translator Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🤖 AI 翻译器 — 20+ 提供商、Quality Badges 0-100、Translation Memory</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-patcher.gif" alt="GameStringer Game Patcher Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>🔧 一键补丁器 — BepInEx、XUnity、UnrealLocres、Bethesda BSA/BA2、CRI CPK、自动备份</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-chat.gif" alt="GameStringer Community Chat Demo" width="720" />
+</p>
+
+<p align="center">
+  <em>💬 Community Chat — Supabase Realtime、自定义房间、在线状态</em>
+</p>
+
+<p align="center">
+  <img src="docs/demo/demo-tray.gif" alt="GameStringer Tray Icon Demo" width="480" />
+</p>
+
+<p align="center">
+  <em>🖥️ System Tray — 快捷操作、实时 Ollama 状态、工具子菜单</em>
+</p>
+
+---
+
+## 🎮 什么是 GameStringer?
+
+GameStringer 是一款**桌面应用程序**(Windows 和 Linux),可让您翻译没有您所用语言的电子游戏。
+
+大多数游戏将文本存储在文件中 — JSON、XML、CSV、`.locres`、`.rpy`、BSA/BA2、CPK、Unity Localization StringTable 以及许多其他格式。GameStringer **扫描您的游戏文件夹**,找到这些文件,将文本通过您选择的 **AI 翻译提供商**发送(OpenAI、Claude、Gemini、DeepSeek、Ollama 以及 20+ 其他),并将**翻译后的文本打补丁**回游戏。一键操作,无需技术知识。
+
+对于在编译资源中锁定文本的 **Unity 游戏**,GameStringer **自动安装 BepInEx + XUnity.AutoTranslator** — 无需手动设置。对于 **Bethesda 游戏**(上古卷轴、辐射、星空),它原生解析 BSA/BA2/ESP。对于 **CRI Middleware 游戏**(女神异闻录、如龙),它处理 CPK/CRILAYLA/MSG/BMD。对于 **Unreal Engine**,它直接编辑 `.locres`。
+
+**这不是一个机器翻译网站。** 这是一个完整的流水线:**使用 P.T. 分析 → 检测引擎 → 提取文本 → 使用 AI 翻译 → 质量检查 → 打补丁回去 → 畅玩。**
+
+---
+
+## 📥 下载
+
+从 **[GitHub Releases](https://github.com/rouges78/GameStringer/releases)** 获取最新版本:
+
+| 平台 | 文件 | 说明 |
+|----------|------|-------|
+| **Windows** | `GameStringer-Setup.exe` | 安装程序(推荐) |
+| **Windows** | `GameStringer-Portable.zip` | 免安装 |
+| **Linux** | `GameStringer.AppImage` | 通用(推荐) |
+| **Linux** | `GameStringer.deb` | Debian / Ubuntu |
+
+**要求:** Windows 10+ 或 Linux(Ubuntu 22.04+, Fedora 38+),4 GB 内存(本地 AI 需 8 GB+),500 MB 磁盘空间。版本经过**代码签名**并通过 Tauri Updater **自动更新**。
+
+---
+
+## 🚀 工作原理
+
+1. **安装** GameStringer 并启动
+2. **您的游戏库自动加载** — Steam、Epic、GOG、Origin、Ubisoft、Amazon、itch.io(秒级检测 800+ 游戏)
+3. **选择一款游戏** → 可选择运行 **P.T.(Prediction Tool)** 查看难度、预计时间、最佳 LLM 链
+4. 点击 **"String it!"** — GameStringer 自动扫描、提取、翻译和打补丁
+5. **用您的语言畅玩** — 打补丁前始终创建备份
+
+就是这样。无需命令行,无需手动编辑文件,无需 modding 经验。
+
+---
+
+## 🧠 Prediction Tool (P.T.)
+
+> **GameStringer 中最强大的功能。** 不要盲目开始翻译 — 先分析。
+
+P.T. 是一个在任何翻译*之前*运行的深度分析引擎。它扫描您的游戏文件夹,检测引擎,估算可翻译文本的量,并告诉您:
+
+- **Difficulty Score 0–100** — 字符串量、引擎复杂度、DRM、编码、语言挑战的综合权重
+- **预计时间**覆盖 **18 个 LLM 模型** — Ollama(Gemma 4、Qwen 3、Llama)、OpenAI GPT-4/4o、Claude 3.5、Gemini、DeepL、DeepSeek、Groq
+- **5 个推荐的 LLM 链**:Local(隐私)、Cloud(质量)、Hybrid(平衡)、Budget、Premium — 每个都有成本和质量评分
+- **DRM 检测**:Denuvo、VMProtect、Steam DRM、EAC、BattlEye — 在尝试前警告
+- **编码分析**:逐文件检测 Shift-JIS、UTF-8、UTF-16、Big5、EUC-KR
+- **翻译复杂度**:敬语、性别一致、RTL、注音/振假名、CJK 特定处理
+- **置信度评分**和**工作流计划** — 点击 "String it!" 时将运行的确切步骤
+- **导出报告**(JSON + Markdown)用于共享或存档
+
+### P.T.Rank — 快速排行
+
+在多款游戏上运行 P.T. 后,打开 **P.T.Rank** 可查看按难度排序的所有已分析标题。非常适合规划您的翻译队列:从轻松的开始,把 80 万字符串的 RPG 留到最后。
+
+### Dry Run Scanner
+
+不想一次分析一款游戏?从库页面运行 **Dry Run** 可批量扫描**整个 Steam 库(800+ 游戏)**,**零文件修改**。您将获得一个 JSON 报告,将每款游戏分类为 **Ready**(引擎支持 + 可提取字符串)、**Errors**(manifest 问题 / DRM 阻塞)或 **Unsupported**(未知引擎 / 无文本)。进度为实时的,且无需备份,因为未触及任何内容。
+
+### String it! Smart Gate
+
+游戏详情页上的 **"String it!"** 按钮很智能:如果游戏在过去 24 小时内已经由 P.T. 分析,它会直接启动翻译向导。否则它会建议先运行 P.T.(一键选择 "Run P.T. first" / "String it! anyway")。不再在 DRM 锁定或 5 分钟就能解决的游戏上浪费运行。
+
+---
+
+## 🎯 支持的游戏引擎
+
+GameStringer 支持具有不同深度级别的 **20+ 引擎**:
+
+| 引擎 | 支持 | 工作原理 |
+|--------|---------|--------------|
+| **Unity** | ✅ 完整 | 自动安装 BepInEx + XUnity.AutoTranslator + Unity Localization Package 流水线(StringTable、SharedTableData、Addressables、Smart Strings) |
+| **Unreal Engine** | ✅ 完整 | 使用 UnrealLocres 提取和修补 `.locres` |
+| **Unreal _P.pak** | ✅ 完整 | 将 Mod 打包为 `<GameStringer>_P.pak`,通过 Paks 文件夹加载 |
+| **Godot** | ✅ 完整 | 原生 `.translation` 文件支持 |
+| **RPG Maker** | ✅ 完整 | MV/MZ JSON,通过 Trans 的 VX/Ace,通过 RMXP 的 XP |
+| **Ren'Py** | ✅ 完整 | 带对话检测的原生 `.rpy` 脚本解析 |
+| **GameMaker** | ⚡ 部分 | 通过 UndertaleModTool 集成 |
+| **Telltale** | ✅ 完整 | `.langdb` / `.dlog` 支持 |
+| **Wolf RPG** | ✅ 完整 | WolfTrans 集成 |
+| **Kirikiri** | ✅ 完整 | `.ks` / `.scn` 解析 |
+| **TyranoScript** | ✅ 完整 | 带 JSON 修补的 fast-path 提取器 |
+| **Electron** | ✅ 完整 | ASAR 解包 + i18n JSON 检测 |
+| **Bethesda(Skyrim/Fallout/Oblivion/Starfield)** | ✅ **NEW v1.6.0** | BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM(FULL/DESC/NAM1)解析器,STRINGS/DLSTRINGS/ILSTRINGS |
+| **CRI Middleware(女神异闻录/如龙/传说系列/龙珠)** | ✅ **NEW v1.6.0** | CPK + CRILAYLA + MSG/BMD/FTD,自动检测 Shift-JIS/UTF-8/UTF-16 |
+| **Visionaire Studio** | ✅ 完整 | Daedalic 冒险游戏(Deponia、Edna 等) |
+| **Danganronpa WAD** | ✅ 完整 | WAD 存档解析器 + STX 对话修补 |
+
+> **Unity 游戏**受到特殊处理:如果没有找到可翻译文件,GameStringer 会检测到这是一款 Unity 游戏,并提供一键**自动安装 BepInEx + XUnity.AutoTranslator**。安装后只需启动游戏一次,然后重新扫描 — 所有文本都可翻译。
+>
+> ⚠️ **反作弊警告**:BepInEx(DLL 注入)可能触发反作弊系统(EAC、BattlEye、Vanguard)。GameStringer 包含反作弊检测并会警告您。**仅用于单人 / 离线游戏。** P.T. 在任何修改之前检测 DRM。
+
+---
+
+## ✨ 功能
+
+### 🤖 AI 翻译
+
+- **20+ 提供商**:OpenAI、Claude、Gemini、DeepSeek、Mistral、Groq、DeepL、Ollama(本地)、LM Studio、TranslateGemma、HY-MT、Qwen 3、NLLB-200、Cerebras、Together AI、Fireworks、OpenRouter、Cohere、Lingva、MyMemory
+- **Context-aware**:理解游戏类型、角色声音、语调、叙事 vs UI vs 对话
+- **Translation Memory 和术语表**:整个项目的一致性,自动术语表提取
+- **Multi-LLM Compare**:并行运行多个提供商,为每个字符串选择最佳结果
+- **Quality gates**:对每个翻译字符串的自动 QA 评分(0-100),带 ContentTypeBadge
+- **Vision LLM Translator**:使用游戏内截图作为上下文(Ollama、Gemini、GPT-4o)
+- **Live Quality Preview**:在批量翻译期间实时查看质量评分
+- **RTL 支持**:自动方向检测和 `dir` 属性处理
+
+### 🧠 P.T. — Prediction Tool (v1.6.0)
+
+- **Difficulty Score 0-100**,带加权因素(量、引擎、DRM、编码、复杂度)
+- **18 个 LLM 模型的时间估计**,包括 Gemma 4(27B MoE A4B / E4B / E2B)
+- **5 个 LLM 链**(Local / Cloud / Hybrid / Budget / Premium),带成本和质量估计
+- **DRM / 反作弊检测**(Denuvo、VMProtect、Steam DRM、EAC、BattlEye、Vanguard)
+- 逐文件**编码分析**(Shift-JIS、UTF-8/16、Big5、EUC-KR)
+- **翻译复杂度分析**(敬语、性别、CJK、注音、RTL)
+- **P.T.Rank / Quick Ranking** — 按难度对所有已分析游戏排序
+- **Dry Run Scanner** — 整个 Steam 库(800+ 游戏)的批量扫描,无修改
+- **Workflow Orchestrator** — 实际执行引擎,具有 6+ 引擎的通用 fast path 和实时进度
+- **预测缓存**(24 小时) — 立即重新打开之前分析过的游戏
+- **导出报告**(JSON + Markdown)用于共享和存档
+
+### 📚 游戏库
+
+- **自动检测**:Steam(带 Family Sharing)、Epic、GOG Galaxy、Origin/EA、Ubisoft Connect、Amazon Games、itch.io
+- 秒级从已安装库识别 **800+ 游戏**
+- 带封面艺术、元数据、引擎徽章、VR 徽章、安装状态的**游戏卡片**
+- **悬停快捷操作**:String it!、Batch、Community、P.T. — 全部一键
+- **Game Update Tracker**:检测 Steam 何时更新了已翻译的游戏(通过 `buildid`),验证补丁完整性(BepInEx 文件、`_P.pak` 存在),如果需要重新打补丁则警告
+- **"Stop monitoring"** 按钮以取消跟踪特定游戏
+
+### 🔧 翻译工具
+
+- **One-Click Translate**("String it!"):扫描 → 翻译 → 打补丁,单一流程
+- **Batch Translation**:一次翻译整个游戏或文件夹
+- **字幕翻译器**:SRT、VTT、ASS/SSA,保留时间
+- **OCR Translator**:使用真实 Tauri Tesseract 后端从复古游戏(8-bit、16-bit、DOS 预设)提取文本
+- **Voice Pipeline**:speech-to-text → 翻译 → text-to-speech
+- **实时叠加**:通过 VR/屏幕叠加在玩游戏时查看翻译
+- **Auto-Translate Review**:带进度条的 "Translate all untranslated" 按钮
+- **Lore Assistant**:了解游戏背景和对话的 RAG 聊天
+- **Character Voice Profiles**:为每个角色定义个性、语调、说话模式
+- **Translation Confidence Heatmap**:所有翻译质量的可视化概览
+
+### 🎮 游戏引擎补丁器
+
+- **Unity**:BepInEx + XUnity.AutoTranslator 自动安装程序,Unity Localization Package(StringTable、SharedTableData、Addressables 目录、Smart Strings 验证器)
+- **Unreal Engine**:`.locres` 提取 + `_P.pak` Mod 打包
+- **Bethesda Engine Patcher**(NEW v1.6.0):Skyrim LE/SE/AE、Fallout 3/NV/4、Oblivion、Starfield — BSA v103-105 + BA2 GNRL/DX10 + ESP/ESM(FULL/DESC/NAM1)
+- **CRI Middleware Patcher**(NEW v1.6.0):女神异闻录 5 Royal、如龙、传说系列、龙珠 — CPK + CRILAYLA + MSG/BMD/FTD
+- **Ren'Py**、**RPG Maker**、**Godot**、**GameMaker**、**Kirikiri**、**Wolf RPG**、**Telltale**、**Visionaire**、**Danganronpa WAD** — 全部带原生解析器
+- **Wizard Stepper**:所有补丁器的共享多步 UI
+- 每个补丁器的 **Universal PO Export**(gettext `.po`),带项目/语言/源/引擎元数据
+- **自动备份**:在每次打补丁之前,带一键恢复
+
+### 🔌 高级
+
+- **Auto-Hook Scanner**:硬编码字符串的进程内存扫描(Windows WinAPI)
+- **System Monitor**:本地 LLM 规划的实时 VRAM/RAM 使用
+- **Ollama Setup Wizard**:本地 AI 的分步安装
+- **Ollama Manager**:从 ollama.com 注册表自动发现模型 + 焦点/导航时自动刷新
+- **Debug Console**:带日志拦截的集成控制台
+- **Plugin System**:第三方插件的设计文档(请参阅 `PLUGIN_SYSTEM.md`)
+- **Community Hub**:共享和下载 Translation Memories + GitHub Discussions 集成
+- **Public API v1**:用于集成的 REST 端点(`/api/v1/translate`、`/api/v1/batch`)
+
+### 💬 Community Chat
+
+- 通过 Supabase Realtime 与其他翻译者进行**实时聊天**
+- **4 个默认房间**:General、Translations、Feedback & Bugs、Announcements
+- **自定义房间**:为特定游戏或项目创建房间
+- **Auto-Bridge Auth**:您的 GameStringer 配置文件自动同步到 Supabase — 无需额外登录
+- **在线状态**:查看每个房间中谁在线
+- 带 RLS 强制所有权的**回复 / 编辑 / 删除**消息
+- 右下角的**可展开抽屉小部件**
+
+### ♿ 无障碍 (v1.6.0)
+
+- **WCAG 2.1 AA sweep** — 图标按钮上的 `aria-label`、语义 `CardTitle` 标题、所有原语上的 `focus-visible`、skip-to-content 链接、`main` 地标、意大利语 `sr-only` 助手
+- 所有动画中尊重 **`prefers-reduced-motion`**
+- 尊重 **`forced-colors`**(Windows 高对比度模式)
+- **11 种语言 UI**:IT、EN、ES、FR、DE、JA、ZH、KO、PT、RU、PL
+- 带自动方向检测的 **RTL 布局支持**
+
+### 🎨 Design System (v1.6.0)
+
+- 通过 `cva` 的 **Card 变体**:default、muted、highlight、success、error、warning
+- 包括 `xs` 和 `icon-sm` 的 **Button 尺寸**
+- **文本工具**:`text-micro`(9px)、`text-2xs`(10px) — 不再有任意的 Tailwind
+- **Radix UI 统一**:将 37 个文件从 `@radix-ui/react-*` 迁移到 `radix-ui`,删除了 27 个包
+- **优化包**:radix-ui、framer-motion、recharts、cmdk 的 `optimizePackageImports`
+
+### 🖥️ 应用
+
+- **签名自动更新**:通过 Tauri Updater 从应用中一键更新
+- **配置文件**:带恢复密钥的多个用户配置文件
+- **Global Hotkeys**:`Ctrl+Shift+T` OCR、`Ctrl+Shift+Q` Quick Translate、`Ctrl+Alt+O` Overlay、`Alt+T` XUnity 切换
+- **System Tray**:快捷操作、实时 Ollama 状态、工具子菜单
+- **跨平台**:带原生构建的 Windows 和 Linux
+- **Windows tray 修复**:防止子进程生成时的控制台闪烁循环
+
+---
+
+## 🔧 AI 提供商
+
+| 提供商 | API Key | Free Tier | 最适合 |
+|----------|---------|-----------|----------|
+| **Ollama** | 否(本地) | ✅ 无限 | 隐私、离线 |
+| **LM Studio** | 否(本地) | ✅ 无限 | 隐私、GGUF 模型 |
+| **TranslateGemma** | 否(Ollama) | ✅ 无限 — 55 种语言,Google | **推荐起点** |
+| **HY-MT1.5** | 否(Ollama) | ✅ 无限 — 约 1GB RAM,腾讯 | 低 RAM 机器 |
+| **Qwen 3** | 否(Ollama) | ✅ 无限 — 多语言 | CJK 语言 |
+| **Gemma 4** | 否(Ollama) | ✅ 无限 — 27B MoE A4B/E4B/E2B | 本地质量 |
+| **Gemini** | 是 | ✅ 免费层(15 RPM) | **推荐云端** |
+| **DeepSeek** | 是 | ✅ $0.14/1M input | 经济云端 |
+| **Groq** | 是 | ✅ 14,400 请求/天 | 速度 |
+| **Mistral** | 是 | ✅ 免费层 | 欧盟云端 |
+| **OpenAI** | 是 | 付费 | GPT-4o 质量 |
+| **Claude** | 是 | 付费 | 细微差别、长上下文 |
+| **DeepL** | 是 | ✅ 500k 字符/月 | 欧洲语言 |
+| **MyMemory** | 否 | ✅ 无限 | 回退 |
+| **Lingva** | 否 | ✅ 无限 | Google MT 镜像 |
+| **Cerebras** | 是 | ✅ 免费层 | 速度 |
+| **Together AI** | 是 | ✅ $25 免费额度 | 开放模型 |
+| **Fireworks** | 是 | ✅ 免费层 | 开放模型 |
+| **OpenRouter** | 是 | ✅ 免费模型 | 模型多样性 |
+| **NLLB-200** | 是 | ✅ 200 种语言 | 稀有语言 |
+| **Cohere** | 是 | ✅ 免费试用 | RAG |
+
+**推荐起点**:通过 Ollama 的 **TranslateGemma**(免费、本地、55 种语言)或 **Gemini**(免费层、云端)。低 RAM:**HY-MT1.5**(约 1GB)。最佳质量:**Claude 3.5** 或 **GPT-4o**。最佳 CJK:**Qwen 3**。
+
+---
+
+## 📖 文档
+
+### 用户指南(11 种语言)
+
+| | | |
+|---|---|---|
+| 🇮🇹 [Italiano](docs/GUIDA_UTENTE.md) | 🇬🇧 [English](docs/USER_GUIDE_EN.md) | 🇪🇸 [Español](docs/USER_GUIDE_ES.md) |
+| 🇫🇷 [Français](docs/USER_GUIDE_FR.md) | 🇩🇪 [Deutsch](docs/USER_GUIDE_DE.md) | 🇯🇵 [日本語](docs/USER_GUIDE_JA.md) |
+| 🇨🇳 [中文](docs/USER_GUIDE_ZH.md) | 🇰🇷 [한국어](docs/USER_GUIDE_KO.md) | 🇧🇷 [Português](docs/USER_GUIDE_PT.md) |
+| 🇷🇺 [Русский](docs/USER_GUIDE_RU.md) | 🇵🇱 [Polski](docs/USER_GUIDE_PL.md) | |
+
+### 项目文档
+
+- **[CHANGELOG.md](CHANGELOG.md)** — 完整版本历史
+- **[docs/VERSIONING.md](docs/VERSIONING.md)** — 版本控制政策
+- **[docs/PROJECT_STATUS.md](docs/PROJECT_STATUS.md)** — 当前路线图
+- **[PLUGIN_SYSTEM.md](PLUGIN_SYSTEM.md)** — 插件架构设计
+- **[LICENSE](LICENSE)** — Source-Available License v1.1
+
+---
+
+## 🛠️ 从源码构建
+
+**先决条件**:Node.js 18+、Rust 1.70+、npm。在 Linux 上还需要:`libwebkit2gtk-4.1-dev`、`libayatana-appindicator3-dev`、`librsvg2-dev`。
+
+```bash
+git clone https://github.com/rouges78/GameStringer.git
+cd GameStringer
+npm install
+npm run dev          # 开发
+npm run tauri:build  # 生产构建
+```
+
+Rust 后端:`cd src-tauri && cargo check` 以验证 Tauri 命令在您的平台上编译。
+
+---
+
+## 💖 支持
+
+如果 GameStringer 帮助您用自己的语言玩游戏:
+
+<p align="center">
+  <a href="https://buymeacoffee.com/gamestringer">
+    <img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://ko-fi.com/gamestringer">
+    <img src="https://img.shields.io/badge/Ko--fi-FF5E5B?logo=ko-fi&logoColor=white" alt="Ko-fi" />
+  </a>
+  <a href="https://github.com/sponsors/rouges78">
+    <img src="https://img.shields.io/badge/GitHub%20Sponsors-EA4AAA?logo=github-sponsors&logoColor=white" alt="GitHub Sponsors" />
+  </a>
+</p>
+
+---
+
+## 📜 许可证
+
+**Source-Available License v1.1** — 源代码是公开的,您可以自己构建它,但它不是 OSI 批准的"开源"。
+
+- ✅ 个人使用免费
+- ✅ 可自由检查、构建和修改供自己使用
+- ❌ 商业使用需要书面许可
+- ❌ 修改版本的再分发需要书面许可
+
+详情请参阅 [LICENSE](LICENSE)。有问题?请打开一个 [Discussion](https://github.com/rouges78/GameStringer/discussions)。
+
+---
+
+## 🙏 Credits
+
+- **[BepInEx](https://github.com/BepInEx/BepInEx)** — Unity modding 框架(BepInEx Team)
+- **[XUnity.AutoTranslator](https://github.com/bbepis/XUnity.AutoTranslator)** — Unity 翻译框架(bbepis)
+- **[UnrealLocres](https://github.com/akintos/UnrealLocres)** — Unreal `.locres` 解析器(akintos)
+- **[UndertaleModTool](https://github.com/krzys-h/UndertaleModTool)** — GameMaker modding(krzys-h)
+- **[Tauri](https://tauri.app)** — 桌面应用框架
+- **[Tesseract.js](https://github.com/naptha/tesseract.js)** — OCR 引擎
+- **[Ollama](https://ollama.com)** — 本地 LLM 运行时
+- **[Supabase](https://supabase.com)** — Community Chat 的实时后端
+
+---
+
+<p align="center">
+  用 ❤️ 为想用自己语言玩游戏的玩家制作<br>
+  <strong>GameStringer v1.6.0</strong> · © 2025-2026 GameStringer Team
+</p>

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -15,7 +15,8 @@ import {
   CheckCircle2, Info, Globe, Monitor, Target, Eye, Wrench,
   Package, Heart, Cpu, Film, Layers, AudioLines, User,
   FileArchive, ShoppingBag, Users, MessageSquare, Glasses,
-  Subtitles, Play, FileText,
+  Subtitles, Play, FileText, Trophy, FlaskConical, GitBranch,
+  ListOrdered, Gauge, Workflow,
 } from 'lucide-react';
 import { useTranslation, translations } from '@/lib/i18n';
 import { getGuideTranslations } from '@/lib/i18n/guide-translations';
@@ -129,7 +130,7 @@ export default function GuidePage() {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col min-h-0">
-        <TabsList className="grid grid-cols-5 w-full h-9 shrink-0">
+        <TabsList className="grid grid-cols-6 w-full h-9 shrink-0">
           <TabsTrigger value="quickstart" className="text-xs gap-1">
             <Rocket className="h-3 w-3" /> {g.tabQuickStart}
           </TabsTrigger>
@@ -138,6 +139,9 @@ export default function GuidePage() {
           </TabsTrigger>
           <TabsTrigger value="tools" className="text-xs gap-1">
             <Wrench className="h-3 w-3" /> {g.tabTools}
+          </TabsTrigger>
+          <TabsTrigger value="advanced" className="text-xs gap-1">
+            <Brain className="h-3 w-3" /> Avanzate
           </TabsTrigger>
           <TabsTrigger value="shortcuts" className="text-xs gap-1">
             <Keyboard className="h-3 w-3" /> {g.tabShortcuts}
@@ -438,6 +442,224 @@ export default function GuidePage() {
                   </div>
                 );
               })}
+            </div>
+          </ScrollArea>
+        </TabsContent>
+
+        {/* ================================================================ */}
+        {/* TAB: AVANZATE — P.T., Dry Run, P.T.Rank                         */}
+        {/* ================================================================ */}
+        <TabsContent value="advanced" className="flex-1 overflow-hidden mt-3">
+          <ScrollArea className="h-full">
+            <div className="space-y-4 pr-3 pb-6">
+
+              {/* ── CARD 1: Prediction Tool ────────────────────────────── */}
+              <Card className="border-purple-500/30 bg-gradient-to-br from-purple-950/20 to-slate-900/30">
+                <CardHeader className="py-2 px-3">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Brain className="w-4 h-4 text-purple-400" />
+                    Prediction Tool (P.T.) — Lo strumento più potente
+                    <Badge variant="outline" className="ml-auto text-2xs border-purple-500/40 text-purple-300">v1.6.0</Badge>
+                  </CardTitle>
+                  <CardDescription className="text-xs">
+                    Analizza in profondità un gioco <em>prima</em> di tradurlo: difficoltà, engine, volume stringhe, DRM, encoding, tempi stimati LLM e chain suggerite.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-3 space-y-3">
+                  {/* Pipeline diagram */}
+                  <div className="rounded-lg border border-purple-500/20 bg-slate-950/40 p-3">
+                    <div className="text-2xs text-purple-300 font-semibold mb-2 uppercase tracking-wider">Pipeline di analisi</div>
+                    <div className="flex items-center justify-between gap-1 text-2xs">
+                      {[
+                        { icon: FolderTree, label: 'Input', sub: 'game path' },
+                        { icon: Cpu, label: 'Engine', sub: '20+ detect' },
+                        { icon: FileText, label: 'Extract', sub: 'stringhe' },
+                        { icon: Gauge, label: 'Analyze', sub: 'DRM/enc/vol' },
+                        { icon: Workflow, label: 'Plan', sub: 'chain + tempi' },
+                        { icon: CheckCircle2, label: 'Report', sub: 'score 0-100' },
+                      ].map((step, i, arr) => (
+                        <React.Fragment key={i}>
+                          <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-purple-500/15 border border-purple-500/40">
+                              <step.icon className="h-3.5 w-3.5 text-purple-300" />
+                            </div>
+                            <div className="text-center">
+                              <div className="font-semibold text-purple-200">{step.label}</div>
+                              <div className="text-[9px] text-muted-foreground">{step.sub}</div>
+                            </div>
+                          </div>
+                          {i < arr.length - 1 && (
+                            <ArrowRight className="h-3 w-3 text-purple-500/50 shrink-0 mt-[-14px]" />
+                          )}
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                    <div className="rounded border border-slate-700/40 bg-slate-900/40 p-2">
+                      <div className="flex items-center gap-1.5 text-2xs font-semibold text-purple-300 mb-1">
+                        <Gauge className="h-3 w-3" /> Difficulty Score 0-100
+                      </div>
+                      <p className="text-2xs text-muted-foreground">Combinazione pesata di volume stringhe, engine, DRM, encoding e complessità linguistica. Più basso = più facile.</p>
+                    </div>
+                    <div className="rounded border border-slate-700/40 bg-slate-900/40 p-2">
+                      <div className="flex items-center gap-1.5 text-2xs font-semibold text-purple-300 mb-1">
+                        <ShieldCheck className="h-3 w-3" /> DRM & Encoding
+                      </div>
+                      <p className="text-2xs text-muted-foreground">Rileva Denuvo, VMProtect, Steam DRM + encoding Shift-JIS/UTF-8/UTF-16 per-file prima di tradurre.</p>
+                    </div>
+                    <div className="rounded border border-slate-700/40 bg-slate-900/40 p-2">
+                      <div className="flex items-center gap-1.5 text-2xs font-semibold text-purple-300 mb-1">
+                        <Cpu className="h-3 w-3" /> 18 modelli LLM stimati
+                      </div>
+                      <p className="text-2xs text-muted-foreground">Ollama (Gemma 4, Qwen, Llama), OpenAI, DeepL, Gemini — con tempo e costo per ogni modello.</p>
+                    </div>
+                    <div className="rounded border border-slate-700/40 bg-slate-900/40 p-2">
+                      <div className="flex items-center gap-1.5 text-2xs font-semibold text-purple-300 mb-1">
+                        <GitBranch className="h-3 w-3" /> 5 chain suggerite
+                      </div>
+                      <p className="text-2xs text-muted-foreground">Local (privacy), Cloud (qualità), Hybrid (bilanciata) — con fallback automatico e qualità/costo stimati.</p>
+                    </div>
+                  </div>
+
+                  <Tip variant="info">
+                    Come si apre: <strong>icona Brain (viola)</strong> sulla game card in libreria (hover) oppure dal bottone <strong>P.T.</strong> nella pagina dettaglio gioco. Output: report esportabile + bottone "Esegui workflow".
+                  </Tip>
+                </CardContent>
+              </Card>
+
+              {/* ── CARD 2: Dry Run Scanner ────────────────────────────── */}
+              <Card className="border-sky-500/30 bg-gradient-to-br from-sky-950/20 to-slate-900/30">
+                <CardHeader className="py-2 px-3">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <FlaskConical className="w-4 h-4 text-sky-400" />
+                    Dry Run Scanner — Scansione sicura dell'intera libreria
+                    <Badge variant="outline" className="ml-auto text-2xs border-sky-500/40 text-sky-300">v1.6.0</Badge>
+                  </CardTitle>
+                  <CardDescription className="text-xs">
+                    Analizza <strong>tutti</strong> i tuoi giochi Steam (800+) in batch <strong>senza modificare nessun file</strong>. Identifica quali sono traducibili e con quale engine.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-3 space-y-3">
+                  {/* Flow diagram */}
+                  <div className="rounded-lg border border-sky-500/20 bg-slate-950/40 p-3">
+                    <div className="text-2xs text-sky-300 font-semibold mb-2 uppercase tracking-wider">Flusso dry run</div>
+                    <div className="flex items-start gap-2 text-2xs">
+                      <div className="flex flex-col items-center gap-1 flex-1">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-sky-500/15 border border-sky-500/40">
+                          <Database className="h-3.5 w-3.5 text-sky-300" />
+                        </div>
+                        <div className="text-center font-semibold text-sky-200">Steam Library</div>
+                        <div className="text-[9px] text-muted-foreground">800+ giochi</div>
+                      </div>
+                      <ArrowRight className="h-3 w-3 text-sky-500/50 mt-3 shrink-0" />
+                      <div className="flex flex-col items-center gap-1 flex-1">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-sky-500/15 border border-sky-500/40">
+                          <Scan className="h-3.5 w-3.5 text-sky-300" />
+                        </div>
+                        <div className="text-center font-semibold text-sky-200">Engine Detect</div>
+                        <div className="text-[9px] text-muted-foreground">+ string count</div>
+                      </div>
+                      <ArrowRight className="h-3 w-3 text-sky-500/50 mt-3 shrink-0" />
+                      <div className="flex flex-col items-center gap-1 flex-1">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-sky-500/15 border border-sky-500/40">
+                          <Layers className="h-3.5 w-3.5 text-sky-300" />
+                        </div>
+                        <div className="text-center font-semibold text-sky-200">Categorizza</div>
+                        <div className="text-[9px] text-muted-foreground">ready/err/nosup</div>
+                      </div>
+                      <ArrowRight className="h-3 w-3 text-sky-500/50 mt-3 shrink-0" />
+                      <div className="flex flex-col items-center gap-1 flex-1">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-sky-500/15 border border-sky-500/40">
+                          <FileText className="h-3.5 w-3.5 text-sky-300" />
+                        </div>
+                        <div className="text-center font-semibold text-sky-200">Report JSON</div>
+                        <div className="text-[9px] text-muted-foreground">DATA_DIR</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="rounded border border-emerald-500/30 bg-emerald-950/20 p-2 text-center">
+                      <div className="text-sm font-bold text-emerald-300">✓ Ready</div>
+                      <div className="text-[10px] text-muted-foreground">Engine supportato + stringhe estraibili</div>
+                    </div>
+                    <div className="rounded border border-amber-500/30 bg-amber-950/20 p-2 text-center">
+                      <div className="text-sm font-bold text-amber-300">⚠ Errors</div>
+                      <div className="text-[10px] text-muted-foreground">Manifest corrotto / DRM bloccante</div>
+                    </div>
+                    <div className="rounded border border-slate-500/30 bg-slate-950/40 p-2 text-center">
+                      <div className="text-sm font-bold text-slate-300">— Unsupported</div>
+                      <div className="text-[10px] text-muted-foreground">Engine ignoto o senza stringhe</div>
+                    </div>
+                  </div>
+
+                  <Tip variant="success">
+                    Come si lancia: bottone <strong>Dry Run</strong> nel pannello in cima alla pagina <NavLink href="/library">Libreria</NavLink>. Progress real-time, nessun file toccato. Al termine, report JSON salvato in <code className="text-[10px] bg-slate-800 px-1 rounded">DATA_DIR/dry_run_report.json</code>.
+                  </Tip>
+                </CardContent>
+              </Card>
+
+              {/* ── CARD 3: P.T.Rank / Classifica Rapida ─────────────── */}
+              <Card className="border-amber-500/30 bg-gradient-to-br from-amber-950/20 to-slate-900/30">
+                <CardHeader className="py-2 px-3">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Trophy className="w-4 h-4 text-amber-400" />
+                    P.T.Rank — Classifica Rapida
+                    <Badge variant="outline" className="ml-auto text-2xs border-amber-500/40 text-amber-300">v1.6.0</Badge>
+                  </CardTitle>
+                  <CardDescription className="text-xs">
+                    Ordina tutti i giochi analizzati dal <strong>più facile</strong> al <strong>più difficile</strong> da tradurre. Perfetto per decidere da dove cominciare.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-3 space-y-3">
+                  {/* Sample ranking visualization */}
+                  <div className="rounded-lg border border-amber-500/20 bg-slate-950/40 p-3 space-y-1.5">
+                    <div className="text-2xs text-amber-300 font-semibold mb-1 uppercase tracking-wider flex items-center gap-1">
+                      <ListOrdered className="h-3 w-3" /> Esempio ranking
+                    </div>
+                    {[
+                      { rank: 1, name: 'Mother Russia Bleeds', engine: 'GameMaker', score: 12, badge: 'bg-emerald-500/20 border-emerald-500/40 text-emerald-300', bar: 'bg-emerald-500/70', txt: 'text-emerald-300' },
+                      { rank: 2, name: 'Hollow Knight', engine: 'Unity', score: 28, badge: 'bg-emerald-500/20 border-emerald-500/40 text-emerald-300', bar: 'bg-emerald-500/70', txt: 'text-emerald-300' },
+                      { rank: 3, name: 'Persona 5 Royal', engine: 'CRI CPK', score: 54, badge: 'bg-amber-500/20 border-amber-500/40 text-amber-300', bar: 'bg-amber-500/70', txt: 'text-amber-300' },
+                      { rank: 4, name: 'Cyberpunk 2077', engine: 'REDengine', score: 78, badge: 'bg-orange-500/20 border-orange-500/40 text-orange-300', bar: 'bg-orange-500/70', txt: 'text-orange-300' },
+                      { rank: 5, name: 'Starfield', engine: 'Creation 2', score: 91, badge: 'bg-red-500/20 border-red-500/40 text-red-300', bar: 'bg-red-500/70', txt: 'text-red-300' },
+                    ].map(g => (
+                      <div key={g.rank} className="flex items-center gap-2 text-2xs">
+                        <div className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border font-bold ${g.badge}`}>
+                          {g.rank}
+                        </div>
+                        <div className="flex-1 min-w-0 truncate font-semibold text-slate-200">{g.name}</div>
+                        <div className="text-[10px] text-muted-foreground">{g.engine}</div>
+                        <div className="w-24 h-1.5 bg-slate-800 rounded-full overflow-hidden">
+                          <div className={`h-full ${g.bar}`} style={{ width: `${g.score}%` }} />
+                        </div>
+                        <div className={`text-[10px] font-mono w-6 text-right ${g.txt}`}>{g.score}</div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <Tip variant="info">
+                    Dove si trova: <NavLink href="/prediction-tool/ranking">/prediction-tool/ranking</NavLink>. Clicca un gioco nella lista per aprire direttamente il suo report P.T. completo.
+                  </Tip>
+                </CardContent>
+              </Card>
+
+              {/* ── CARD 4: "String it!" quick action ────────────────── */}
+              <Card className="border-indigo-500/30 bg-gradient-to-br from-indigo-950/20 to-slate-900/30">
+                <CardHeader className="py-2 px-3">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Sparkles className="w-4 h-4 text-indigo-400" />
+                    "String it!" — Traduzione in un click
+                    <Badge variant="outline" className="ml-auto text-2xs border-indigo-500/40 text-indigo-300">v1.6.0</Badge>
+                  </CardTitle>
+                  <CardDescription className="text-xs">
+                    Bottone viola <Sparkles className="inline h-3 w-3 text-indigo-400" /> che appare in <em>hover</em> sulla game card: lancia direttamente il Translation Wizard precompilato con tutto ciò che serve (appid, engine, path).
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+
             </div>
           </ScrollArea>
         </TabsContent>

--- a/components/game-detail-client.tsx
+++ b/components/game-detail-client.tsx
@@ -250,6 +250,7 @@ export default function GameDetailPage() {
     message: string;
   } | null>(null);
   const [isDismissingUpdate, setIsDismissingUpdate] = useState(false);
+  const [isUntrackingGame, setIsUntrackingGame] = useState(false);
   
   // Ref guards per StrictMode — traccia quale gameId è stato caricato
   const gameDataLoadedRef = useRef<string | null>(null);
@@ -695,6 +696,21 @@ export default function GameDetailPage() {
       setUpdateStatus(prev => prev ? { ...prev, update_detected: false, known_build_id: prev.current_build_id } : prev);
     } catch (e) { console.warn('[UpdateTracker] dismiss:', e); }
     finally { setIsDismissingUpdate(false); }
+  };
+
+  const untrackGame = async () => {
+    if (!game?.appid) return;
+    setIsUntrackingGame(true);
+    try {
+      await invoke<boolean>('remove_tracked_game', { appId: String(game.appid) });
+      setUpdateStatus(null);
+      toast.success('Monitoraggio disattivato per questo gioco');
+    } catch (e) {
+      console.warn('[UpdateTracker] untrack:', e);
+      toast.error('Impossibile disattivare il monitoraggio');
+    } finally {
+      setIsUntrackingGame(false);
+    }
   };
 
   // === UNREAL ENGINE LOCALIZATION STATE ===
@@ -1373,6 +1389,51 @@ export default function GameDetailPage() {
     }
   };
 
+  // ═══ STRING IT! — smart entry point con gate P.T. ═══
+  // Se il gioco non è stato ancora analizzato da P.T. (o la cache è scaduta),
+  // chiediamo all'utente se vuole eseguire prima l'analisi. Altrimenti parte diretto.
+  const handleStringIt = async () => {
+    if (!game?.installPath) {
+      toast.error('Percorso di installazione non disponibile');
+      return;
+    }
+    if (autoTranslateRunningRef.current || autoTranslateActive) return;
+
+    try {
+      const info = await invoke<{ cached: boolean; expired: boolean; age_minutes: number; difficulty_score: number | null }>(
+        'has_cached_prediction',
+        { installPath: game.installPath, gameTitle: game.title || game.name || '' }
+      );
+
+      if (info.cached && !info.expired) {
+        // Già analizzato di recente → parti diretto
+        startAutoTranslate();
+        return;
+      }
+
+      // Nessuna cache valida → chiedi conferma
+      const ptUrl = `/prediction-tool?name=${encodeURIComponent(game.title || game.name || '')}&installDir=${encodeURIComponent(game.installPath)}&engine=${encodeURIComponent(engineInfo?.engine || '')}&headerImage=${encodeURIComponent(game.headerImage || game.coverImage || '')}`;
+      toast('Gioco non ancora analizzato con P.T.', {
+        description: info.expired
+          ? `Analisi precedente scaduta (${Math.floor(info.age_minutes / 60)}h fa). Rianalizzare migliora tempi e qualità stimate.`
+          : 'Eseguire prima P.T. permette di scegliere la chain LLM migliore e stimare tempi/costi.',
+        duration: 12000,
+        action: {
+          label: 'Esegui P.T. prima',
+          onClick: () => router.push(ptUrl),
+        },
+        cancel: {
+          label: 'String it! comunque',
+          onClick: () => startAutoTranslate(),
+        },
+      });
+    } catch (e) {
+      console.warn('[StringIt] cache check failed:', e);
+      // Fallback: parti diretto se il check fallisce
+      startAutoTranslate();
+    }
+  };
+
   // ═══ AUTO-TRANSLATE ONE-CLICK FLOW ═══
   const autoTranslateRunningRef = useRef(false);
   const startAutoTranslate = async () => {
@@ -1913,18 +1974,19 @@ export default function GameDetailPage() {
             )}
             <div className="flex flex-col items-stretch">
               <div className="flex items-stretch gap-0">
-                {/* ── Bottone STRING IT! ── */}
-                <button className="h-10 flex-1 flex items-center justify-center gap-2 rounded-l-xl bg-gradient-to-r from-indigo-600 to-violet-500 hover:from-indigo-500 hover:to-violet-400 text-white font-bold text-2xs uppercase tracking-widest shadow-lg shadow-indigo-500/20 transition-all border border-indigo-400/20 border-r-0 relative overflow-hidden group"
-                  onClick={startAutoTranslate}
+                {/* ── Bottone STRING IT! (HERO — azione principale) ── */}
+                <button className="h-12 flex-1 flex items-center justify-center gap-2 rounded-l-xl bg-gradient-to-r from-indigo-600 to-violet-500 hover:from-indigo-500 hover:to-violet-400 text-white font-extrabold text-xs uppercase tracking-widest shadow-xl shadow-indigo-500/40 hover:shadow-indigo-500/60 transition-all border border-indigo-400/30 border-r-0 relative overflow-hidden group"
+                  onClick={handleStringIt}
                   disabled={autoTranslateActive}
+                  title="Avvia la traduzione completa del gioco"
                 >
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent -translate-x-[200%] group-hover:translate-x-[200%] transition-transform duration-1000" />
-                  {autoTranslateActive ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" fill="currentColor" />} {autoTranslateActive ? t('gameDetails.translating') || 'Translating...' : 'String it!'}
+                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/15 to-transparent -translate-x-[200%] group-hover:translate-x-[200%] transition-transform duration-1000" />
+                  {autoTranslateActive ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" fill="currentColor" />} {autoTranslateActive ? t('gameDetails.translating') || 'Translating...' : 'String it!'}
                 </button>
                 {/* ── Bandierina lingua target ── */}
                 <div className="relative" ref={langPickerRef}>
                   <button
-                    className="h-10 px-2.5 flex items-center gap-1 rounded-r-xl bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-400 hover:to-purple-500 text-white text-2xs font-bold uppercase tracking-wider shadow-lg shadow-purple-500/20 transition-all border border-purple-400/20 border-l-0"
+                    className="h-12 px-2.5 flex items-center gap-1 rounded-r-xl bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-400 hover:to-purple-500 text-white text-2xs font-bold uppercase tracking-wider shadow-xl shadow-purple-500/30 transition-all border border-purple-400/30 border-l-0"
                     onClick={() => setShowLangPicker(!showLangPicker)}
                     title={`Lingua: ${currentFlag.label}`}
                   >
@@ -1984,11 +2046,11 @@ export default function GameDetailPage() {
             <Play className="h-3.5 w-3.5 fill-current" /> Gioca
           </button>
         )}
-        <button className="flex-1 h-9 flex items-center justify-center gap-1.5 rounded-l-lg bg-indigo-600/90 text-white font-bold text-2xs uppercase tracking-wider"
-          onClick={startAutoTranslate}
+        <button className="flex-1 h-9 flex items-center justify-center gap-1.5 rounded-l-lg bg-gradient-to-r from-indigo-600 to-violet-500 text-white font-bold text-2xs uppercase tracking-wider shadow-lg shadow-indigo-500/30"
+          onClick={handleStringIt}
           disabled={autoTranslateActive}
         >
-          {autoTranslateActive ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />} {autoTranslateActive ? '...' : 'String it!'}
+          {autoTranslateActive ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" fill="currentColor" />} {autoTranslateActive ? '...' : 'String it!'}
         </button>
         <button className="h-9 px-2 flex items-center gap-0.5 rounded-r-lg bg-violet-600/90 text-white text-xs font-bold"
           onClick={() => setShowLangPicker(!showLangPicker)}
@@ -2267,6 +2329,15 @@ export default function GameDetailPage() {
                     disabled={isDismissingUpdate}
                   >
                     {isDismissingUpdate ? <Loader2 className="h-3 w-3 animate-spin inline" /> : null} Segna come visto
+                  </button>
+                  {/* Smetti di monitorare */}
+                  <button
+                    className="h-6 px-2.5 rounded-lg text-2xs font-semibold bg-red-500/10 hover:bg-red-500/20 text-red-300/80 hover:text-red-200 border border-red-500/20 transition-all"
+                    onClick={untrackGame}
+                    disabled={isUntrackingGame}
+                    title="Rimuovi questo gioco dal monitoraggio aggiornamenti/patch"
+                  >
+                    {isUntrackingGame ? <Loader2 className="h-3 w-3 animate-spin inline" /> : null} Smetti di monitorare
                   </button>
                 </div>
               </div>

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -2558,7 +2558,9 @@
       "PROVIDER_MAP mit automatischem Modell-Mapping",
       "Chain Presets mit automatischem Fallback zwischen Providern",
       "Komplett kostenlos und offline"
-    ]
+    ],
+    "stores": "Stores",
+    "autotranslate": "Auto-Übersetzung"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -2108,7 +2108,9 @@
       "PROVIDER_MAP with automatic model mapping",
       "Chain presets with automatic fallback between providers",
       "Completely free and offline"
-    ]
+    ],
+    "stores": "Stores",
+    "autotranslate": "Auto-Translate"
   },
   "dictionary": {
     "title": "Dictionary",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -2568,7 +2568,9 @@
       "PROVIDER_MAP con mapeo automático de modelos",
       "Chain presets con fallback automático entre providers",
       "Completamente gratuito y offline"
-    ]
+    ],
+    "stores": "Tiendas",
+    "autotranslate": "Traducción Automática"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -2439,7 +2439,9 @@
       "PROVIDER_MAP avec mappage automatique des modèles",
       "Chain presets avec fallback automatique entre providers",
       "Entièrement gratuit et hors ligne"
-    ]
+    ],
+    "stores": "Boutiques",
+    "autotranslate": "Traduction Auto"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -2108,7 +2108,9 @@
       "PROVIDER_MAP con mapping automatico dei modelli",
       "Chain presets con fallback automatico tra provider",
       "Completamente gratuito e offline"
-    ]
+    ],
+    "stores": "Store",
+    "autotranslate": "Traduzione Automatica"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -2297,7 +2297,9 @@
       "PROVIDER_MAPによる自動モデルマッピング",
       "プロバイダー間の自動フォールバック付きチェーンプリセット",
       "完全無料でオフライン対応"
-    ]
+    ],
+    "stores": "ストア",
+    "autotranslate": "自動翻訳"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -1970,7 +1970,9 @@
     "subtitle": "사용 가이드",
     "gettingStarted": "시작하기",
     "advanced": "고급",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "stores": "스토어",
+    "autotranslate": "자동 번역"
   },
   "gamePatcher": {
     "title": "게임 패처",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -1969,7 +1969,9 @@
     "subtitle": "Przewodniki użytkownika",
     "gettingStarted": "Wprowadzenie",
     "advanced": "Zaawansowane",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "stores": "Sklepy",
+    "autotranslate": "Auto-tłumaczenie"
   },
   "gamePatcher": {
     "title": "Patcher gier",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -1970,7 +1970,9 @@
     "subtitle": "Guias de uso",
     "gettingStarted": "Primeiros Passos",
     "advanced": "Avançado",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "stores": "Lojas",
+    "autotranslate": "Tradução Automática"
   },
   "gamePatcher": {
     "title": "Patcher de Jogos",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -2059,7 +2059,9 @@
     "subtitle": "Руководства пользователя",
     "gettingStarted": "Начало работы",
     "advanced": "Продвинутый",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "stores": "Магазины",
+    "autotranslate": "Авто-перевод"
   },
   "gamePatcher": {
     "title": "Патчер игр",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -2297,7 +2297,9 @@
       "PROVIDER_MAP自动模型映射",
       "提供商之间自动回退的链式预设",
       "完全免费且离线可用"
-    ]
+    ],
+    "stores": "商店",
+    "autotranslate": "自动翻译"
   },
   "gamePatcher": {
     "title": "Game Patcher",

--- a/src-tauri/src/commands/game_update_tracker.rs
+++ b/src-tauri/src/commands/game_update_tracker.rs
@@ -290,3 +290,15 @@ pub async fn get_all_tracked_games() -> Result<serde_json::Value, String> {
     let store = load_store();
     Ok(serde_json::json!(store.games))
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// COMMAND: Rimuove un gioco dal tracking (smette di monitorarlo)
+// ──────────────────────────────────────────────────────────────────────────────
+#[command]
+pub async fn remove_tracked_game(app_id: String) -> Result<bool, String> {
+    let mut store = load_store();
+    let game_key = format!("steam_{}", app_id);
+    let removed = store.games.remove(&game_key).is_some();
+    save_store(&store)?;
+    Ok(removed)
+}

--- a/src-tauri/src/commands/game_update_tracker.rs
+++ b/src-tauri/src/commands/game_update_tracker.rs
@@ -173,9 +173,13 @@ fn check_patch_integrity(game_path: &Path) -> (bool, String, Vec<String>) {
             })
             .unwrap_or_default();
 
+        // Nessun pak GameStringer = gioco Unreal mai patchato da noi,
+        // NON è una patch danneggiata. Ogni gioco Unreal ha Content/Paks/
+        // di default, quindi trovare la cartella non implica l'esistenza
+        // di una patch precedente.
         if gs_paks.is_empty() {
-            details.push("✗ Nessun _P.pak GameStringer trovato in Content/Paks/".to_string());
-            return (false, "unreal_pak".to_string(), details);
+            details.push("Nessuna patch GameStringer rilevata (gioco Unreal non patchato)".to_string());
+            return (true, "none".to_string(), details);
         } else {
             for pak in &gs_paks {
                 details.push(format!("✓ {} presente", pak.file_name().to_string_lossy()));

--- a/src-tauri/src/commands/prediction_tool.rs
+++ b/src-tauri/src/commands/prediction_tool.rs
@@ -9176,3 +9176,45 @@ pub async fn dry_run_scan_all_games(app: tauri::AppHandle) -> Result<DryRunRepor
 
     Ok(report)
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// COMMAND: has_cached_prediction — rapido check "è già stato analizzato con P.T.?"
+// Usato da "String it!" per decidere se suggerire P.T. prima del wizard.
+// ──────────────────────────────────────────────────────────────────────────────
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachedPredictionInfo {
+    pub cached: bool,
+    pub expired: bool,
+    pub age_minutes: u64,
+    pub difficulty_score: Option<u32>,
+}
+
+#[tauri::command]
+pub async fn has_cached_prediction(
+    install_path: String,
+    game_title: String,
+) -> Result<CachedPredictionInfo, String> {
+    let cache_key = format!("{}:{}", game_title, install_path);
+    let cache = load_cache();
+
+    if let Some(entry) = cache.get(&cache_key) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age_minutes = now.saturating_sub(entry.timestamp) / 60;
+        return Ok(CachedPredictionInfo {
+            cached: true,
+            expired: entry.is_expired(),
+            age_minutes,
+            difficulty_score: Some(entry.result.difficulty_score),
+        });
+    }
+
+    Ok(CachedPredictionInfo {
+        cached: false,
+        expired: false,
+        age_minutes: 0,
+        difficulty_score: None,
+    })
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -541,6 +541,7 @@ fn main() {
             commands::game_update_tracker::acknowledge_game_update,
             commands::game_update_tracker::verify_patch_integrity,
             commands::game_update_tracker::get_all_tracked_games,
+            commands::game_update_tracker::remove_tracked_game,
 
             // Unreal Engine Localization Pipeline (.locres + .pak)
             commands::unreal_localization::extract_unreal_localization,
@@ -828,6 +829,7 @@ fn main() {
             commands::prediction_tool::export_prediction_report,
             commands::prediction_tool::execute_complete_workflow,
             commands::prediction_tool::dry_run_scan_all_games,
+            commands::prediction_tool::has_cached_prediction,
             // Global Hotkeys System
             commands::global_hotkeys::init_global_hotkeys,
             commands::global_hotkeys::register_global_hotkey,


### PR DESCRIPTION
## Summary

- **String it! smart gate**: the button on the game detail page now checks whether the game has already been analyzed by P.T. (24h cache). If not, it shows a toast with two actions: *Run P.T. first* / *String it! anyway*. If yes, it launches directly.
- **String it! hero button**: h-12, Sparkles icon, stronger shadow — now the primary action of the game detail page (P.T.Rank stays accessible from the library).
- **Backend**: new `has_cached_prediction` command (reads `prediction_cache.json`, returns cached/expired/age_minutes/difficulty_score).
- **Guide — new "Advanced" tab**: 4 cards with inline pipeline diagrams (Prediction Tool, Dry Run Scanner, P.T.Rank/Quick Ranking, String it!) — fills the gap "the most powerful tool is not explained in the guide".
- **Guide i18n fix**: `guidePage.stores` and `guidePage.autotranslate` added to all 11 locales (previously rendered as literal keys).
- **Untrack game**: "Stop monitoring" button on the game detail page + `remove_tracked_game` backend command — fixes the recurring "damaged patch" toast for games whose patch is no longer present (e.g. Split Fiction).
- **CHANGELOG v1.6.0**: added the missing entries (P.T., P.T.Rank, Dry Run, Workflow Orchestrator, String it!, Ollama Manager) that were merged between April 1–3 but forgotten in the version bump.

## Test plan

- [ ] Open a game detail never analyzed → click String it! → verify toast with two actions
- [ ] Open a game detail already analyzed recently → click String it! → launches directly without toast
- [ ] Click "Run P.T. first" → redirects to /prediction-tool?name=...
- [ ] Click "String it! anyway" → starts auto-translate
- [ ] Guide → Advanced tab → verify 4 cards + diagrams rendered
- [ ] Guide → home → verify "Stores" and "Auto-Translate" (no longer literal keys)
- [ ] Game detail with update detection active → click "Stop monitoring" → verify entry removed from `update_tracking.json`
- [ ] Rust build OK (new command registered in main.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)