### PR TITLE
Hook FText::ToString for real: validated signature, and the translation goes back in

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -559,6 +559,73 @@ bug in entrambe.
 per attribuirlo all'hook. Avviato **senza** iniettare, esce da solo lo stesso:
 vuole Steam. Prima di dare la colpa al proprio codice, si prova il caso base.
 
+### La traduzione rientra nel gioco: sostituzione in-place e crescita del buffer
+
+**Il fatto.** `FText::ToString` restituisce un riferimento alla `FString` interna
+di UE: sovrascriverla traduce il testo davvero, a schermo. Se la traduzione non
+entra in `ArrayMax` si fa crescere il buffer con **`FMemory::Realloc`** — non con
+`malloc` o `new`, perché a liberare quel puntatore sarà UE col proprio
+allocatore, e un allocatore diverso corrompe l'heap alla prima free.
+
+**Il margine di UE non è affidabile.** Misurato su Father's Day:
+
+| stringa | ArrayNum | ArrayMax | margine |
+|---|---|---|---|
+| `English` | 8 | 8 | **nessuno** |
+| `Russian` | 8 | 8 | **nessuno** |
+| `Exit game` | 10 | 16 | 6 slot |
+
+Due casi su tre hanno `ArrayMax == ArrayNum`. Contare sullo slack di UE non
+funziona: l'italiano è mediamente più lungo dell'inglese, e senza `Realloc` una
+buona parte delle traduzioni verrebbe scartata in silenzio.
+
+**La firma di `FMemory::Realloc`.** Ricavata col metodo della voce precedente —
+`UnrealGame-Win64-Shipping.exe` di UE 5.8, simbolo a RVA 0x12D29F0:
+
+```text
+48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 20 48 8B F1 41 8B D8 48 8B 0D ?? ?? ?? ?? 48 8B FA 48 85 C9 75 ??
+```
+
+Il prologo iniziale da solo sarebbe generico — è quello che rese inutilizzabile
+la firma UE4.27 — ma `mov rsi,rcx / mov ebx,r8d / mov rcx,[rip+GMalloc]`
+discrimina. **1 match esatto su tutti e 15** gli Shipping installati, unica e
+all'indirizzo giusto sul riferimento, verificata a inizio funzione su The Skin
+Stapler (0x123A3A0) e Father's Day (0xD94DD0).
+
+**Prova sul campo.** Cache pre-seedata con traduzioni deliberatamente più lunghe
+del buffer, iniezione reale in Father's Day:
+
+```text
+SUBST(grow): English   -> Inglese (lingua lunga)             [len=22 ArrayNum=8  ArrayMax=8]
+SUBST:       Russian   -> Russo                              [len=5  ArrayNum=8  ArrayMax=8]
+SUBST(grow): Exit game -> Esci dal gioco e torna al desktop   [len=33 ArrayNum=10 ArrayMax=16]
+```
+
+22 caratteri in un buffer da 8 e 33 in uno da 16: entrambi cresciuti. Soak di
+90 s campionato ogni 15: UI sempre responsiva, RAM stabile a ~350 MB, handle
+fermi a ~1535. Nessun segno di heap corrotto.
+
+**La trappola, e perché il primo tentativo sembrava un crash.** Con la cache
+pre-seedata il gioco moriva e non compariva nessuna riga `SUBST`: sembrava che
+la sostituzione lo uccidesse. Erano due cose diverse, entrambe da verificare
+prima di concludere. (1) Il gioco esce da solo anche **senza** iniezione, a
+volte: il caso base va sempre provato. (2) La cache non veniva letta affatto —
+il messaggio «cache pre-seedata» lo stampa il dllmain perché la env var è
+impostata, **non** perché il caricamento sia riuscito. Il magic del formato GSTC
+va scritto come u32 little-endian `0x47535443`, che su disco dà i byte `CTSG`;
+scrivendo `GSTC` il file viene rifiutato in silenzio. L'indizio era nel dump di
+`gs-hook/testapp/test-cache.gstc`, che comincia proprio con `CTSG`.
+
+**Il vero limite rimasto è un altro.** Su UE la stessa stringa raramente passa
+due volte da `ToString`: la display string resta in cache dentro l'`FTextData`.
+Il percorso fire-and-forget — che chiede la traduzione al primo avvistamento e
+la usa dal secondo — quindi **non scatta**. Perché la traduzione compaia serve
+che sia già nella cache locale della DLL quando il testo viene convertito: cioè
+il dizionario va pre-caricato (`GS_HOOK_CACHE`, o la cache persistita da una
+sessione precedente). È il motivo per cui in queste prove è stata usata una
+cache seminata, e va risolto prima di poter promettere traduzione "al primo
+avvio".
+
 ---
 
 ## Come si aggiunge una voce

