### PR TITLE
Cover the build where Rebuild is inlined, using caller counts as ground truth

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -680,6 +680,72 @@ persistenza gratuita fra sessioni, ma il file è uno solo per coppia di lingue:
 due giochi diversi si sovrascrivono a vicenda. Innocuo finché le traduzioni sono
 testo→testo, da rivedere se serviranno dizionari per-gioco.
 
+### Quando manca la verità di riferimento, il conteggio dei chiamanti la sostituisce
+
+**Il fatto.** `FText::ToString` esiste anche nei build dove la firma validata fa
+0 match: cambia il **codegen**, non la funzione. Su ProjectAIDA (il gioco AILA)
+il compilatore ha **inlinato `Rebuild`** come chiamata virtuale invece di
+emettere un `call rel32`, e il prologo non combacia più.
+
+**Il problema del metodo.** Qui non c'è un binario con simboli da cui leggere i
+byte: ProjectAIDA si dichiara `UE5-CL-0`, build custom, e nessuna installazione
+UE corrisponde. Ricavare una firma «perché la forma sembra giusta» è esattamente
+l'errore che ha prodotto la firma confutata.
+
+**Cosa la sostituisce: i chiamanti.** Il nucleo semantico non cambia mai —
+carica TextData da `[this]`, carica la vtable, **tail-call** a
+`GetDisplayString`. Cercando quel nucleo (`48 8B 0B 48 8B 01`) seguito
+dall'epilogo con tail-jmp (`48 83 C4 ?? 5B 48 FF 60 ??`) restano quattro
+candidati; a separarli è quanto vengono chiamati:
+
+| RVA | lunghezza | chiamanti diretti |
+|---|---|---|
+| **0x12847F0** | 41 byte | **429** |
+| 0x12848F0 | 65 byte | 1 |
+| 0x1284A80 | 65 byte | 1 |
+| 0x36095A0 | 73 byte | 1 |
+
+429 contro 1. E il numero è coerente con i ~397 della `ToString` **validata sui
+simboli** su The Skin Stapler: una funzione chiamata centinaia di volte che
+carica TextData e fa tail-call a uno slot di vtable non può essere altro.
+Il solo nucleo, senza la coda, compare **602 volte**: non discrimina niente.
+
+**La firma.** Identica alla principale salvo il prologo:
+
+```text
+40 53 48 83 EC ?? 48 8B D9 48 8B 09 48 8B 01 FF 50 ?? 48 8B C8 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??
+```
+
+`mov rcx,[rcx]` invece di `call <rebuild>`, poi la chiamata virtuale che è la
+`Rebuild` espansa. **1 match su ProjectAIDA e 0 sugli altri 14**: è
+complementare alla firma principale, che fa 0 proprio lì. Insieme coprono
+**15 giochi su 15**.
+
+**Nel codice.** `source_unreal_ftext.cpp` ora prova le firme **in ordine** e si
+ferma alla prima univoca; un'ambiguità su una non ferma la ricerca, perché
+sull'altra quel binario può essere univoco. Il log dice **con quale firma** ha
+agganciato — serve a sapere, quando un gioco nuovo non funziona, se il problema
+è una firma da estendere o una da aggiungere.
+
+**Prova sul campo (AILA, 21/08/2026).** Iniezione reale:
+
+```text
+[gs-hook/UE] FText::ToString trovato con la firma "UE5 rebuild inline"
+[gs-hook/UE] hook FText::ToString installato
+[gs-hook/UE] FMemory::Realloc risolto
+[gs-hook] sorgente attiva: Unreal/FText (livello 1)
+```
+
+Gioco vivo, nessuna regressione su The Skin Stapler e Father's Day, che
+continuano ad agganciare con la firma principale.
+
+**Una correzione allo strumento.** `ue-validate-ftext-pattern.js` giudicava
+l'effetto a runtime guardando **una sola** firma, e su ProjectAIDA stampava
+«fallback GDI» mentre la DLL aggancia. Affermava un esito che non aveva
+misurato — lo stesso difetto che quello script esiste per smascherare. Ora
+considera tutte le firme provate, nell'ordine in cui la DLL le prova, e dice
+quale ha agganciato.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_unreal_ftext.cpp
+++ b/gs-hook/src/sources/source_unreal_ftext.cpp
@@ -241,22 +241,40 @@ public:
         //    firma validata oggi può diventare ambigua su una build futura, e
         //    in quel caso si rifiuta e si scende a GDI. Fallire qui è il caso
         //    BENIGNO; agganciare la funzione sbagliata no.
