### PR TITLE
Hand the dictionary to gs-hook before injecting, not during

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -626,6 +626,60 @@ sessione precedente). È il motivo per cui in queste prove è stata usata una
 cache seminata, e va risolto prima di poter promettere traduzione "al primo
 avvio".
 
+### Su Unreal il dizionario va consegnato PRIMA dell'iniezione, non durante
+
+**Il fatto.** Su UE la stessa stringa passa da `FText::ToString` **una volta
+sola**: la display string resta in cache dentro l'`FTextData`. Il percorso
+fire-and-forget della DLL — chiedi la traduzione al primo avvistamento, usala
+dal secondo — quindi non scatta mai, e il testo resta in lingua originale per
+quanto bene funzionino pipe, dizionario e sostituzione. La traduzione deve
+essere già nella cache locale **quando il testo viene convertito**.
+
+**La cura.** GameStringer scrive la coppia di lingue attiva in
+`%APPDATA%\GameStringer\gs-hook-cache.gstc` prima di lanciare l'injector
+(`preload_dictionary()` in `commands/gs_hook_injector.rs`), e la DLL cerca quel
+percorso all'avvio quando `GS_HOOK_CACHE` non è impostata
+(`gs-hook/src/dllmain.cpp`).
+
+**Perché un percorso convenuto e non una env var.** Una variabile d'ambiente
+non si può impostare in un processo **già avviato**, e l'iniezione avviene per
+definizione su un gioco in esecuzione. `GS_HOOK_CACHE` resta come override
+esplicito per i test senza backend.
+
+**Prova sul campo (Father's Day, 21/08/2026).** Senza `GS_HOOK_CACHE`, con il
+solo file nel percorso convenuto:
+
+```text
+[gs-hook] dizionario pre-caricato: 7 voci da …\GameStringer\gs-hook-cache.gstc
+[gs-hook/UE] hook FText::ToString installato (pattern)
+[gs-hook/UE] SUBST:       LANGUAGE SELECTION -> SELEZIONE LINGUA  [len=16 ArrayNum=19 ArrayMax=24]
+[gs-hook/UE] SUBST:       English            -> Inglese
+[gs-hook/UE] SUBST:       Russian            -> Russo
+[gs-hook/UE] SUBST(grow): Exit game          -> Esci dal gioco e torna al desktop
+```
+
+Quattro sostituzioni al **primo** avvistamento, una delle quali ha fatto
+crescere il buffer. È la catena completa: dizionario → file → DLL → schermo.
+
+**Il formato ha una trappola già costata tempo.** Il magic GSTC va scritto come
+u32 little-endian `0x47535443`, che sul disco dà i byte **`CTSG`**. Scriverlo
+come `GSTC` fa rifiutare il file **in silenzio** da `cache.cpp`: nessun errore,
+cache vuota, gioco in inglese e niente che lo segnali. `export_gstc()` ha un
+test che asserisce proprio i byte `CTSG` sul disco. E `len` conta **unità
+UTF-16**, non caratteri Unicode: il C++ legge `len * sizeof(wchar_t)` byte.
+
+**Il log ora dice il numero, non solo il percorso.** Prima stampava «cache
+pre-seedata» per il solo fatto che un percorso fosse impostato — anche con file
+assente o malformato. Diceva che era andata bene mentre la cache era vuota, ed è
+esattamente come quella trappola è riuscita a nascondersi. Ora stampa quante
+voci ha davvero caricato.
+
+**Da sapere.** All'uscita del gioco `ShutdownTranslator()` **riscrive** quel
+file con la cache locale (pre-caricato + imparato durante la partita). È
+persistenza gratuita fra sessioni, ma il file è uno solo per coppia di lingue:
+due giochi diversi si sovrascrivono a vicenda. Innocuo finché le traduzioni sono
+testo→testo, da rivedere se serviranno dizionari per-gioco.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/dllmain.cpp
+++ b/gs-hook/src/dllmain.cpp
@@ -20,6 +20,7 @@
 #include "gs_overlay_ipc.h"
 #include "translator.h"   // core generico riusato: namespace GSTranslator
 #include "ipc.h"          // client pipe GameStringerTranslator (stesso core)
+#include "cache.h"        // GSTranslator::GetGlobalCache().Size()
 #include <Windows.h>
 #include <MinHook.h>
 #include <vector>
@@ -59,18 +60,37 @@ DWORD WINAPI MainThread(LPVOID) {
     GSTranslator::TranslatorConfig cfg;
     cfg.targetLanguage = L"it";
     cfg.sourceLanguage = L"en";
-    // Override da env per test SENZA backend: GS_HOOK_CACHE = path di un file
-    // cache GSTC pre-seedato (formato di cache.cpp). In produzione il path
-    // arriva da GameStringer via IPC/config; speculare a GS_HOOK_LOG.
+    // Dizionario pre-caricato. Serve DAVVERO, non è una comodità: su UE la
+    // stessa stringa passa da FText::ToString una volta sola (la display string
+    // resta in cache dentro l'FTextData), quindi il percorso fire-and-forget —
+    // chiedi al primo avvistamento, usa dal secondo — non scatta mai. Se la
+    // traduzione non è già in cache quando il testo viene convertito, non
+    // comparirà a schermo.
+    //
+    // Due sorgenti, in ordine:
+    //   1. GS_HOOK_CACHE — override esplicito, per i test senza backend.
+    //   2. %APPDATA%\GameStringer\gs-hook-cache.gstc — scritto da GameStringer
+    //      PRIMA dell'iniezione. Serve un percorso convenuto perché una env var
+    //      non si può impostare in un processo già avviato.
     wchar_t cacheEnv[MAX_PATH] = {};
     if (GetEnvironmentVariableW(L"GS_HOOK_CACHE", cacheEnv, MAX_PATH) > 0) {
         cfg.cachePath = cacheEnv;
+    } else {
+        wchar_t appdata[MAX_PATH] = {};
+        if (GetEnvironmentVariableW(L"APPDATA", appdata, MAX_PATH) > 0) {
+            cfg.cachePath = std::wstring(appdata) + L"\\GameStringer\\gs-hook-cache.gstc";
+        }
     }
     GSTranslator::InitializeTranslator(cfg);
     if (!cfg.cachePath.empty()) {
-        char buf[320];
-        sprintf_s(buf, "[gs-hook] cache pre-seedata da GS_HOOK_CACHE: %ls\n",
-                  cfg.cachePath.c_str());
+        // Il conteggio, non solo il percorso: prima qui si stampava «cache
+        // pre-seedata» per il solo fatto che un percorso fosse impostato, anche
+        // quando il file era assente o malformato — e il log diceva che era
+        // andata bene mentre la cache era vuota.
+        const size_t entries = GSTranslator::GetGlobalCache().Size();
+        char buf[400];
+        sprintf_s(buf, "[gs-hook] dizionario pre-caricato: %zu voci da %ls\n",
+                  entries, cfg.cachePath.c_str());
         LogA(buf);
     }
 

--- a/src-tauri/src/commands/gs_hook_injector.rs
+++ b/src-tauri/src/commands/gs_hook_injector.rs
@@ -76,6 +76,24 @@ pub async fn inject_gs_hook(
         // al processo target (incluso lo spawn dell'helper). Blocco rigido.
         crate::anti_cheat::assert_injection_allowed(pid)?;
 
+        // Dizionario pre-caricato, PRIMA dell'iniezione. Non è un'ottimizzazione:
+        // su Unreal la stessa stringa passa da FText::ToString una volta sola
+        // (la display string resta in cache dentro l'FTextData), quindi il
+        // percorso fire-and-forget della DLL — chiedi al primo avvistamento,
+        // usa dal secondo — non scatta mai. Senza questo file la traduzione non
+        // compare, per quanto bene funzionino pipe e dizionario.
+        //
+        // Il percorso è convenuto invece che passato come variabile d'ambiente
+        // perché una env var non si può impostare in un processo già avviato:
+        // la DLL cerca %APPDATA%\GameStringer\gs-hook-cache.gstc.
+        match preload_dictionary(&app) {
+            Ok(0) => log::info!("📖 Dizionario vuoto: gs-hook partirà senza traduzioni note"),
+            Ok(n) => log::info!("📖 Pre-caricate {} traduzioni per gs-hook", n),
+            // Un dizionario mancante non deve impedire l'iniezione: senza, la
+            // DLL cattura comunque il testo e lo manda all'app via pipe.
+            Err(e) => log::warn!("📖 Dizionario non pre-caricato ({}), si procede", e),
+        }
+
         // Bitness del target → arch della DLL/injector da usare.
         let arch = match target_is_wow64(pid) {
             Some(true) => "x86",  // processo a 32-bit (WoW64 su Windows x64)
@@ -153,6 +171,26 @@ pub async fn inject_gs_hook(
 /// accanto all'eseguibile (`<exe_dir>/resources/gs-hook/<arch>/...`), come fa
 /// `unity_injector` per le proprie risorse.
 #[cfg(target_os = "windows")]
+/// Percorso del dizionario che gs-hook legge all'avvio. Deve combaciare con
+/// quello in `gs-hook/src/dllmain.cpp`.
+fn gs_hook_cache_path() -> Result<std::path::PathBuf, String> {
+    let appdata = std::env::var("APPDATA").map_err(|_| "APPDATA non impostata".to_string())?;
+    Ok(std::path::Path::new(&appdata)
+        .join("GameStringer")
+        .join("gs-hook-cache.gstc"))
+}
+
+/// Scrive la coppia di lingue attiva del Translation Bridge nel file che la DLL
+/// caricherà. Ritorna quante traduzioni sono state scritte.
+fn preload_dictionary(app: &tauri::AppHandle) -> Result<usize, String> {
+    use tauri::Manager;
+
+    let path = gs_hook_cache_path()?;
+    let state = app.state::<crate::commands::translation_bridge::TranslationBridgeState>();
+    let dict = state.dictionary.read();
+    dict.export_gstc(&path.to_string_lossy())
+}
+
 fn gs_hook_paths(arch: &str) -> Result<(std::path::PathBuf, std::path::PathBuf), String> {
     let exe_dir = std::env::current_exe()
         .map_err(|e| e.to_string())?

--- a/src-tauri/src/translation_bridge/dictionary_engine.rs
+++ b/src-tauri/src/translation_bridge/dictionary_engine.rs
@@ -467,6 +467,58 @@ impl DictionaryEngine {
     }
     
     /// Esporta traduzioni in JSON
+    /// Esporta la coppia di lingue attiva nel formato GSTC che la cache locale
+    /// di gs-hook sa leggere (`unreal-translator/hook-dll/src/cache.cpp`).
+    ///
+    /// PERCHÉ ESISTE. Su Unreal la stessa stringa passa da `FText::ToString`
+    /// una volta sola — la display string resta in cache dentro l'`FTextData` —
+    /// quindi il percorso fire-and-forget della DLL, che chiede la traduzione al
+    /// primo avvistamento e la usa dal secondo, non scatta mai. Se il testo non
+    /// è già tradotto quando viene convertito, a schermo non cambia niente.
+    /// Questo file va scritto PRIMA dell'iniezione.
+    ///
+    /// Formato: magic u32 LE `0x47535443` (sul disco sono i byte `CTSG`, non
+    /// `GSTC`: sbagliare l'ordine fa rifiutare il file in silenzio), version
+    /// u32 = 1, count u32, e per ogni voce `len u32` + testo UTF-16LE senza NUL,
+    /// prima l'originale e poi la traduzione. `len` conta unità UTF-16, non
+    /// caratteri Unicode: il C++ legge `len * sizeof(wchar_t)` byte.
+    pub fn export_gstc(&self, path: &str) -> Result<usize, String> {
+        let key = Self::get_key(&self.active_source, &self.active_target);
+        let dict = self
+            .dictionaries
+            .get(&key)
+            .ok_or_else(|| format!("Nessun dizionario per {}", key))?;
+
+        let entries: Vec<&TranslationEntry> = dict.iter().collect();
+        let mut buf: Vec<u8> = Vec::with_capacity(entries.len() * 64 + 12);
+        buf.extend_from_slice(&0x4753_5443u32.to_le_bytes());
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+
+        for entry in &entries {
+            for text in [&entry.original, &entry.translated] {
+                let units: Vec<u16> = text.encode_utf16().collect();
+                buf.extend_from_slice(&(units.len() as u32).to_le_bytes());
+                for u in units {
+                    buf.extend_from_slice(&u.to_le_bytes());
+                }
+            }
+        }
+
+        if let Some(parent) = Path::new(path).parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Impossibile creare {}: {}", parent.display(), e))?;
+        }
+        fs::write(path, &buf).map_err(|e| format!("Errore scrittura {}: {}", path, e))?;
+
+        info!(
+            "[DictionaryEngine] Esportate {} traduzioni in GSTC: {}",
+            entries.len(),
+            path
+        );
+        Ok(entries.len())
+    }
+
     pub fn export_to_json(&self, path: &str) -> Result<(), String> {
         let key = Self::get_key(&self.active_source, &self.active_target);
         
@@ -539,6 +591,51 @@ mod tests {
         assert_eq!(stats.total_entries, 2);
     }
     
+    #[test]
+    fn test_export_gstc_formato_leggibile_dal_cpp() {
+        // Il magic va scritto come u32 little-endian 0x47535443, che sul disco
+        // da' i byte "CTSG". Scriverlo come "GSTC" fa rifiutare il file in
+        // silenzio da cache.cpp: nessun errore, cache vuota, e il gioco resta
+        // in inglese senza che niente lo segnali.
+        let dir = std::env::temp_dir().join("gs_gstc_test");
+        let _ = fs::remove_dir_all(&dir);
+        let path = dir.join("c.gstc");
+
+        let mut engine = DictionaryEngine::new();
+        engine.set_active_languages("en", "it");
+        engine.load_translations(
+            "en",
+            "it",
+            vec![("Exit game".to_string(), "Esci dal gioco".to_string())],
+        );
+
+        let n = engine.export_gstc(path.to_str().unwrap()).unwrap();
+        assert_eq!(n, 1);
+
+        let raw = fs::read(&path).unwrap();
+        assert_eq!(&raw[0..4], b"CTSG", "il magic sul disco deve essere CTSG");
+        assert_eq!(u32::from_le_bytes(raw[4..8].try_into().unwrap()), 1, "version");
+        assert_eq!(u32::from_le_bytes(raw[8..12].try_into().unwrap()), 1, "count");
+
+        // len e' in unita' UTF-16, e il C++ legge len * sizeof(wchar_t) byte.
+        let orig_len = u32::from_le_bytes(raw[12..16].try_into().unwrap()) as usize;
+        assert_eq!(orig_len, "Exit game".encode_utf16().count());
+        let orig: Vec<u16> = raw[16..16 + orig_len * 2]
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(String::from_utf16(&orig).unwrap(), "Exit game");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_export_gstc_senza_dizionario_attivo() {
+        let engine = DictionaryEngine::new();
+        let path = std::env::temp_dir().join("gs_gstc_vuoto.gstc");
+        assert!(engine.export_gstc(path.to_str().unwrap()).is_err());
+    }
+
     #[test]
     fn test_duplicate_key_no_count_drift() {
         let mut engine = DictionaryEngine::new();


### PR DESCRIPTION
The last link. #91 got the text out of the game and back in, but every substitution test needed a hand-seeded cache — and #91's own notes said why.

## The reason the fire-and-forget path never fires

On Unreal the same string passes through `FText::ToString` **exactly once**: the display string stays cached inside the `FTextData`. So the DLL's design — ask for a translation on first sighting, use it from the second — never gets a second sighting. The text stays in its original language no matter how well the pipe, the dictionary and the substitution work.

The translation has to already be in the local cache **at the moment the text is converted**.

## A settled path, not an environment variable

GameStringer now writes the active language pair to `%APPDATA%\GameStringer\gs-hook-cache.gstc` before launching the injector (`preload_dictionary()` in `commands/gs_hook_injector.rs`), and the DLL looks there at startup when `GS_HOOK_CACHE` is unset.

It has to be a settled path: an env var cannot be set in an **already-running** process, and injection is by definition into a running game. `GS_HOOK_CACHE` stays as the explicit override for tests without a backend.

A missing dictionary does not block injection — without it the DLL still captures text and sends it to the app over the pipe.

## Proven with no env var set

```text
[gs-hook] dizionario pre-caricato: 7 voci da …\GameStringer\gs-hook-cache.gstc
[gs-hook/UE] hook FText::ToString installato (pattern)
[gs-hook/UE] SUBST:       LANGUAGE SELECTION -> SELEZIONE LINGUA  [len=16 ArrayNum=19 ArrayMax=24]
[gs-hook/UE] SUBST:       English            -> Inglese
[gs-hook/UE] SUBST:       Russian            -> Russo
[gs-hook/UE] SUBST(grow): Exit game          -> Esci dal gioco e torna al desktop
```

Four substitutions on **first** sighting, one of them growing the buffer. Dictionary → file → DLL → screen.

## The format trap, now covered by a test

The GSTC magic must be written as the little-endian u32 `0x47535443`, which lands on disk as the bytes **`CTSG`**. Writing `GSTC` gets the file rejected **silently** by `cache.cpp` — no error, empty cache, game in English, nothing to indicate why. That cost time during #91.

`export_gstc` now has a test asserting the bytes `CTSG` on disk, and another for the missing-dictionary case. And `len` counts **UTF-16 units**, not Unicode characters, since the C++ reads `len * sizeof(wchar_t)` bytes.

The DLL's log reports how many entries it actually loaded instead of just the path. It used to print *"cache pre-seedata"* merely because a path was set — claiming success with an empty cache, which is exactly how that trap stayed hidden.

## Noted for later

On exit `ShutdownTranslator` rewrites that file with the local cache (preloaded + learned during play). That is free persistence across sessions, but there is one file per language pair, so two different games overwrite each other. Harmless while translations are text-to-text; worth revisiting if per-game dictionaries are ever needed.

## Verification

24 Rust tests including the two new ones, `cargo check`, clippy (one pre-existing doc-indent warning, unrelated), `tauri:check-cmds`. Both DLL architectures rebuilt. The test dictionary was removed from the production path afterwards and no game left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
