### PR TITLE
Stop Defender quarantining the 32-bit injector

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -956,6 +956,40 @@ solo (vedi l'intestazione di quel file).
    deve fare l'utente consapevolmente — non un ripiego da suggerire in un
    messaggio d'errore.
 
+**Cosa è stato fatto, e cosa ha risolto davvero (21/08/2026).**
+
+La strada 2 — la meno promettente sulla carta — **è bastata**. Aggiungendo
+`gs-hook/injector/injector.rc` (CompanyName, FileDescription, ProductName,
+OriginalFilename, versione, e un Comments che dice a cosa serve il programma) e
+ricompilando, la stessa macchina con lo stesso Defender **non mette più in
+quarantena l'injector x86**:
+
+```text
+Start-MpScan -ScanType CustomScan -ScanPath ...\x86\gs-injector.exe
+  file ancora presente: True
+  esecuzione: «uso: gs-injector.exe <pid> <percorso-dll>»   -> parte
+  Get-MpThreatDetection negli ultimi 10 minuti: nessuno
+```
+
+Prima erano tre rilevamenti su tre tentativi. **Non una riga di comportamento è
+cambiata**: stesse API, stessa sequenza, stessa dimensione. È cambiato solo il
+fatto che il binario dichiara chi è. Questo dice quanto peso ha, nel punteggio
+euristico, l'anonimato di un eseguibile.
+
+La strada 1 resta la cura definitiva ed è **pronta ma non applicata**:
+`build-all.ps1` accetta `-SignThumbprint` (o `$env:GS_SIGN_THUMBPRINT`), firma con
+`signtool` marca temporale inclusa, e **riverifica la firma dopo averla apposta**
+— perché `signtool sign` può uscire 0 e lasciare una firma che non convalida.
+Senza thumbprint la firma viene saltata con un avviso e il build prosegue.
+
+**Un certificato auto-generato qui non serve a niente.** Non porta attendibilità
+né reputazione: si otterrebbe un binario firmato messo in quarantena esattamente
+come prima. Serve un certificato vero — EV se si vuole reputazione immediata, OV
+se si accetta di costruirsela nel tempo. Su questa macchina non ce n'è nessuno
+(`Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My -CodeSigningCert`
+non restituisce nulla), quindi il percorso di firma è scritto e non è provato:
+va esercitato la prima volta che un certificato esiste davvero.
+
 **La trappola.** «L'iniezione ha funzionato» non vuol dire «l'iniezione
 funzionerà». Qui ha funzionato **una volta sola**, e il fallimento successivo non
 somiglia a un problema di antivirus: somiglia a un file mancante. Chiunque

--- a/gs-hook/CMakeLists.txt
+++ b/gs-hook/CMakeLists.txt
@@ -62,5 +62,9 @@ set_target_properties(gs_hook PROPERTIES OUTPUT_NAME "gs-hook")
 # Va compilato nella stessa arch del target: il build dual-arch (build-all.ps1)
 # configura due build dir, -A Win32 e -A x64, e produce gs-injector.exe per
 # entrambe. NON dipende da MinHook né dal core: solo Win32 API.
-add_executable(gs-injector injector/injector_main.cpp)
+# injector.rc porta i metadati di versione: un eseguibile anonimo che fa
+# injection viene classificato come dropper dalle euristiche ML (misurato:
+# Program:Win32/Contebrew.A!ml sulla build x86). Dichiarare prodotto, descrizione
+# e versione abbassa il punteggio senza cambiare comportamento.
+add_executable(gs-injector injector/injector_main.cpp injector/injector.rc)
 set_target_properties(gs-injector PROPERTIES OUTPUT_NAME "gs-injector")

--- a/gs-hook/build-all.ps1
+++ b/gs-hook/build-all.ps1
@@ -15,10 +15,83 @@
 
 param(
     [ValidateSet('Release', 'Debug')]
-    [string]$Config = 'Release'
+    [string]$Config = 'Release',
+
+    # Impronta (thumbprint) del certificato di code signing da usare. Se assente
+    # si legge da $env:GS_SIGN_THUMBPRINT; se manca anche quella, la firma viene
+    # SALTATA e il build prosegue — cosi' chi non ha un certificato compila lo
+    # stesso, e chi ce l'ha non deve ricordarsi un passaggio in piu'.
+    [string]$SignThumbprint = $env:GS_SIGN_THUMBPRINT,
+
+    # Server di marca temporale. Serve perche' la firma resti valida DOPO la
+    # scadenza del certificato: senza, tutti i binari gia' spediti diventano
+    # non firmati il giorno in cui il certificato scade.
+    [string]$TimestampUrl = 'http://timestamp.digicert.com'
 )
 
 $ErrorActionPreference = 'Stop'
+
+# ── Firma digitale (opzionale) ───────────────────────────────────────────────
+#
+# PERCHE'. Defender mette in quarantena gs-injector.exe x86 come
+# `Program:Win32/Contebrew.A!ml`: un eseguibile piccolo, non firmato, che chiama
+# OpenProcess + VirtualAllocEx + CreateRemoteThread ha il profilo di un dropper.
+# La firma con un certificato ATTENDIBILE e' la cura vera; i metadati di versione
+# in injector/injector.rc sono il palliativo che si puo' fare senza certificato.
+#
+# Un certificato AUTO-GENERATO non serve a niente qui: non e' attendibile, non
+# porta reputazione, e il binario viene messo in quarantena esattamente come
+# prima. Serve un certificato di code signing vero (OV o, meglio, EV: l'EV ha
+# reputazione immediata, l'OV se la costruisce nel tempo).
+
+function Find-SignTool {
+    # Il piu' recente signtool.exe x64 dei Windows Kits.
+    $roots = @(
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin",
+        "$env:ProgramFiles\Windows Kits\10\bin"
+    ) | Where-Object { Test-Path $_ }
+
+    foreach ($r in $roots) {
+        $c = Get-ChildItem $r -Filter 'signtool.exe' -Recurse -ErrorAction SilentlyContinue |
+             Where-Object { $_.FullName -match '\\x64\\' } |
+             Sort-Object FullName -Descending |
+             Select-Object -First 1
+        if ($c) { return $c.FullName }
+    }
+    return $null
+}
+
+function Invoke-Sign {
+    param([string[]]$Files, [string]$Thumbprint, [string]$Timestamp)
+
+    if (-not $Thumbprint) {
+        Write-Host "==> Firma saltata: nessun certificato indicato (-SignThumbprint / GS_SIGN_THUMBPRINT)" -ForegroundColor DarkYellow
+        Write-Host "    I binari non firmati possono essere messi in quarantena dall'antivirus." -ForegroundColor DarkYellow
+        return
+    }
+
+    $signtool = Find-SignTool
+    if (-not $signtool) { throw "signtool.exe non trovato: installa il Windows SDK" }
+
+    $cert = Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My -CodeSigningCert -ErrorAction SilentlyContinue |
+            Where-Object { $_.Thumbprint -eq $Thumbprint } | Select-Object -First 1
+    if (-not $cert) { throw "Certificato $Thumbprint non trovato negli archivi personali" }
+    if (-not $cert.HasPrivateKey) { throw "Il certificato $Thumbprint non ha la chiave privata: non puo' firmare" }
+
+    foreach ($f in $Files) {
+        Write-Host "==> Firma $([System.IO.Path]::GetFileName($f))" -ForegroundColor Cyan
+        & $signtool sign /sha1 $Thumbprint /fd SHA256 /td SHA256 /tr $Timestamp /q $f
+        if ($LASTEXITCODE -ne 0) { throw "signtool ha fallito su $f" }
+
+        # Verificare dopo aver firmato: "signtool sign" puo' uscire 0 e produrre
+        # una firma che non convalida (catena incompleta, marca temporale non
+        # raggiungibile). Senza questo controllo si spedisce un binario che
+        # sembra firmato e non lo e'.
+        & $signtool verify /pa /q $f
+        if ($LASTEXITCODE -ne 0) { throw "la firma su $f non convalida" }
+    }
+}
+
 
 $hookDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent $hookDir
@@ -64,6 +137,10 @@ foreach ($t in $targets) {
 
     if (!(Test-Path $dll)) { throw "DLL non trovata: $dll" }
     if (!(Test-Path $exe)) { throw "Injector non trovato: $exe" }
+
+    # Si firma PRIMA di copiare: cosi' l'artefatto spedito e quello nella build
+    # dir sono lo stesso file, firma compresa.
+    Invoke-Sign -Files @($dll, $exe) -Thumbprint $SignThumbprint -Timestamp $TimestampUrl
 
     Copy-Item $dll -Destination $destDir -Force
     Copy-Item $exe -Destination $destDir -Force

--- a/gs-hook/injector/injector.rc
+++ b/gs-hook/injector/injector.rc
@@ -1,0 +1,53 @@
+// Metadati di versione per gs-injector.exe.
+//
+// PERCHÉ ESISTE (21/08/2026)
+// Microsoft Defender metteva in quarantena la build x86 come
+// `Program:Win32/Contebrew.A!ml` — un'euristica di machine learning. Il profilo
+// che la fa scattare è: eseguibile piccolo, NON firmato, SENZA metadati, che
+// chiama OpenProcess + VirtualAllocEx + WriteProcessMemory + CreateRemoteThread.
+// Un binario anonimo è indistinguibile da un dropper; uno che dichiara chi è,
+// cosa fa e a quale prodotto appartiene abbassa il punteggio euristico senza
+// cambiare una riga di comportamento.
+//
+// Questo NON sostituisce la firma digitale, che resta la cura vera (vedi
+// docs/METODI-DI-TRADUZIONE.md e il supporto in build-all.ps1): è il pezzo che
+// si può fare senza certificato.
+
+#include <winver.h>
+
+#define GS_VERSION      1,17,0,0
+#define GS_VERSION_STR  "1.17.0.0"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    GS_VERSION
+ PRODUCTVERSION GS_VERSION
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+ FILEFLAGS      VS_FF_DEBUG
+#else
+ FILEFLAGS      0x0L
+#endif
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_APP
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"   // inglese (US), Unicode
+        BEGIN
+            VALUE "CompanyName",      "GameStringer"
+            VALUE "FileDescription",  "GameStringer translation hook loader"
+            VALUE "FileVersion",      GS_VERSION_STR
+            VALUE "InternalName",     "gs-injector"
+            VALUE "LegalCopyright",   "GameStringer"
+            VALUE "OriginalFilename", "gs-injector.exe"
+            VALUE "ProductName",      "GameStringer"
+            VALUE "ProductVersion",   GS_VERSION_STR
+            VALUE "Comments",         "Loads the GameStringer translation DLL into a game the user has chosen to translate. Ships with GameStringer; not intended for standalone use."
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
## Il problema

`gs-injector.exe` **x86** veniva messo in quarantena da Defender come `Program:Win32/Contebrew.A!ml`. Tre rilevamenti su tre tentativi; la build x64 mai una volta. È l'injector che conta di più: serve per i giochi a 32 bit, cioè RPG Maker classico e le vecchie VN — il caso di punta della traduzione a runtime.

Il modo in cui falliva era la parte peggiore. La **prima** iniezione ha funzionato davvero (test end-to-end su Yume Nikki: log scritto, sorgenti GDI attive, overlay aperto) e Defender rimuoveva il file subito dopo. Al secondo giro l'utente trova il componente sparito, e non somiglia a un problema di antivirus: somiglia a un file mancante.

## Cosa cambia

**`injector/injector.rc`** — metadati VERSIONINFO. Un eseguibile di 11 KB, non firmato e senza metadati, che chiama `OpenProcess` + `VirtualAllocEx` + `WriteProcessMemory` + `CreateRemoteThread` è indistinguibile da un dropper; uno che dichiara prodotto, scopo e versione abbassa il punteggio euristico.

**`build-all.ps1`** — firma opzionale via `-SignThumbprint` (o `$env:GS_SIGN_THUMBPRINT`). Firma con marca temporale, così le firme sopravvivono alla scadenza del certificato, e **riverifica dopo aver firmato**, perché `signtool sign` può uscire 0 e lasciare una firma che non convalida. Senza thumbprint salta con un avviso e il build prosegue: chi non ha un certificato non è toccato.

## La misura

Dopo il rebuild, stessa macchina e stesso Defender:

```text
Start-MpScan -ScanType CustomScan -ScanPath ...\x86\gs-injector.exe
  file ancora presente: True
  esecuzione: «uso: gs-injector.exe <pid> <percorso-dll>»   -> parte
  Get-MpThreatDetection negli ultimi 10 minuti: nessuno
```

Prima erano tre su tre. **Non una riga di comportamento è cambiata**: stesse API, stessa sequenza, stessa dimensione. È cambiato solo il fatto che il binario dichiara chi è.

Esercitati anche i rami della firma: `Find-SignTool` trova `signtool.exe` (Windows Kits 10.0.26100.0), un thumbprint inesistente fallisce con un messaggio esplicito, e l'assenza di thumbprint salta con l'avviso.

## Cosa resta non provato

La firma è **scritta e non applicata**: su questa macchina non esiste alcun certificato di code signing (`Get-ChildItem Cert:\CurrentUser\My, Cert:\LocalMachine\My -CodeSigningCert` non restituisce nulla). Un certificato **auto-generato non risolverebbe niente** — nessuna attendibilità, nessuna reputazione, binario in quarantena esattamente come prima. Serve un certificato vero (EV per reputazione immediata, OV per costruirsela). Il percorso di firma va esercitato la prima volta che ne esiste uno.

La misura vale per **questa** macchina e **questa** versione delle definizioni. Un'euristica ML può cambiare idea con un aggiornamento: la firma resta la cura che non dipende da questo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)