-        size_t matches = 0;
-        uintptr_t addr = GSTranslator::Utils::PatternScanUnique(
-            game, UE::Patterns::FText_ToString_UE5, &matches);
+        // Le firme si provano IN ORDINE: la stessa funzione ha codegen diversi
+        // fra build (la seconda ha `Rebuild` inlinata come chiamata virtuale).
+        // Sono complementari — misurate su 15 giochi, 14 + 1 — e insieme li
+        // coprono tutti. Un'ambiguita' su una NON ferma la ricerca: si passa
+        // alla successiva, che su quel binario puo' essere univoca.
+        struct Firma { const char* nome; const char* sig; };
+        static const Firma kFirme[] = {
+            { "UE5 Shipping",        UE::Patterns::FText_ToString_UE5 },
+            { "UE5 rebuild inline",  UE::Patterns::FText_ToString_UE5_RebuildInline },
+        };
 
-        if (!addr) {
+        uintptr_t addr = 0;
+        for (const auto& firma : kFirme) {
+            size_t matches = 0;
+            addr = GSTranslator::Utils::PatternScanUnique(game, firma.sig, &matches);
+            if (addr) {
+                LogLineA((std::string("[gs-hook/UE] FText::ToString trovato con la firma \"") +
+                          firma.nome + "\"\n").c_str());
+                break;
+            }
             if (matches > 1) {
                 const std::string quanti =
                     (matches >= GSTranslator::Utils::PATTERN_SCAN_COUNT_CAP)
                         ? "almeno " + std::to_string(matches)
                         : std::to_string(matches);
-                LogLineA(("[gs-hook/UE] pattern FText::ToString ambiguo: " + quanti +
-                          " match, hook RIFIUTATO (aggancerebbe la funzione sbagliata)\n").c_str());
-            } else {
-                LogLineA("[gs-hook/UE] FText::ToString non trovato su questa build "
-                         "(firma UE5 Shipping)\n");
+                LogLineA((std::string("[gs-hook/UE] firma \"") + firma.nome +
+                          "\" ambigua: " + quanti +
+                          " match, scartata (aggancerebbe la funzione sbagliata)\n").c_str());
             }
+        }
+
+        if (!addr) {
+            LogLineA("[gs-hook/UE] FText::ToString non trovato su questa build "
+                     "(nessuna firma nota aggancia)\n");
             return Activation::Failed; // → il dllmain scende a L2 (GDI)
         }
 
@@ -269,7 +287,7 @@ public:
         }
 
         hookedAddr_ = addr;
-        LogLineW(L"[gs-hook/UE] hook FText::ToString installato (pattern)\n");
+        LogLineW(L"[gs-hook/UE] hook FText::ToString installato\n");
 
         // Allocatore UE: se non si trova, la sostituzione resta possibile solo
         // per le traduzioni che entrano nel buffer esistente. Non e' un motivo

--- a/scripts/ue-validate-ftext-pattern.js
+++ b/scripts/ue-validate-ftext-pattern.js
@@ -67,6 +67,11 @@ const PATTERNS = {
   // UnrealGame-Win64-Shipping.exe (UE 5.8, Shipping monolitico come i giochi).
   FText_ToString_UE5:
     '40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??',
+  // Stessa funzione, `Rebuild` inlinata come chiamata virtuale invece che
+  // `call rel32`. Complementare alla precedente: 1 match su ProjectAIDA (dove
+  // l'altra fa 0) e 0 sugli altri 14.
+  FText_ToString_UE5_RebuildInline:
+    '40 53 48 83 EC ?? 48 8B D9 48 8B 09 48 8B 01 FF 50 ?? 48 8B C8 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??',
 };
 
 const MAX_DEPTH = 6;
