### PR TITLE
fix: prevent onboarding dialogs from flashing after updates

### DIFF
--- a/components/onboarding/interactive-tutorial.tsx
+++ b/components/onboarding/interactive-tutorial.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from '@/lib/i18n';
 import Image from 'next/image';
 
 const TUTORIAL_KEY = 'gamestringer-tutorial-completed';
-const TUTORIAL_VERSION = '5'; // Versione 5: aggiornati step con feature attuali
+const TUTORIAL_VERSION = 5; // Increment ONLY when tutorial content actually changes
 
 interface TutorialStep {
   id: string;
@@ -134,7 +134,9 @@ export function InteractiveTutorial({ onComplete, forceShow = false }: Interacti
       const tutorialCompleted = localStorage.getItem(TUTORIAL_KEY);
       
       // Mostra tutorial se non è stato completato
-      if (tutorialCompleted === TUTORIAL_VERSION) {
+      // Accept any version >= TUTORIAL_VERSION (don't re-show after app updates)
+      const completedVer = tutorialCompleted ? parseInt(tutorialCompleted, 10) : 0;
+      if (!isNaN(completedVer) && completedVer >= TUTORIAL_VERSION) {
         return;
       }
 
@@ -194,7 +196,7 @@ export function InteractiveTutorial({ onComplete, forceShow = false }: Interacti
   };
 
   const handleComplete = () => {
-    localStorage.setItem(TUTORIAL_KEY, TUTORIAL_VERSION);
+    localStorage.setItem(TUTORIAL_KEY, String(TUTORIAL_VERSION));
     localStorage.setItem('tutorial-completed', 'true');
     setIsVisible(false);
     onComplete?.();

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -50,7 +50,7 @@ interface OnboardingStep {
 }
 
 const ONBOARDING_KEY = 'gamestringer_onboarding_completed';
-const ONBOARDING_VERSION = '3';
+const ONBOARDING_VERSION = 3; // Increment ONLY when onboarding content actually changes
 const TUTORIAL_KEY = 'gamestringer-tutorial-completed'; // Chiave condivisa con InteractiveTutorial
 
 export function OnboardingWizard() {
@@ -71,27 +71,30 @@ export function OnboardingWizard() {
 
   const checkOnboardingStatus = () => {
     if (typeof window === 'undefined') return;
-    
+
     const completed = localStorage.getItem(ONBOARDING_KEY);
-    if (completed !== ONBOARDING_VERSION) {
-      // Non mostrare se i Terms of Use non sono ancora stati accettati
-      const tosAccepted = localStorage.getItem('gamestringer_tos_accepted');
-      if (!tosAccepted) {
-        const retryInterval = setInterval(() => {
-          if (localStorage.getItem('gamestringer_tos_accepted')) {
-            clearInterval(retryInterval);
-            setTimeout(() => setIsOpen(true), 500);
-          }
-        }, 500);
-        return;
-      }
-      setIsOpen(true);
+    // Accept any version >= ONBOARDING_VERSION (don't re-show after app updates)
+    const completedVersion = completed ? parseInt(completed, 10) : 0;
+    if (!isNaN(completedVersion) && completedVersion >= ONBOARDING_VERSION) return;
+
+    // Non mostrare se i Terms of Use non sono ancora stati accettati
+    const tosAccepted = localStorage.getItem('gamestringer_tos_accepted');
+    if (!tosAccepted) {
+      const retryInterval = setInterval(() => {
+        if (localStorage.getItem('gamestringer_tos_accepted')) {
+          clearInterval(retryInterval);
+          setTimeout(() => setIsOpen(true), 500);
+        }
+      }, 500);
+      return;
     }
+    // Delay to avoid flash on startup
+    setTimeout(() => setIsOpen(true), 400);
   };
 
   const completeOnboarding = () => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(ONBOARDING_KEY, ONBOARDING_VERSION);
+      localStorage.setItem(ONBOARDING_KEY, String(ONBOARDING_VERSION));
       localStorage.setItem(TUTORIAL_KEY, '2'); // Marca anche il tutorial interattivo come completato
       localStorage.setItem('gamestringer_preferences', JSON.stringify(preferences));
     }
@@ -100,7 +103,7 @@ export function OnboardingWizard() {
 
   const skipOnboarding = () => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(ONBOARDING_KEY, ONBOARDING_VERSION);
+      localStorage.setItem(ONBOARDING_KEY, String(ONBOARDING_VERSION));
       localStorage.setItem(TUTORIAL_KEY, '2'); // Marca anche il tutorial interattivo come completato
     }
     setIsOpen(false);

--- a/components/onboarding/terms-of-use.tsx
+++ b/components/onboarding/terms-of-use.tsx
@@ -13,7 +13,7 @@ import { VisuallyHidden } from 'radix-ui';
 import { useTranslation } from '@/lib/i18n';
 
 const TOS_KEY = 'gamestringer_tos_accepted';
-const TOS_VERSION = '2';
+const TOS_VERSION = 2; // Increment ONLY when TOS content actually changes
 
 export function TermsOfUse() {
   const { t } = useTranslation();
@@ -22,22 +22,27 @@ export function TermsOfUse() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const tosAccepted = localStorage.getItem(TOS_KEY);
-    if (tosAccepted !== TOS_VERSION) {
-      setIsOpen(true);
+    // Accept any version >= TOS_VERSION (don't re-show after app updates)
+    const acceptedVersion = tosAccepted ? parseInt(tosAccepted, 10) : 0;
+    if (isNaN(acceptedVersion) || acceptedVersion < TOS_VERSION) {
+      // Small delay to avoid flash on startup
+      const timer = setTimeout(() => setIsOpen(true), 300);
+      return () => clearTimeout(timer);
     }
   }, []);
 
   const handleAccept = () => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(TOS_KEY, TOS_VERSION);
+      localStorage.setItem(TOS_KEY, String(TOS_VERSION));
     }
     setIsOpen(false);
   };
 
   // Non può essere chiuso senza accettare
   const handleOpenChange = (open: boolean) => {
-    if (!open && localStorage.getItem(TOS_KEY) !== TOS_VERSION) {
-      return;
+    if (!open) {
+      const accepted = parseInt(localStorage.getItem(TOS_KEY) || '0', 10);
+      if (isNaN(accepted) || accepted < TOS_VERSION) return;
     }
     setIsOpen(open);
   };


### PR DESCRIPTION
## Summary
- I 3 dialog di onboarding (TOS, Wizard, Tutorial) usavano `===` per confrontare la versione → ogni mismatch li rimostrava
- Cambiato a confronto numerico `>=` → si rimostrano solo quando il contenuto cambia davvero (numero incrementato)
- Aggiunto delay di 300-400ms per evitare il flash visivo all'avvio

## Files changed
- `components/onboarding/terms-of-use.tsx`
- `components/onboarding/onboarding-wizard.tsx`
- `components/onboarding/interactive-tutorial.tsx`

## Test plan
- [ ] Aggiornare l'app e verificare che TOS/onboarding non appaiano se già accettati
- [ ] Resettare da Settings → Tutorial e verificare che si rimostrano correttamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)