--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -487,6 +487,78 @@ gioco, risolvere il simbolo nella sua `UnrealEditor-Core.dll`, leggere i byte
 lì, ricavare la firma da quelli, e solo allora contarla sul gioco. Lo strumento
 per contare esiste già: `scripts/ue-validate-ftext-pattern.js --exe <path> --dump`.
 
+### La firma giusta di `FText::ToString` si ricava da un binario Shipping col PDB
+
+**Il fatto.** UE spedisce, dentro l'installazione dell'engine,
+`Engine/Binaries/Win64/UnrealGame-Win64-Shipping.exe` **con il suo PDB**
+(150 MB). È Shipping e monolitico come i giochi commerciali, quindi il codice
+generato è della stessa famiglia — a differenza di `UnrealEditor-Core.dll`, che
+è Development. È lì che si va a leggere com'è fatta davvero la funzione.
+
+**Come.** DbgHelp (`SymLoadModuleEx` + `SymEnumSymbols` con maschera
+`FText::ToString`) la risolve a **RVA 0x1302480** su UE 5.8. I byte:
+
+```text
+40 53              push rbx
+48 83 EC 20        sub  rsp, 0x20
+48 8B D9           mov  rbx, rcx
+E8 A2 D0 00 00     call <rebuild>            ← rel32, wildcard
+48 8B 0B           mov  rcx, [rbx]           ← TextData
+48 8B 01           mov  rax, [rcx]           ← vtable
+48 83 C4 20        add  rsp, 0x20
+5B                 pop  rbx
+48 FF 60 28        jmp  [rax+0x28]           ← tail-call GetDisplayString
+```
+
+Ventinove byte, e la **tail-call finale** è ciò che li rende specifici. Firma:
+
+```text
+40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??
+```
+
+Wildcard sull'immediato di `sub`/`add`, sul `rel32` della `call` e sullo slot
+della vtable — che cambia per gioco: 0x28 sul riferimento, 0x10 su Father's Day,
+0x20 su The Skin Stapler.
+
+**Misura.** 1 match esatto su **14 giochi su 15** (UE 5.5, 5.6, 5.8), unica e
+all'indirizzo giusto anche sul riferimento. Verificata all'inizio di funzione
+(preceduta da padding `CC`) su The Skin Stapler (UE 5.6, RVA 0x1269100) e
+Father's Day (RVA 0xDD3FC0). Il conteggio che convince più di tutti lo dà
+`scripts/ue-validate-ftext-pattern.js`: **397 chiamanti** su The Skin Stapler,
+contro gli 1-4 dei candidati della vecchia firma, che lo script stesso bollava
+«pochi per FText::ToString».
+
+**Prova sul campo (Father's Day, 21/08/2026).** Iniezione reale con il server di
+prova in ascolto:
+
+```text
+[gs-hook/UE] hook FText::ToString installato (pattern)
+[gs-hook] sorgente attiva: Unreal/FText (livello 1)
+```
+
+e lato server il testo vero del menu del gioco:
+`LANGUAGE SELECTION`, `English`, `Russian`, `Exit game`, `Yes`, `True`, `False`.
+Gioco responsivo, 119 s di CPU, nessun crash.
+
+**La trappola.** Non era la versione UE la variabile che contava, era la
+**configurazione di build**. Una firma ricavata dalla `UnrealEditor-Core.dll`
+(Development) fa 0 match su tutti i 18 Shipping installati; quella ricavata dal
+binario Shipping ne fa 1 quasi ovunque, attraversando tre versioni UE. Cercare
+«la stessa versione dell'engine» era la pista sbagliata: serviva la stessa
+*configurazione*.
+
+**Un controllo che ha smascherato un errore mio.** Due script indipendenti
+davano risultati opposti sullo stesso file — 1 match contro 0. Avevo scompattato
+l'header di sezione PE nell'ordine sbagliato (`SizeOfRawData` e
+`PointerToRawData` sono in quell'ordine, non l'inverso) e leggevo dall'offset
+sbagliato: sembrava «la firma non c'è», era lo script rotto. Quando due misure
+della stessa cosa non concordano, prima di scegliere quale credere si cerca il
+bug in entrambe.
+
+**Un altro controllo, sul gioco.** The Skin Stapler moriva all'iniezione e stavo
+per attribuirlo all'hook. Avviato **senza** iniettare, esce da solo lo stesso:
+vuole Steam. Prima di dare la colpa al proprio codice, si prova il caso base.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_unreal_ftext.cpp
+++ b/gs-hook/src/sources/source_unreal_ftext.cpp
@@ -11,20 +11,21 @@
 // incluso da gs-hook via CMake. Il pattern-scan non serve più: vedi LIMITI.
 //
 // LIMITI NOTI (aggiornati 21/08/2026):
-//   • Si aggancia SOLO per SIMBOLO, quindi in pratica solo su build non
-//     monolitici (editor, giochi modulari). Sui build Shipping — la norma
-//     commerciale — non c'è nessun simbolo UE e questa sorgente non aggancia:
+//   • Due strade, in ordine: SIMBOLO (deterministico, ma esiste solo sui
+//     build non monolitici) e poi la firma di byte UE5, ricavata da un
+//     binario Shipping con PDB e misurata su 15 giochi. Se nessuna aggancia,
 //     Activate ritorna Failed e si scende a L2 (GDI).
-//   • Non esiste più un pattern di ripiego. Quello UE4.2x era stato rimosso il
-//     30/07/2026 (89-127 match); quello UE5 è stato CONFUTATO il 21/08/2026
-//     contro UE 5.8 con i simboli — descriveva una dispatch virtuale su
-//     `this`, e FText non ha vtable. Dettagli e numeri in ue_types.h.
+//   • Non c'è una firma UE4.2x: quella provata faceva 89-127 match (rimossa il
+//     30/07/2026), e la vecchia firma UE5 è stata CONFUTATA il 21/08/2026 —
+//     descriveva una dispatch virtuale su `this`, e FText non ha vtable.
+//     Entrambe restano documentate in ue_types.h come cosa NON funziona.
 //   • Sostituzione in-place SOLO se la traduzione entra nel buffer già allocato
 //     da UE (FString::ArrayMax). Espanderlo richiede l'allocatore UE
 //     (FMemory::Realloc) → TODO.
 //
 #include "text_source.h"
-#include "ue_types.h"   // UE::FString, UE::FText
+#include "ue_types.h"   // UE::FString, UE::FText, UE::Patterns::FText_ToString_UE5
+#include "utils.h"      // GSTranslator::Utils::PatternScanUnique
 #include "gs_log.h"     // log unificato gs-hook (%TEMP%\gs-hook.log)
 #include <Windows.h>
 #include <TlHelp32.h>
@@ -189,21 +190,49 @@ public:
             LogLineA("[gs-hook/UE] simbolo trovato ma hook fallito (MinHook)\n");
         }
 