@@ -596,8 +601,16 @@ function main() {
   // `PatternScanUnique` accetta solo i match unici. Quindi oggi un pattern
   // ambiguo non è più "innocuo finché l'altro aggancia": è rifiutato e basta,
   // e si scende al livello 2 (GDI).
-  const primo = 'FText_ToString_UE5';
-  if (Object.keys(PATTERNS).includes(primo)) {
+  // La DLL prova le firme IN ORDINE e si ferma alla prima univoca (vedi
+  // source_unreal_ftext.cpp). Guardarne una sola faceva dire "fallback GDI" su
+  // binari dove l'altra aggancia — lo strumento affermava un esito che non
+  // aveva misurato, che e' il difetto che questo script esiste per smascherare.
+  const provate = ['FText_ToString_UE5', 'FText_ToString_UE5_RebuildInline']
+    .filter((k) => Object.keys(PATTERNS).includes(k));
+  /** La prima firma univoca per questo binario, o null. */
+  const firmaCheAggancia = (r) =>
+    provate.find((k) => r.risultati[k] && r.risultati[k].match === 1) || null;
+  if (provate.length) {
     // ⚠️ I binari NON ANALIZZABILI vanno contati a parte, mai dedotti per
     // differenza. Nella prima stesura di questo blocco il totale era
     // `referti.length - zero - ambigui`, quindi un file che non si era
@@ -607,11 +620,15 @@ function main() {
     // dovrebbe smascherarlo.
     const illeggibili = referti.filter((r) => r.errore);
     const letti = referti.filter((r) => !r.errore);
-    const zero = letti.filter((r) => r.risultati[primo].match === 0);
-    const ambiguiUE5 = letti.filter((r) => r.risultati[primo].match > 1);
-    const agganciano = letti.filter((r) => r.risultati[primo].match === 1);
+    const agganciano = letti.filter((r) => firmaCheAggancia(r));
+    const restanti = letti.filter((r) => !firmaCheAggancia(r));
+    // Fra chi non aggancia, distinguere "nessuna firma trova nulla" da
+    // "qualcuna trova troppo": sono due diagnosi diverse.
+    const ambiguiUE5 = restanti.filter((r) =>
+      provate.some((k) => r.risultati[k] && r.risultati[k].match > 1));
+    const zero = restanti.filter((r) => !ambiguiUE5.includes(r));
 
-    console.log('\nEFFETTO A RUNTIME (solo pattern UE5, match unico obbligatorio)');
+    console.log(`\nEFFETTO A RUNTIME (${provate.length} firme provate in ordine, match unico obbligatorio)`);
     if (!letti.length) {
       console.log('  NIENTE DA DIRE: nessun binario è stato letto davvero.');
     } else {
@@ -620,7 +637,7 @@ function main() {
         `${zero.length} nessun match, ${ambiguiUE5.length} ambigui → rifiutati.`
       );
       for (const r of agganciano) {
-        console.log(`     ✔ ${path.basename(r.file)} → hook engine`);
+        console.log(`     ✔ ${path.basename(r.file)} → hook engine (${firmaCheAggancia(r)})`);
       }
       for (const r of [...zero, ...ambiguiUE5]) {
         console.log(`     · ${path.basename(r.file)} → fallback GDI`);

--- a/unreal-translator/hook-dll/include/ue_types.h
+++ b/unreal-translator/hook-dll/include/ue_types.h
@@ -106,6 +106,39 @@ namespace Patterns {
         "40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 "
         "48 83 C4 ?? 5B 48 FF 60 ??";
 
+    // UE5 FText::ToString, variante con `Rebuild` INLINATA — USABILE.
+    // Stessa funzione, altro codegen: invece di `call rel32` verso Rebuild, il
+    // compilatore l'ha espansa in una chiamata virtuale su TextData. Il resto
+    // è identico, tail-call finale compresa:
+    //
+    //   40 53              push rbx
+    //   48 83 EC 20        sub  rsp, 0x20
+    //   48 8B D9           mov  rbx, rcx
+    //   48 8B 09           mov  rcx, [rcx]        ← TextData (niente call prima)
+    //   48 8B 01           mov  rax, [rcx]        ← vtable
+    //   FF 50 50           call [rax+0x50]        ← Rebuild, inlinata
+    //   48 8B C8           mov  rcx, rax
+    //   E8 66 5C 01 00     call <…>               ← rel32, wildcard
+    //   48 8B 0B           mov  rcx, [rbx]        ← TextData
+    //   48 8B 01           mov  rax, [rcx]        ← vtable
+    //   48 83 C4 20        add  rsp, 0x20
+    //   5B                 pop  rbx
+    //   48 FF 60 28        jmp  [rax+0x28]        ← tail-call GetDisplayString
+    //
+    // Qui NON c'è un binario con simboli da cui leggerla: ProjectAIDA (il gioco
+    // AILA) si dichiara `UE5-CL-0`, build custom. La corroborazione è il
+    // **conteggio dei chiamanti**: 429 diretti, contro 1 degli altri tre
+    // candidati con la stessa coda nello stesso binario — e i ~397 della
+    // ToString validata su The Skin Stapler. Una funzione chiamata 429 volte
+    // che carica TextData e fa tail-call a uno slot di vtable è quella.
+    //
+    // MISURATA: 1 match su ProjectAIDA (RVA 0x12847F0) e **0 su tutti gli altri
+    // 14** Shipping installati. È complementare alla firma sopra, che fa 0
+    // proprio su ProjectAIDA: insieme coprono 15 giochi su 15.
+    constexpr const char* FText_ToString_UE5_RebuildInline =
+        "40 53 48 83 EC ?? 48 8B D9 48 8B 09 48 8B 01 FF 50 ?? 48 8B C8 "
+        "E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??";
+
     // FMemory::Realloc — USABILE. Serve a far CRESCERE il buffer di una FString
     // quando la traduzione non entra in ArrayMax. Scrivere oltre corromperebbe
     // l'heap; allocare con `new`/malloc pure, perché UE libererà quel puntatore


### PR DESCRIPTION
`FText::ToString` exists in builds where the validated signature matches nothing: the **codegen** changes, not the function. On ProjectAIDA — the game **AILA** — the compiler inlined `Rebuild` as a virtual call instead of emitting a `call rel32`, so the prologue no longer lines up.

## The method problem, and what solved it

There is no symbol-bearing binary to read the bytes from here: ProjectAIDA declares itself `UE5-CL-0`, a custom build, and no installed UE matches. Deriving a signature *because the shape looks right* is exactly what produced the refuted signature in #90.

What stands in for a ground truth is the **caller count**. The semantic core never changes — load TextData from `[this]`, load the vtable, tail-call `GetDisplayString` — so searching for that core followed by the tail-jump epilogue leaves four candidates:

| RVA | length | direct callers |
|---|---|---|
| **0x12847F0** | 41 bytes | **429** |
| 0x12848F0 | 65 bytes | 1 |
| 0x1284A80 | 65 bytes | 1 |
| 0x36095A0 | 73 bytes | 1 |

429 against 1, and that number lines up with the ~397 of the symbol-validated `ToString` on The Skin Stapler. A function called hundreds of times that loads TextData and tail-calls a vtable slot is not something else.

Worth noting: the core **alone**, without the epilogue, appears **602 times** and discriminates nothing. The tail-call is what carries the signal.

## The signature

```text
40 53 48 83 EC ?? 48 8B D9 48 8B 09 48 8B 01 FF 50 ?? 48 8B C8 E8 ?? ?? ?? ?? 48 8B 0B 48 8B 01 48 83 C4 ?? 5B 48 FF 60 ??
```

`mov rcx,[rcx]` instead of `call <rebuild>`, then the virtual call that *is* the inlined Rebuild. **1 match on ProjectAIDA and 0 on the other 14** — complementary to the primary, which matches 14 and misses only there. Together they cover **15 of 15**.

## Signatures are now tried in order

`source_unreal_ftext.cpp` stops at the first unique one. An ambiguity on one no longer ends the search, since the same binary may be unambiguous for another. The log names **which** signature hooked, so when a new game fails it is clear whether a signature needs extending or adding.

## Verified

Injected into AILA: hooked with `"UE5 rebuild inline"`, game alive. No regression — The Skin Stapler and Father's Day still hook with the primary. 24 Rust tests pass.

## One tooling fix

`ue-validate-ftext-pattern.js` judged the runtime effect from a **single** signature and printed *"fallback GDI"* for ProjectAIDA while the DLL actually hooks. It asserted an outcome it had not measured — the very defect that script exists to expose. It now walks every signature in the order the DLL tries them, and reports which one hooked:

```text
EFFETTO A RUNTIME (2 firme provate in ordine, match unico obbligatorio)
  su 1 binario/i letti: 1 aggancerebbero, 0 nessun match, 0 ambigui → rifiutati.
     ✔ ProjectAIDA-Win64-Shipping.exe → hook engine (FText_ToString_UE5_RebuildInline)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
