### PR TITLE
Take the three Rust major bumps dependabot could not do alone

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
  "open",
  "parking_lot",
  "pbkdf2",
- "rand 0.9.4",
+ "rand 0.10.2",
  "regex",
  "reqwest",
  "rusqlite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures 0.2.17",
- "password-hash 0.5.0",
+ "password-hash",
 ]
 
 [[package]]
@@ -733,9 +733,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1019,6 +1019,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
@@ -1428,6 +1434,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1651,7 +1658,7 @@ dependencies = [
  "once_cell",
  "open",
  "parking_lot",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "rand 0.9.4",
  "regex",
  "reqwest",
@@ -1681,7 +1688,7 @@ dependencies = [
  "winapi",
  "windows 0.51.1",
  "winreg 0.52.0",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -2722,6 +2729,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0a34ca854fd4f20c07f696fc8675aec78f87d88d29f5e10257a7490a1b2e1"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dad045e4b1b7b170be4b60b54b780cafb4490165461bac7d1cf7b703f61d5f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,17 +3366,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
@@ -3361,25 +3377,13 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash 0.4.2",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
- "password-hash 0.5.0",
+ "password-hash",
  "sha2 0.10.9",
 ]
 
@@ -5356,7 +5360,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip 4.6.1",
+ "zip",
 ]
 
 [[package]]
@@ -7179,6 +7183,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"
@@ -7215,35 +7233,36 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes 0.8.4",
- "byteorder",
- "bzip2 0.4.4",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
+ "aes 0.8.4",
  "arbitrary",
+ "bzip2 0.6.1",
+ "constant_time_eq",
  "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
  "indexmap 2.13.0",
+ "liblzma",
  "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
@@ -7252,21 +7271,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1686,7 +1686,8 @@ dependencies = [
  "uuid",
  "walkdir",
  "winapi",
- "windows 0.51.1",
+ "windows 0.61.3",
+ "windows-future",
  "winreg 0.52.0",
  "zip",
 ]
@@ -2268,7 +2269,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5075,7 +5076,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -6303,7 +6304,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -6327,7 +6328,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6412,22 +6413,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
-dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6439,16 +6430,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-core",
 ]
 
 [[package]]
@@ -6470,7 +6452,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6515,7 +6497,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -7017,7 +6999,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,7 +72,7 @@ bincode = "1.3"
 keyvalues-serde = "0.2.2"
 dirs = "6.0.0"
 new-vdf-parser = "0.2.0"
-zip = "0.6"
+zip = "4.6"
 # sevenz-rust2, non sevenz-rust: il crate originale è abbandonato (repository
 # cancellato) e RUSTSEC-2026-0245 lo dà vulnerabile in TUTTE le versioni —
 # `decompress_impl` faceva `dest.join(entry.name())` senza validare il nome,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,7 +104,7 @@ fontdue = "0.9"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 winapi = { version = "0.3", features = ["winuser", "processthreadsapi", "handleapi", "memoryapi", "tlhelp32", "psapi", "synchapi", "winnt"] }