-        // 2) PATTERN — non c'è più. La firma UE5 che stava qui è stata
-        //    CONFUTATA il 21/08/2026 contro una verità di riferimento (UE 5.8
-        //    con i simboli): descriveva una dispatch virtuale su `this`, e FText
-        //    non è polimorfico. Dove faceva «1 match unico» l'hook sarebbe
-        //    finito su una funzione qualsiasi. I dettagli e i numeri stanno in
-        //    ue_types.h accanto alla costante, e nel registro.
+        // 2) PATTERN. Nei build Shipping monolitici non c'è nessun simbolo da
+        //    risolvere, quindi si ricade qui — ed è il caso normale.
         //
-        //    Finché non esiste una firma ricavata da un binario con i simboli
-        //    E validata sulla versione UE di quel gioco, qui si fallisce: il
-        //    dllmain scende a L2 (GDI). Non tradurre a livello engine è un
-        //    difetto; agganciare la funzione sbagliata in un gioco commerciale
-        //    è un crash.
-        LogLineA("[gs-hook/UE] nessuna firma validata per questa build: "
-                 "hook engine non installato (fallback GDI)\n");
-        return Activation::Failed;
+        //    La firma NON è indovinata: è letta dai byte di FText::ToString
+        //    risolto col PDB su UnrealGame-Win64-Shipping.exe di UE 5.8, che è
+        //    Shipping e monolitico come i giochi. Misurata su 15 giochi (UE 5.5,
+        //    5.6, 5.8): 1 match esatto su 14. Dettagli in ue_types.h.
+        //
+        //    UNICITÀ COMUNQUE OBBLIGATORIA: PatternScanUnique ritorna un
+        //    indirizzo solo se il pattern compare esattamente una volta. Una
+        //    firma validata oggi può diventare ambigua su una build futura, e
+        //    in quel caso si rifiuta e si scende a GDI. Fallire qui è il caso
+        //    BENIGNO; agganciare la funzione sbagliata no.
+        size_t matches = 0;
+        uintptr_t addr = GSTranslator::Utils::PatternScanUnique(
+            game, UE::Patterns::FText_ToString_UE5, &matches);
+
+        if (!addr) {
+            if (matches > 1) {
+                const std::string quanti =
+                    (matches >= GSTranslator::Utils::PATTERN_SCAN_COUNT_CAP)
+                        ? "almeno " + std::to_string(matches)
+                        : std::to_string(matches);
+                LogLineA(("[gs-hook/UE] pattern FText::ToString ambiguo: " + quanti +
+                          " match, hook RIFIUTATO (aggancerebbe la funzione sbagliata)\n").c_str());
+            } else {
+                LogLineA("[gs-hook/UE] FText::ToString non trovato su questa build "
+                         "(firma UE5 Shipping)\n");
+            }
+            return Activation::Failed; // → il dllmain scende a L2 (GDI)
+        }
+
+        if (MH_CreateHook(reinterpret_cast<LPVOID>(addr),
+                          reinterpret_cast<LPVOID>(&Hook_FText_ToString),
+                          reinterpret_cast<LPVOID*>(&Original_FText_ToString)) != MH_OK ||
+            MH_EnableHook(reinterpret_cast<LPVOID>(addr)) != MH_OK) {
+            LogLineA("[gs-hook/UE] hook FText::ToString fallito (MinHook)\n");
+            return Activation::Failed;
+        }
+
+        hookedAddr_ = addr;
+        LogLineW(L"[gs-hook/UE] hook FText::ToString installato (pattern)\n");
+        return Activation::Activated;
     }
 
     void Deactivate() override {

--- a/gs-hook/src/sources/source_unreal_ftext.cpp
+++ b/gs-hook/src/sources/source_unreal_ftext.cpp
@@ -41,6 +41,14 @@ TranslateFn g_translate = nullptr;
 using FText_ToString_t = UE::FString* (__fastcall*)(const UE::FText*, UE::FString*);
 FText_ToString_t Original_FText_ToString = nullptr;
 
+// Allocatore di UE. Serve SOLO per far crescere il buffer di una FString quando
+// la traduzione non ci sta: il puntatore risultante verra' liberato da UE con il
+// proprio allocatore, quindi deve essere UE stessa ad allocarlo. Con malloc o
+// new si corromperebbe l'heap alla prima free.
+//   void* FMemory::Realloc(void* Original, SIZE_T Count, uint32 Alignment)
+using FMemory_Realloc_t = void* (__fastcall*)(void*, size_t, uint32_t);
+FMemory_Realloc_t g_ueRealloc = nullptr;
+
 // Hook su FText::ToString. `out` è la FString che UE riempie col testo: dopo aver
 // lasciato lavorare l'originale, leggiamo il testo, lo traduciamo e lo
 // riscriviamo in-place nel buffer di UE (se ci sta).
@@ -61,13 +69,43 @@ UE::FString* __fastcall Hook_FText_ToString(const UE::FText* self, UE::FString* 
                 // In-place SOLO se la traduzione (incluso il NUL) entra nel buffer
                 // già allocato da UE. Altrimenti la lasciamo invariata: scrivere
                 // oltre ArrayMax corromperebbe l'heap di UE.
-                if (static_cast<int32_t>(t.size() + 1) <= result->ArrayMax) {
+                // I numeri del buffer finiscono nel log in ENTRAMBI i rami:
+                // servono a sapere quanto margine lascia UE, cioe' quanto spesso
+                // il vincolo morde davvero. Senza, "non sostituita" non dice se
+                // mancava un carattere o cinquanta.
+                const std::wstring dims =
+                    L" [len=" + std::to_wstring(t.size()) +
+                    L" ArrayNum=" + std::to_wstring(result->ArrayNum) +
+                    L" ArrayMax=" + std::to_wstring(result->ArrayMax) + L"]";
+
+                const int32_t needed = static_cast<int32_t>(t.size() + 1); // col NUL
+
+                if (needed <= result->ArrayMax) {
                     wcscpy_s(result->Data, static_cast<size_t>(result->ArrayMax), t.c_str());
-                    result->ArrayNum = static_cast<int32_t>(t.size() + 1); // include il NUL
-                    LogLineW(L"[gs-hook/UE] SUBST: " + original + L" -> " + t + L"\n");
+                    result->ArrayNum = needed;
+                    LogLineW(L"[gs-hook/UE] SUBST: " + original + L" -> " + t + dims + L"\n");
+                } else if (g_ueRealloc) {
+                    // Non ci sta: chiedi a UE un buffer piu' grande. Deve essere
+                    // il suo allocatore, perche' sara' lui a liberarlo.
+                    void* grown = g_ueRealloc(result->Data,
+                                              static_cast<size_t>(needed) * sizeof(wchar_t),
+                                              0 /* DEFAULT_ALIGNMENT */);
+                    if (grown) {
+                        result->Data = static_cast<wchar_t*>(grown);
+                        result->ArrayMax = needed;
+                        wcscpy_s(result->Data, static_cast<size_t>(needed), t.c_str());
+                        result->ArrayNum = needed;
+                        LogLineW(L"[gs-hook/UE] SUBST(grow): " + original + L" -> " + t
+                                 + dims + L"\n");
+                    } else {
+                        // Realloc fallita: la FString resta quella di prima e
+                        // valida — Realloc non libera l'originale se non riesce.
+                        LogLineW(L"[gs-hook/UE] (non sostituita: Realloc fallita) "
+                                 + original + dims + L"\n");
+                    }
                 } else {
-                    LogLineW(L"[gs-hook/UE] (non sostituita: buffer UE troppo piccolo) "
-                             + original + L"\n");
+                    LogLineW(L"[gs-hook/UE] (non sostituita: buffer piccolo e allocatore "
+                             L"UE non risolto) " + original + dims + L"\n");
                 }
             }
         }
@@ -232,6 +270,22 @@ public:
 
         hookedAddr_ = addr;
         LogLineW(L"[gs-hook/UE] hook FText::ToString installato (pattern)\n");
+
+        // Allocatore UE: se non si trova, la sostituzione resta possibile solo
+        // per le traduzioni che entrano nel buffer esistente. Non e' un motivo
+        // per rinunciare all'hook, quindi qui non si fallisce.
+        size_t reallocMatches = 0;
+        if (uintptr_t ra = GSTranslator::Utils::PatternScanUnique(
+                game, UE::Patterns::FMemory_Realloc, &reallocMatches)) {
+            g_ueRealloc = reinterpret_cast<FMemory_Realloc_t>(ra);
+            LogLineA("[gs-hook/UE] FMemory::Realloc risolto: le traduzioni piu' lunghe "
+                     "dell'originale possono crescere il buffer\n");
+        } else {
+            LogLineA(("[gs-hook/UE] FMemory::Realloc non risolto (" +
+                      std::to_string(reallocMatches) +
+                      " match): solo traduzioni che entrano nel buffer\n").c_str());
+        }
+
         return Activation::Activated;
     }
 

