### PR TITLE
Fail the injector when the remote thread hangs, instead of faking success

### DIFF
--- a/gs-hook/injector/injector_main.cpp
+++ b/gs-hook/injector/injector_main.cpp
@@ -21,6 +21,7 @@
 //   5  GetProcAddress(LoadLibraryW) fallita
 //   6  CreateRemoteThread fallita
 //   7  thread remoto ok ma LoadLibraryW ha ritornato modulo nullo
+//   8  thread remoto non terminato entro il timeout (esito ignoto)
 
 #include <Windows.h>
 #include <cstdio>
@@ -82,7 +83,33 @@ int wmain(int argc, wchar_t* argv[]) {
         return 6;
     }
 
-    WaitForSingleObject(thread, 15000);
+    constexpr DWORD kRemoteThreadTimeoutMs = 15000;
+    DWORD waited = WaitForSingleObject(thread, kRemoteThreadTimeoutMs);
+
+    // Se il thread NON è terminato, non abbiamo un esito: leggere qui l'exit
+    // code darebbe STILL_ACTIVE (259), che essendo diverso da zero passerebbe
+    // per un HMODULE valido e stamperebbe «DLL caricata» su un'iniezione che
+    // non è mai finita. È il caso che questo ramo esiste per intercettare.
+    //
+    // E soprattutto NON si libera la memoria remota: il thread è ancora dentro
+    // LoadLibraryW e sta leggendo proprio quella stringa. Liberarla sarebbe una
+    // use-after-free NEL PROCESSO DEL GIOCO, cioè un crash causato da noi
+    // mentre segnaliamo un errore. Meglio perdere pathBytes byte (poche
+    // centinaia) in un processo che sta comunque per essere diagnosticato.
+    if (waited != WAIT_OBJECT_0) {
+        if (waited == WAIT_TIMEOUT) {
+            std::fwprintf(stderr,
+                          L"thread remoto ancora in esecuzione dopo %lu ms: "
+                          L"esito ignoto, la DLL potrebbe non essere caricata\n",
+                          kRemoteThreadTimeoutMs);
+        } else {
+            std::fwprintf(stderr, L"attesa del thread remoto fallita (err=%lu)\n",
+                          GetLastError());
+        }
+        CloseHandle(thread);
+        CloseHandle(proc);
+        return 8;
+    }
 
     // Exit code del thread = valore di ritorno di LoadLibraryW troncato a 32 bit.
     // 0 ⇒ LoadLibraryW ha fallito (DLL non caricata). Su x64 l'HMODULE è a 64


### PR DESCRIPTION
`WaitForSingleObject(thread, 15000)` can return `WAIT_TIMEOUT`, after which `GetExitCodeThread` yields `STILL_ACTIVE` (259). Being non-zero, that value passed the `remoteModule == 0` failure check, so the injector printed "gs-hook.dll caricata in PID N" and exited 0 — a false success on an injection that never finished.

**Fix:** gate on `WAIT_OBJECT_0`. Any other wait result returns a new **exit code 8** with a message that distinguishes "remote thread still running" (`WAIT_TIMEOUT`) from a failed wait.

**Why it doesn't free the remote memory on that branch:** the timeout branch is reached precisely while the remote `LoadLibraryW` may still be reading the path string we copied in. Calling `VirtualFreeEx` there would be a use-after-free *in the game's process* — a crash we'd cause while reporting an error. Leaking a few hundred bytes in a process that's already being diagnosed is the safe trade. The success path frees as before.

Exit-code documentation block at the top of the file kept in sync (added `8`).

**Testing.** Rebuilt both architectures clean. Verified against a live process that the existing branches are unchanged: bad args → exit 1, non-existent DLL (thread returns NULL) → exit 7 in 0s. The new branch fires only when the remote thread exceeds 15s, which can't be forced without contrivance, but it is by construction the only case that previously printed a false success.

Found while documenting the Yume Nikki GDI session (#98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)