-windows = { version = "0.51", features = [
+windows = { version = "0.61", features = [
     "Win32_Foundation", 
     "Win32_System_Diagnostics_Debug", 
     "Win32_System_Memory", 
@@ -117,6 +117,12 @@ windows = { version = "0.51", features = [
     "Foundation",
     "Foundation_Collections"
 ] }
+# Le `impl IntoFuture` per IAsyncOperation vivono in windows-future dietro la
+# feature `std`, ma `windows` la tira con default-features = false e il suo
+# `std` inoltra solo a windows-core. Senza questa riga `.await` sulle API WinRT
+# non compila ("IAsyncOperation is not a future"). Dipendenza diretta solo per
+# accendere la feature: il codice continua a usarla via `windows::Foundation`.
+windows-future = { version = "0.2", features = ["std"] }
 shared_memory = "0.12.4"
 
 [dev-dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 # `query` non serve: nel codice non compare (misurato, 0 occorrenze).
 reqwest = { version = "0.13", features = ["json", "stream", "form"] }
 moka = { version = "0.12", features = ["future"] }
-rand = "0.9"
+rand = "0.10"
 once_cell = "1.19"
 regex = "1.10"
 walkdir = "2.4"

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -758,7 +758,7 @@ use aes_gcm::{
 };
 use sha2::{Sha256, Digest};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use rand::Rng;
+use rand::RngExt;
 
 /// Backup criptato con password
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/commands/battlenet.rs
+++ b/src-tauri/src/commands/battlenet.rs
@@ -10,7 +10,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/commands/danganronpa_patcher.rs
+++ b/src-tauri/src/commands/danganronpa_patcher.rs
@@ -7,7 +7,7 @@ use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write, BufReader, BufRead};
 use std::path::{Path, PathBuf};
 use tauri::command;
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 use zip::ZipWriter;
 
 // ============================================================================
@@ -3447,7 +3447,7 @@ pause
     let zip_file = File::create(&output_path)
         .map_err(|e| format!("Errore creazione ZIP: {}", e))?;
     let mut zip = ZipWriter::new(zip_file);
-    let options = FileOptions::default()
+    let options = SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Stored);
 
     let mut files_included = Vec::new();

--- a/src-tauri/src/commands/epic.rs
+++ b/src-tauri/src/commands/epic.rs
@@ -26,7 +26,7 @@ use std::fs;
 use log::{debug, info, error};
 use base64::{Engine as _, engine::general_purpose};
 use aes_gcm::{Aes256Gcm, Nonce, aead::{Aead, KeyInit}};
-use rand::RngCore;
+use rand::Rng;
 use chrono;
 
 // ============================================================================

--- a/src-tauri/src/commands/gog.rs
+++ b/src-tauri/src/commands/gog.rs
@@ -9,7 +9,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/commands/itchio.rs
+++ b/src-tauri/src/commands/itchio.rs
@@ -10,7 +10,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/commands/origin.rs
+++ b/src-tauri/src/commands/origin.rs
@@ -10,7 +10,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/commands/project_export.rs
+++ b/src-tauri/src/commands/project_export.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 use zip::ZipWriter;
 use chrono::Utc;
 
@@ -121,7 +121,7 @@ pub async fn export_translation_project(
     let file = fs::File::create(output)
         .map_err(|e| format!("Errore creazione file ZIP: {}", e))?;
     let mut zip = ZipWriter::new(file);
-    let options = FileOptions::default()
+    let options = SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated);
 
     let mut stats = ProjectStats {

--- a/src-tauri/src/commands/rockstar.rs
+++ b/src-tauri/src/commands/rockstar.rs
@@ -10,7 +10,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/commands/secure_delete.rs
+++ b/src-tauri/src/commands/secure_delete.rs
@@ -3,7 +3,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{Write, Seek, SeekFrom};
 use std::path::PathBuf;
 use log::info;
-use rand::Rng;
+use rand::RngExt;
 
 // ============================================================================
 // SECURE DELETE SYSTEM - Cancellazione sicura dati sensibili

--- a/src-tauri/src/commands/secure_storage.rs
+++ b/src-tauri/src/commands/secure_storage.rs
@@ -2,7 +2,7 @@ use aes_gcm::{
     aead::{Aead, KeyInit},
     Aes256Gcm, Nonce,
 };
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;

--- a/src-tauri/src/commands/security.rs
+++ b/src-tauri/src/commands/security.rs
@@ -171,7 +171,7 @@ pub async fn generate_session_token(
     profile_id: String,
     device_fingerprint: Option<String>,
 ) -> Result<String, String> {
-    use rand::Rng;
+    use rand::RngExt;
     use sha2::{Sha256, Digest};
     
     let mut rng = rand::rng();

--- a/src-tauri/src/commands/steam.rs
+++ b/src-tauri/src/commands/steam.rs
@@ -29,7 +29,7 @@ use keyvalues_serde as kv;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
 use base64::{Engine as _, engine::general_purpose};
-use rand::RngCore;
+use rand::Rng;
 use log::{debug, info, warn, error};
 
 // ============================================================================

--- a/src-tauri/src/commands/two_factor.rs
+++ b/src-tauri/src/commands/two_factor.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use chrono::Utc;
 use log::info;
-use rand::Rng;
+use rand::RngExt;
 use hmac::{Hmac, Mac};
 use sha1::Sha1;
 

--- a/src-tauri/src/commands/ubisoft.rs
+++ b/src-tauri/src/commands/ubisoft.rs
@@ -10,7 +10,7 @@ use crate::commands::library::InstalledGame;
 use std::path::PathBuf;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use aes_gcm::aead::Aead;
-use rand::RngCore;
+use rand::Rng;
 use base64::{Engine as _, engine::general_purpose};
 use chrono;
 

--- a/src-tauri/src/ocr_translator/ocr_engine.rs
+++ b/src-tauri/src/ocr_translator/ocr_engine.rs
@@ -112,7 +112,9 @@ fn create_software_bitmap(image: &ImageData) -> Result<SoftwareBitmap, String> {
     
     // Usa IMemoryBufferByteAccess per accesso diretto
     use windows::Win32::System::WinRT::IMemoryBufferByteAccess;
-    use windows::core::ComInterface;
+    // `ComInterface` è stato rinominato `Interface` in windows 0.58: è il
+    // tratto che porta `cast()`.
+    use windows::core::Interface;
     
     let byte_access: IMemoryBufferByteAccess = reference.cast()
         .map_err(|e| format!("Failed to cast: {:?}", e))?;


### PR DESCRIPTION
Supersedes #64, #63 and #65. Each of those was a version bump with no code behind it, so all three failed to compile. This branch carries the bump and the migration together, one commit per dependency so any of them can be reverted on its own.

## zip 0.6 → 4.6

`FileOptions` became generic over its extended-data type, so `FileOptions::default()` no longer has enough information to infer it. The crate ships `SimpleFileOptions` for exactly this case. Two call sites, both writing plain archives; one keeps Deflated, the other Stored.

## windows 0.51 → 0.61

Three failures in `ocr_engine.rs`, and only two were renames.

`ComInterface` became `Interface` in 0.58. It is the trait that carries `cast()`, so the new name fixes both the unresolved import and the missing method on `IMemoryBufferReference`.

The third one was not visible from our code at all. Awaiting `IAsyncOperation` stopped compiling with "is not a future" because the `IntoFuture` impls moved into `windows-future`, where they sit behind that crate's `std` feature — and `windows` pulls it with `default-features = false` while its own `std` feature only forwards to `windows-core`. Nothing we could write in the OCR module would express that, so `windows-future` is now a direct dependency for the single purpose of switching the feature on. The code still reaches the types through `windows::Foundation`.

## rand 0.9 → 0.10

rand renamed both traits and reused one of the names, which is why this read as a removal. The old `RngCore`, the trait carrying `fill_bytes`, is now `Rng`; the old `Rng`, the extension trait with `fill()` and `random()`, is now `RngExt`. So `use rand::Rng` kept compiling in some files while quietly meaning something else, and broke in others.

Eight modules import it for `fill_bytes` on nonces — the store integrations plus profile encryption — and move to `rand::Rng`. Five import it for the extension methods and move to `rand::RngExt`. No semantics change: `rand::rng()` is still the thread-local CSPRNG, so the nonces are what they were.

## For the reviewer

- `cargo check` and `cargo clippy` clean, full suite green at 1537 passed after each of the three commits.
- Checked on Windows, so the OCR module actually compiled instead of being skipped by cfg. That matters here: `windows` is a `cfg(windows)` dependency, and CI's check-linux would not have caught any of its three errors.
- Not covered: no test exercises the WinRT OCR path, so the windows migration is verified by compilation and by the unchanged call shape, not by running OCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)