--- a/scripts/ue-validate-ftext-pattern.js
+++ b/scripts/ue-validate-ftext-pattern.js
@@ -59,8 +59,14 @@ const path = require('path');
 const PATTERNS = {
   FText_ToString_UE427_INUTILIZZABILE:
     '48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B FA 48 8B F1',
-  FText_ToString_UE5:
+  // CONFUTATA il 21/08/2026: descriveva una dispatch virtuale su `this`, e
+  // FText non ha vtable. Resta qui per poter rimisurare cosa NON funziona.
+  FText_ToString_UE5_CONFUTATA:
     '40 53 48 83 EC ?? 48 8B D9 48 85 C9 74 ?? 48 8B 01',
+  // In uso. Ricavata dai byte di FText::ToString risolto col PDB su
+  // UnrealGame-Win64-Shipping.exe (UE 5.8, Shipping monolitico come i giochi).
+  FText_ToString_UE5:
+    '40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??',
 };
 
 const MAX_DEPTH = 6;

--- a/unreal-translator/hook-dll/include/ue_types.h
+++ b/unreal-translator/hook-dll/include/ue_types.h
@@ -106,6 +106,38 @@ namespace Patterns {
         "40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 "
         "48 83 C4 ?? 5B 48 FF 60 ??";
 
+    // FMemory::Realloc — USABILE. Serve a far CRESCERE il buffer di una FString
+    // quando la traduzione non entra in ArrayMax. Scrivere oltre corromperebbe
+    // l'heap; allocare con `new`/malloc pure, perché UE libererà quel puntatore
+    // con il PROPRIO allocatore. L'unica via sicura è chiedere a UE.
+    //
+    // Ricavata come quella di ToString, dal binario Shipping con PDB:
+    // `FMemory::Realloc` sta a RVA 0x12D29F0 su UE 5.8. Firma C++:
+    //   void* FMemory::Realloc(void* Original, SIZE_T Count, uint32 Alignment)
+    // (rcx = Original, rdx = Count, r8d = Alignment; 0 = DEFAULT_ALIGNMENT)
+    //
+    //   48 89 5C 24 08     mov  [rsp+8], rbx
+    //   48 89 74 24 10     mov  [rsp+0x10], rsi
+    //   57                 push rdi
+    //   48 83 EC 20        sub  rsp, 0x20
+    //   48 8B F1           mov  rsi, rcx          ← Original
+    //   41 8B D8           mov  ebx, r8d          ← Alignment
+    //   48 8B 0D ?? ?? ?? ?? mov rcx, [rip+…]     ← GMalloc, wildcard
+    //   48 8B FA           mov  rdi, rdx          ← Count
+    //   48 85 C9           test rcx, rcx          ← GMalloc già creato?
+    //   75 ??              jne  …
+    //
+    // Il prologo iniziale da solo sarebbe generico (è quello che rese
+    // inutilizzabile la firma UE4.27): a discriminare è la sequenza
+    // `mov rsi,rcx / mov ebx,r8d / mov rcx,[rip+GMalloc]`.
+    //
+    // MISURATA: 1 match esatto su **tutti e 15** gli Shipping installati, e
+    // unica all'indirizzo giusto sul riferimento. Verificata all'inizio di
+    // funzione su The Skin Stapler (0x123A3A0) e Father's Day (0xD94DD0).
+    constexpr const char* FMemory_Realloc =
+        "48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 20 48 8B F1 41 8B D8 "
+        "48 8B 0D ?? ?? ?? ?? 48 8B FA 48 85 C9 75 ??";
+
     // ⛔ UE5 FText::ToString — CONFUTATO il 21/08/2026, NON REINSERIRE.
     //
     // Era qui dal commit iniziale con la nota «(esempio)»: un'ipotesi mai

--- a/unreal-translator/hook-dll/include/ue_types.h
+++ b/unreal-translator/hook-dll/include/ue_types.h
@@ -74,6 +74,38 @@ typedef void (__fastcall* STextBlock_SetText_t)(void* This, const FText& InText)
 // sbagliata → crash, o corruzione heap silenziosa.
 // Prima di aggiungere o cambiare un pattern qui, rimisurare con quello script.
 namespace Patterns {
+    // UE5 FText::ToString — USABILE. Ricavata da una VERITÀ DI RIFERIMENTO il
+    // 21/08/2026, non indovinata: UE 5.8 spedisce
+    // `Engine/Binaries/Win64/UnrealGame-Win64-Shipping.exe` **col suo PDB**.
+    // È Shipping e monolitico come i giochi commerciali — a differenza della
+    // `UnrealEditor-Core.dll`, che è Development e genera codice diverso.
+    // DbgHelp risolve lì `FText::ToString` a RVA 0x1302480, e i byte sono:
+    //
+    //   40 53              push rbx
+    //   48 83 EC 20        sub  rsp, 0x20
+    //   48 8B D9           mov  rbx, rcx
+    //   E8 A2 D0 00 00     call <rebuild>            ← rel32, wildcard
+    //   48 8B 0B           mov  rcx, [rbx]           ← TextData
+    //   48 8B 01           mov  rax, [rcx]           ← vtable
+    //   48 83 C4 20        add  rsp, 0x20
+    //   5B                 pop  rbx
+    //   48 FF 60 28        jmp  [rax+0x28]           ← tail-call GetDisplayString
+    //
+    // 29 byte, con una tail-call finale che è ciò che la rende specifica.
+    // Wildcard su: l'immediato di sub/add, il rel32 della call, e lo slot della
+    // vtable (0x28 sul riferimento, 0x10 su Father's Day: cambia per gioco).
+    //
+    // MISURATA su 15 Shipping installati (UE 5.5, 5.6 e 5.8): **1 match esatto
+    // su 14**, incluso The Skin Stapler (UE 5.6, RVA 0x1269100) e Father's Day
+    // (RVA 0xDD3FC0), entrambi verificati all'inizio di una funzione (preceduti
+    // da padding CC). Unica e all'indirizzo giusto anche sul riferimento.
+    // L'unico a zero è ProjectAIDA, che quindi cadrà su GDI: il caso benigno.
+    //
+    // Prima di toccarla, rimisurare con scripts/ue-validate-ftext-pattern.js.
+    constexpr const char* FText_ToString_UE5 =
+        "40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 "
+        "48 83 C4 ?? 5B 48 FF 60 ??";
+
     // ⛔ UE5 FText::ToString — CONFUTATO il 21/08/2026, NON REINSERIRE.
     //
     // Era qui dal commit iniziale con la nota «(esempio)»: un'ipotesi mai


### PR DESCRIPTION
#90 established that the old signature was wrong and wrote down the method to derive a correct one. This runs that method, and the chain now reaches engine level on a commercial game for the first time.

## The ground truth that mattered

UE ships `Engine/Binaries/Win64/UnrealGame-Win64-Shipping.exe` **with its own 150 MB PDB**. It is Shipping and monolithic like commercial games, so its codegen is the same family — unlike `UnrealEditor-Core.dll`, which is Development.

DbgHelp resolves `FText::ToString` there at RVA `0x1302480`. The function is 29 bytes ending in a tail-call:

```text
40 53              push rbx
48 83 EC 20        sub  rsp, 0x20
48 8B D9           mov  rbx, rcx
E8 A2 D0 00 00     call <rebuild>            ← rel32, wildcard
48 8B 0B           mov  rcx, [rbx]           ← TextData
48 8B 01           mov  rax, [rcx]           ← vtable
48 83 C4 20        add  rsp, 0x20
5B                 pop  rbx
48 FF 60 28        jmp  [rax+0x28]           ← tail-call GetDisplayString
```

The tail-call is what makes it specific. Wildcards go on the `sub`/`add` immediates, the `call`'s rel32, and the vtable slot — which varies per game: `0x28` on the reference, `0x10` on Father's Day, `0x20` on The Skin Stapler.

## Measured

**1 match exactly, on 14 of 15** installed Shipping binaries across UE 5.5, 5.6 and 5.8 — and unique at the right address on the reference itself. Function-start alignment confirmed on The Skin Stapler (`0x1269100`) and Father's Day (`0xDD3FC0`).

The number that settles it comes from the project's own validator: **397 callers** on The Skin Stapler, against the 1–4 of the refuted signature's candidates — which that same script already flagged as *"pochi per FText::ToString"*.

## Proven in the game, not just on disk

Injected into Father's Day with the pipe server listening:

```text
[gs-hook/UE] hook FText::ToString installato (pattern)
[gs-hook] sorgente attiva: Unreal/FText (livello 1)
```

and the server received the game's real menu text:

```text
IMPARATA → "LANGUAGE SELECTION"   "English"   "Russian"
IMPARATA → "Exit game"   "Yes"   "True"   "False"
```

Game responsive, 119 s CPU, 368 MB, no crash.

## The trap, recorded

The variable that mattered was **not the UE version but the build configuration**. A signature taken from the editor DLL matches zero of the 18 installed Shipping binaries; one taken from the Shipping binary matches almost all of them, across three UE versions. Chasing "the same engine version" was the wrong lead.

Two more entries earned the hard way: two of my own scripts disagreed on the same file — 1 match against 0 — because one unpacked the PE section header with `SizeOfRawData` and `PointerToRawData` swapped and read from the wrong offset. And The Skin Stapler dying on injection turned out to exit on its own without Steam; running the base case first would have saved the suspicion.

## Still open

No `SUBST` lines. The hook captures and translates, but in-place substitution only fires when the translation fits UE's already-allocated buffer (`ArrayMax`), and `[IT] English` is longer than `English`. Text now leaves the game and reaches the dictionary; it does not yet go back in. That is the next link, and it is an allocation problem, not a symbol-finding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: the translation goes back in

`FText::ToString` returns a reference to UE's internal `FString`, so overwriting it translates the text on screen for real. When the translation does not fit `ArrayMax`, the buffer now grows through **`FMemory::Realloc`** — not `malloc` or `new`, because UE will free that pointer with its own allocator and a mismatched one corrupts the heap on the first free.

## UE's slack is not something to rely on

| string | ArrayNum | ArrayMax | room |
|---|---|---|---|
| `English` | 8 | 8 | **none** |
| `Russian` | 8 | 8 | **none** |
| `Exit game` | 10 | 16 | 6 slots |

Two of three had none. Italian runs longer than English, so without `Realloc` a good share of translations would be dropped silently.

## The Realloc signature

Same method as the first commit — Shipping binary with a PDB, symbol at RVA `0x12D29F0`:

```text
48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 20 48 8B F1 41 8B D8 48 8B 0D ?? ?? ?? ?? 48 8B FA 48 85 C9 75 ??
```

Its opening prologue alone would be generic — the same trap that made the UE4.27 signature unusable — but `mov rsi,rcx / mov ebx,r8d / mov rcx,[rip+GMalloc]` discriminates: **1 match on all 15** installed Shipping binaries, unique and at the right address on the reference.

## Proven in the game

```text
SUBST(grow): English   -> Inglese (lingua lunga)            [len=22 ArrayNum=8  ArrayMax=8]
SUBST:       Russian   -> Russo                             [len=5  ArrayNum=8  ArrayMax=8]
SUBST(grow): Exit game -> Esci dal gioco e torna al desktop  [len=33 ArrayNum=10 ArrayMax=16]
```

22 characters into an 8-slot buffer, 33 into a 16-slot one, both grown. A **90-second soak** sampled every 15 s kept the UI responsive, RAM steady at ~350 MB and handles at ~1535 — no sign of a damaged heap.

## Two traps recorded

The first attempt looked like the substitution was killing the game. It was not. The game sometimes exits on its own **without** injection — the base case is worth running first. And the cache was never being read: `dllmain` prints *"cache pre-seedata"* because the env var is set, **not** because loading succeeded. The GSTC magic must be written as the little-endian u32 `0x47535443`, which lands on disk as the bytes `CTSG`; writing `GSTC` gets the file rejected silently. The evidence was in the project's own `test-cache.gstc`, which starts with `CTSG`.

## The real remaining limit

On UE the same string rarely passes through `ToString` twice — the display string stays cached inside the `FTextData` — so the fire-and-forget path never fires. The translation has to already be in the DLL's local cache by the time the text is converted, which is why these runs used a seeded one. Pre-loading the dictionary before injection is the next link, and it is written down.
