### PR TITLE
The UE5 FText::ToString pattern was wrong: unique is not correct

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -421,6 +421,72 @@ Per RPG_RT e i giochi GDI la sorgente funziona ed è stata vista funzionare;
 per UE no. Prima di considerare chiusa quella strada, va reso non ambiguo il
 pattern (o sostituito con una risoluzione per simbolo).
 
+### Il pattern UE5 di `FText::ToString` era sbagliato: unicità non è correttezza
+
+**Il fatto.** La firma usata per agganciare `FText::ToString` sui giochi Unreal
+non descriveva quella funzione. Dove faceva «1 match unico» — e quindi dove il
+codice si fidava e installava l'hook — avrebbe agganciato **una funzione
+qualsiasi**. Il caso «ambiguo» di Father's Day, che veniva rifiutato, era il
+meno pericoloso dei due.
+
+**Come è stato smascherato.** Serviva una verità di riferimento, e c'era senza
+saperlo: un'installazione **UE 5.8** in `C:\Program Files\Epic Games`, con 566
+DLL dell'engine. Lì i simboli esistono, quindi si può chiedere *quale* funzione
+sia quella giusta invece di indovinarlo:
+
+```bash
+# in UnrealEditor-Core.dll: 7632 export, fra cui
+#   ?ToString@FText@@QEBAAEBVFString@@XZ  →  RVA 0x3EFA60
+```
+
+I byte a quell'indirizzo:
+
+```text
+40 53              push rbx
+48 83 EC 30        sub  rsp, 0x30
+48 8B D9           mov  rbx, rcx
+E8 F2 EE FE FF     call <rebuild>        ← una CALL
+48 8B 0B           mov  rcx, [rbx]       ← carica TextData
+48 85 C9           test rcx, rcx
+```
+
+Il pattern in uso era
+`40 53 48 83 EC ?? 48 8B D9 48 85 C9 74 ?? 48 8B 01`, cioè si aspettava
+`test rcx,rcx` **subito** dopo `mov rbx,rcx`, poi `mov rax,[rcx]` seguito da una
+chiamata attraverso `rax`: una **dispatch virtuale su `this`**. `FText` non è
+polimorfico — non ha vtable — quindi quella forma non può essere il suo
+`ToString` in nessuna versione UE5. La conferma numerica chiude il discorso:
+il pattern compare **0 volte** in tutta `UnrealEditor-Core.dll`, che quella
+funzione la contiene di sicuro.
+
+**Numeri sui 18 Shipping installati.** Il vecchio pattern fa 1-4 match ovunque
+(1 su The Skin Stapler, Greed Stays Home, Beyond Hanwell, Cooking Simulator VR,
+Oneirophobia; 4 su Father's Day, Maestro, Subside). Una firma ricavata *dal
+simbolo* di UE 5.8 fa 6 match sulla DLL stessa e **0** su tutti i 18 giochi:
+il prologo cambia fra versioni UE, quindi una firma va ricavata **e** validata
+sulla versione di quel gioco, non trasportata.
+
+**Nel codice.** La costante è ora
+`UE::Patterns::FText_ToString_UE5_CONFUTATO` (rinominata apposta: chi prova a
+usarla non compila e legge il perché), e `source_unreal_ftext.cpp` non fa più
+pattern-scan — resta la sola risoluzione per simbolo, che serve ai build non
+monolitici. Sui giochi commerciali la sorgente ora fallisce con un messaggio
+esplicito e si scende a GDI.
+
+**La trappola.** «Un solo match» sembra la prova che il pattern è quello giusto,
+e non lo è: misura l'**ambiguità**, non la **correttezza**. Le due cose si
+separano solo con una verità di riferimento, e una verità di riferimento serve
+averla — un binario con i simboli della stessa famiglia. Senza, si può
+verificare che una firma non peschi troppo, mai che peschi la cosa giusta.
+Questo pattern era nel repo dal commit iniziale con la nota «(esempio)», ed è
+sopravvissuto a una revisione che ne misurò l'unicità sui giochi reali senza
+poterne misurare la correttezza.
+
+**Il metodo, per la prossima volta.** Installare l'engine UE della versione del
+gioco, risolvere il simbolo nella sua `UnrealEditor-Core.dll`, leggere i byte
+lì, ricavare la firma da quelli, e solo allora contarla sul gioco. Lo strumento
+per contare esiste già: `scripts/ue-validate-ftext-pattern.js --exe <path> --dump`.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_unreal_ftext.cpp
+++ b/gs-hook/src/sources/source_unreal_ftext.cpp
@@ -7,24 +7,24 @@
 // per UE — molto meglio del GDI/OCR — perché vediamo la frase intera, già
 // decodificata, prima che venga renderizzata.
 //
-// Porting completato riusando il core di unreal-translator (incluso da gs-hook
-// via CMake): `UE::Patterns::*` (firme byte di FText::ToString) e
-// `GSTranslator::Utils::PatternScanUnique` vivono in ../unreal-translator/hook-dll
-// e NON sono duplicati qui.
+// I tipi UE (`UE::FString`, `UE::FText`) vengono dal core di unreal-translator,
+// incluso da gs-hook via CMake. Il pattern-scan non serve più: vedi LIMITI.
 //
-// LIMITI NOTI:
-//   • Si aggancia SOLO con il pattern UE5: quello UE4.2x è stato rimosso il
-//     30/07/2026 perché faceva 89-127 match sui giochi veri (vedi ue_types.h).
-//     Sui giochi UE4.2x questa sorgente quindi non aggancia → fallback L2.
-//   • Il pattern UE5 è **x64** (prefissi REX.W "48 ..."): per i (rari) giochi
-//     UE a 32-bit non aggancia → Activate ritorna Failed → fallback L2.
+// LIMITI NOTI (aggiornati 21/08/2026):
+//   • Si aggancia SOLO per SIMBOLO, quindi in pratica solo su build non
+//     monolitici (editor, giochi modulari). Sui build Shipping — la norma
+//     commerciale — non c'è nessun simbolo UE e questa sorgente non aggancia:
+//     Activate ritorna Failed e si scende a L2 (GDI).
+//   • Non esiste più un pattern di ripiego. Quello UE4.2x era stato rimosso il
+//     30/07/2026 (89-127 match); quello UE5 è stato CONFUTATO il 21/08/2026
+//     contro UE 5.8 con i simboli — descriveva una dispatch virtuale su
+//     `this`, e FText non ha vtable. Dettagli e numeri in ue_types.h.
 //   • Sostituzione in-place SOLO se la traduzione entra nel buffer già allocato
 //     da UE (FString::ArrayMax). Espanderlo richiede l'allocatore UE
 //     (FMemory::Realloc) → TODO.
 //
 #include "text_source.h"
-#include "ue_types.h"   // UE::FString, UE::FText, UE::Patterns::FText_ToString_*
-#include "utils.h"      // GSTranslator::Utils::PatternScanUnique
+#include "ue_types.h"   // UE::FString, UE::FText
 #include "gs_log.h"     // log unificato gs-hook (%TEMP%\gs-hook.log)
 #include <Windows.h>
 #include <TlHelp32.h>
@@ -76,14 +76,14 @@ UE::FString* __fastcall Hook_FText_ToString(const UE::FText* self, UE::FString* 
 }
 
 // ─── Risoluzione per SIMBOLO ─────────────────────────────────────────────────
-// Un simbolo esportato e' deterministico: o c'e', ed e' quello giusto, o non
-// c'e'. Nessuna ambiguita' possibile, a differenza di una firma di byte.
+// Un simbolo esportato è deterministico: o c'è, ed è quello giusto, o non
+// c'è. Nessuna ambiguità possibile, a differenza di una firma di byte.
 //
 // QUANDO FUNZIONA E QUANDO NO — misurato, non supposto (21/08/2026):
 // serve un build **non monolitico**, con l'engine in DLL (editor, o giochi
 // compilati modulari). I build Shipping monolitici — la norma commerciale — non
 // esportano nulla di UE: Father's Day ha 312 export e sono tutti hint per i
-// driver AMD/NVIDIA (`NvOptimusEnablement`, `ags*`), il PDB e' dichiarato
+// driver AMD/NVIDIA (`NvOptimusEnablement`, `ags*`), il PDB è dichiarato
 // nell'header ma non spedito. Li' questa strada non puo' funzionare, e si
 // scende al pattern.
 //
@@ -94,7 +94,7 @@ UE::FString* __fastcall Hook_FText_ToString(const UE::FText* self, UE::FString* 
 //
 // La firma dell'hook resta a due argomenti anche qui: usa il VALORE DI RITORNO,
 // non `out`, quindi funziona sia con il ritorno per riferimento sia con quello
-// per valore (dove rdx e' il buffer di ritorno e rax lo ripete).
+// per valore (dove rdx è il buffer di ritorno e rax lo ripete).
 const char* const kFTextToStringSymbols[] = {
     "?ToString@FText@@QEBAAEBVFString@@XZ",
 };
@@ -102,8 +102,8 @@ const char* const kFTextToStringSymbols[] = {
 /// Cerca il simbolo in tutti i moduli caricati. `moduleOut` riceve il nome del
 /// modulo che l'ha fornito; `scanned` quanti moduli sono stati interrogati.
 ///
-/// `scanned` non e' decorativo: senza, un ritorno a zero non distingue «ho
-/// guardato ovunque e non c'e'» da «lo snapshot e' fallito e non ho guardato
+/// `scanned` non è decorativo: senza, un ritorno a zero non distingue «ho
+/// guardato ovunque e non c'è» da «lo snapshot è fallito e non ho guardato
 /// niente». Sono due diagnosi diverse e portano a due indagini diverse.
 uintptr_t ResolveFTextToStringBySymbol(std::string& moduleOut, size_t& scanned) {
     scanned = 0;
@@ -174,7 +174,7 @@ public:
         if (!sym) {
             LogLineA(("[gs-hook/UE] nessun simbolo FText::ToString in "
                       + std::to_string(symScanned)
-                      + " moduli (build monolitico?), provo il pattern\n").c_str());
+                      + " moduli (build monolitico?)\n").c_str());
         }
         if (sym) {
             if (MH_CreateHook(reinterpret_cast<LPVOID>(sym),
@@ -186,58 +186,24 @@ public:
                           + symModule + " — hook installato\n").c_str());
                 return Activation::Activated;
             }
-            LogLineA("[gs-hook/UE] simbolo trovato ma hook fallito (MinHook), provo il pattern\n");
+            LogLineA("[gs-hook/UE] simbolo trovato ma hook fallito (MinHook)\n");
         }
 
-        // 2) PATTERN. Nei build Shipping monolitici non c'è nessun simbolo da
-        //    risolvere, quindi si ricade qui — ed è il caso normale.
-        // Pattern-scan di FText::ToString. UNICITÀ OBBLIGATORIA: PatternScanUnique
-        // ritorna un indirizzo solo se il pattern compare ESATTAMENTE una volta.
+        // 2) PATTERN — non c'è più. La firma UE5 che stava qui è stata
+        //    CONFUTATA il 21/08/2026 contro una verità di riferimento (UE 5.8
+        //    con i simboli): descriveva una dispatch virtuale su `this`, e FText
+        //    non è polimorfico. Dove faceva «1 match unico» l'hook sarebbe
+        //    finito su una funzione qualsiasi. I dettagli e i numeri stanno in
+        //    ue_types.h accanto alla costante, e nel registro.
         //
-        // Perché non basta il primo match (misurato il 30/07/2026 su 5 giochi UE
-        // reali, 71-140 MB, con scripts/ue-validate-ftext-pattern.js): il pattern
-        // UE5 è specifico — 1 solo match su 4 binari su 5 — ma il vecchio pattern
-        // UE4.27 ne faceva 89, 103, 104, 117 e 127, perché è il prologo MSVC
-        // standard di qualunque funzione a due argomenti che salva due registri.
-        // Prendere "il primo di 100" significa agganciare una funzione a caso con
-        // una firma sbagliata: crash, o peggio corruzione heap silenziosa.
-        // Per questo il pattern UE4.27 NON è più in questa lista (vedi ue_types.h)
-        // e il multi-match è un rifiuto, non un ripiego.
-        //
-        // Fallire qui è il caso BENIGNO: il dllmain scende al livello 2 (GDI).
-        size_t matches = 0;
-        uintptr_t addr = GSTranslator::Utils::PatternScanUnique(
-            game, UE::Patterns::FText_ToString_UE5, &matches);
-
-        if (!addr) {
-            if (matches > 1) {
-                // Il conteggio è saturato al cap: oltre quella soglia diciamo
-                // "almeno N", non un numero che non abbiamo misurato.
-                const std::string quanti =
-                    (matches >= GSTranslator::Utils::PATTERN_SCAN_COUNT_CAP)
-                        ? "almeno " + std::to_string(matches)
-                        : std::to_string(matches);
-                const std::string msg =
-                    "[gs-hook/UE] pattern FText::ToString ambiguo: " + quanti +
-                    " match, hook RIFIUTATO (aggancerebbe la funzione sbagliata)\n";
-                LogLineA(msg.c_str());
-            } else {
-                LogLineA("[gs-hook/UE] FText::ToString non trovato (pattern x64 UE5)\n");
-            }
-            return Activation::Failed; // → il dllmain scende a L2 (GDI)
-        }
-
-        if (MH_CreateHook(reinterpret_cast<LPVOID>(addr),
-                          reinterpret_cast<LPVOID>(&Hook_FText_ToString),
-                          reinterpret_cast<LPVOID*>(&Original_FText_ToString)) != MH_OK ||
-            MH_EnableHook(reinterpret_cast<LPVOID>(addr)) != MH_OK) {
-            LogLineA("[gs-hook/UE] hook FText::ToString fallito (MinHook)\n");
-            return Activation::Failed;
-        }
-
-        hookedAddr_ = addr;
-        LogLineW(L"[gs-hook/UE] hook FText::ToString installato\n");
-        return Activation::Activated;
+        //    Finché non esiste una firma ricavata da un binario con i simboli
+        //    E validata sulla versione UE di quel gioco, qui si fallisce: il
+        //    dllmain scende a L2 (GDI). Non tradurre a livello engine è un
+        //    difetto; agganciare la funzione sbagliata in un gioco commerciale
+        //    è un crash.
+        LogLineA("[gs-hook/UE] nessuna firma validata per questa build: "
+                 "hook engine non installato (fallback GDI)\n");
+        return Activation::Failed;
     }
 
     void Deactivate() override {

--- a/unreal-translator/hook-dll/include/ue_types.h
+++ b/unreal-translator/hook-dll/include/ue_types.h
@@ -74,12 +74,43 @@ typedef void (__fastcall* STextBlock_SetText_t)(void* This, const FText& InText)
 // sbagliata → crash, o corruzione heap silenziosa.
 // Prima di aggiungere o cambiare un pattern qui, rimisurare con quello script.
 namespace Patterns {
-    // UE 5.0+ FText::ToString — USABILE.
-    // 1 solo match su 4 binari su 5 (eccezione: Father's Day, 4 match → lì
-    // PatternScanUnique rifiuta e si scende a GDI, che è il comportamento
-    // voluto). La sequenza `test rcx,rcx / je / mov rax,[rcx]` subito dopo
-    // `mov rbx,rcx` discrimina davvero, nonostante il prologo generico.
-    constexpr const char* FText_ToString_UE5 =
+    // ⛔ UE5 FText::ToString — CONFUTATO il 21/08/2026, NON REINSERIRE.
+    //
+    // Era qui dal commit iniziale con la nota «(esempio)»: un'ipotesi mai
+    // verificata. Sembrava buona perché faceva 1 solo match su 4 binari su 5,
+    // ma **unicità non è correttezza**, ed era il match sbagliato.
+    //
+    // La prova, con una verità di riferimento vera: UE 5.8 installato
+    // (`Engine/Binaries/Win64/UnrealEditor-Core.dll`) esporta
+    // `?ToString@FText@@QEBAAEBVFString@@XZ` a RVA 0x3EFA60. I byte lì sono:
+    //
+    //   40 53              push rbx
+    //   48 83 EC 30        sub  rsp, 0x30
+    //   48 8B D9           mov  rbx, rcx
+    //   E8 F2 EE FE FF     call <rebuild>        ← una CALL
+    //   48 8B 0B           mov  rcx, [rbx]       ← carica TextData
+    //   48 85 C9           test rcx, rcx
+    //
+    // Questo pattern si aspetta invece `48 85 C9` (test) SUBITO dopo
+    // `48 8B D9`, e poi `48 8B 01` (mov rax,[rcx]) seguito da una chiamata
+    // attraverso rax: cioè **una dispatch virtuale su `this`**. FText non è
+    // polimorfico — non ha vtable — quindi quella forma non può essere
+    // FText::ToString in nessuna versione UE5. Conferma numerica: il pattern
+    // compare **0 volte** in tutta UnrealEditor-Core.dll, che quella funzione
+    // la contiene di sicuro.
+    //
+    // Dove faceva «1 match unico» (The Skin Stapler, Greed Stays Home, Beyond
+    // Hanwell, Cooking Simulator VR, Oneirophobia…) l'hook si sarebbe
+    // installato su una funzione qualsiasi con firma diversa: esattamente il
+    // crash o la corruzione heap che PatternScanUnique doveva prevenire. Il
+    // caso «ambiguo» di Father's Day era il meno pericoloso, non il più.
+    //
+    // Non è stato sostituito con una firma nuova perché quella ricavata da
+    // UE 5.8 (`40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 85 C9 75 ??`)
+    // fa 6 match sulla stessa DLL e **0** su tutti i 18 Shipping installati:
+    // il prologo cambia fra versioni UE, quindi una firma va ricavata E
+    // validata sulla versione di quel gioco. Vedi il registro.
+    constexpr const char* FText_ToString_UE5_CONFUTATO =
         "40 53 48 83 EC ?? 48 8B D9 48 85 C9 74 ?? 48 8B 01";
 
     // ⛔ UE 4.27 FText::ToString — INUTILIZZABILE, NON REINSERIRE fra i pattern


### PR DESCRIPTION
The signature used to hook `FText::ToString` on Unreal games **did not describe that function**. Where it matched uniquely — and so where the code trusted it and installed the hook — it would have hooked an arbitrary function. Father's Day, the "ambiguous" case that got refused, was the safer of the two outcomes.

## The ground truth was on this machine all along

A UE 5.8 install in `C:\Program Files\Epic Games`, with 566 engine DLLs. There the symbols exist, so you can ask *which* function is the right one instead of guessing:

```
UnrealEditor-Core.dll → ?ToString@FText@@QEBAAEBVFString@@XZ → RVA 0x3EFA60
```

The bytes there:

```text
40 53              push rbx
48 83 EC 30        sub  rsp, 0x30
48 8B D9           mov  rbx, rcx
E8 F2 EE FE FF     call <rebuild>        ← a CALL
48 8B 0B           mov  rcx, [rbx]       ← loads TextData
48 85 C9           test rcx, rcx
```

The pattern in use was `40 53 48 83 EC ?? 48 8B D9 48 85 C9 74 ?? 48 8B 01` — it expects `test rcx,rcx` *immediately* after `mov rbx,rcx`, then `mov rax,[rcx]` followed by a call through `rax`: a **virtual dispatch on `this`**. `FText` is not polymorphic and has no vtable, so that shape cannot be its `ToString` in any UE5.

The count closes it: the pattern occurs **zero times** in the whole of `UnrealEditor-Core.dll`, which certainly contains the function.

## Why not just derive a new pattern

Measured across the 18 installed Shipping binaries: the old pattern hits 1–4 everywhere. A signature derived from the 5.8 symbol hits **6** in that DLL and **0** in all 18 games. The prologue changes between UE versions, so a signature must be derived *and* validated against the version of the game it will run on — not carried across.

## What changes

The constant is renamed `FText_ToString_UE5_CONFUTATO`, so anyone reaching for it fails to compile and reads why. `source_unreal_ftext.cpp` no longer pattern-scans at all; symbol resolution remains and serves non-monolithic builds. Commercial games now fail with an explicit message and fall to GDI.

Not translating at engine level is a shortcoming. Hooking the wrong function in a shipping game is a crash, or silent heap corruption.

## The trap, recorded

"One match" looks like proof the pattern is right, and it is not: it measures **ambiguity**, not **correctness**. The two only separate against a ground truth, and a ground truth has to be obtained — a binary with symbols from the same family. Without one you can verify a signature does not catch too much, never that it catches the right thing.

This pattern had been in the repo since the initial commit, annotated "(esempio)", and survived a review that measured its uniqueness on real games without being able to measure its correctness.

The entry also records the method for next time: install the UE version the game uses, resolve the symbol in its `UnrealEditor-Core.dll`, read the bytes there, derive the signature from those, and only then count it on the game. The counting tool already exists: `scripts/ue-validate-ftext-pattern.js --exe <path> --dump`.

## Verification

Father's Day, real injection: 147 modules scanned, no symbol, explicit refusal, GDI fallback activates, game responsive. Both architectures rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
