### PR TITLE
Screen capture uses no xcap, and grabs coordinates rather than the window

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -996,6 +996,65 @@ somiglia a un problema di antivirus: somiglia a un file mancante. Chiunque
 diagnostichi un'iniezione che smette di funzionare dovrebbe guardare
 `Get-MpThreatDetection` prima del proprio codice.
 
+### La cattura schermo non usa xcap, e prende le coordinate invece della finestra
+
+**Come e' nata la domanda (22/08/2026).** Serviva una schermata vera di Yume
+Nikki per misurare i backend VLM. Ne ho catturate diverse e sembravano nere, da
+cui la conclusione: «la superficie DirectDraw di RPG_RT non si cattura coi
+metodi GDI». **Era sbagliata**, e il modo in cui lo era vale piu' della domanda
+di partenza.
+
+**Primo fatto: xcap non esiste in questo progetto.**
+`docs/piano-vlm-contesto-visivo.md` dice che «il comando Rust screen_capture.rs
+(xcap) copre gia' Windows/Linux/macOS». Falso: `xcap` compare **zero volte** sia
+in `src-tauri/Cargo.toml` sia in `Cargo.lock`.
+
+**Secondo fatto: ci sono due moduli con lo stesso nome, e quello collegato al
+frontend e' uno stub.**
+
+| Modulo | Stato |
+|---|---|
+| `src-tauri/src/commands/screen_capture.rs` | **stub integrale**: `capture_screen` → `Err`, `capture_window` → `Err`, `get_windows` → `[]`, `get_monitors` → un 1920×1080 inventato, `check_screen_capture_available` → `false` |
+| `src-tauri/src/ocr_translator/screen_capture.rs` | reale: `BitBlt` + `SRCCOPY` dal DC **dello schermo**, alle coordinate della finestra |
+
+`lib/ocr/screen-capture.ts:87` invoca `capture_screen`, cioe' **lo stub**: quel
+percorso fallisce sempre e ripiega su `getDisplayMedia` del browser. Il percorso
+Rust vivo e' l'altro, usato da `capture_screen_region`.
+
+**Terzo fatto, quello che conta: la cattura e' delle COORDINATE, non della
+finestra.** `BitBlt` dal DC dello schermo copia quello che e' composito in quel
+rettangolo — compreso qualunque finestra ci stia sopra. Misurato: mentre cercavo
+di catturare Yume Nikki ho catturato **un video di YouTube dentro Brave**. La
+prova non e' l'immagine, e' `WindowFromPoint`:
+
+```text
+il pixel (630,460) appartiene a PID 13760 (brave)   — gioco: PID 15224
+finestra del gioco secondo GetWindowRect: (300,200)-(960,720)
+```
+
+Il gioco *diceva* di essere li'. I pixel erano di un altro processo.
+
+**E la finestra non si porta sopra a comando.** `SetForegroundWindow` fallisce
+(Windows non lascia rubare il primo piano), e `SetWindowPos(HWND_TOPMOST)` non
+basta contro un browser a schermo intero. Il primitivo giusto sarebbe
+`capture_window`, che mira alla finestra invece che all'area — ed e' quello che
+ritorna `Err("Window capture not available")`.
+
+**Perche' e' grave per il prodotto.** Una cattura dipendente dall'occlusione fa
+tradurre il testo dell'applicazione sbagliata **senza nessun segnale**: una
+notifica, un overlay, un browser davanti, e l'OCR legge quelli. Non c'e' errore,
+non c'e' log: ci sono pixel plausibili e una traduzione di qualcos'altro. Prima
+di investire sul contesto visivo (VLM) conviene sistemare questo, che sta a
+monte: un VLM alimentato dai pixel sbagliati risponde benissimo alla domanda
+sbagliata.
+
+**La trappola.** Una cattura che restituisce pixel non e' una cattura di cio' che
+hai chiesto. Ho concluso due volte dai contenuti dell'immagine («e' nera, quindi
+DirectDraw non si cattura») quando la domanda vera era *di chi sono questi
+pixel*. Il controllo che chiude la questione costa una riga —
+`WindowFromPoint` sul punto che stai per copiare — e va fatto **prima** di
+interpretare l'immagine.
+
 ---
 
 ## Come si aggiunge una voce

--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1001,8 +1001,9 @@ diagnostichi un'iniezione che smette di funzionare dovrebbe guardare
 **Come e' nata la domanda (22/08/2026).** Serviva una schermata vera di Yume
 Nikki per misurare i backend VLM. Ne ho catturate diverse e sembravano nere, da
 cui la conclusione: «la superficie DirectDraw di RPG_RT non si cattura coi
-metodi GDI». **Era sbagliata**, e il modo in cui lo era vale piu' della domanda
-di partenza.
+metodi GDI». **Era sbagliata due volte**, e il modo in cui lo era vale piu'
+della domanda di partenza. La risposta vera e' in fondo, sotto «Come e' finita»:
+`PrintWindow` cattura RPG_RT benissimo.
 
 **Primo fatto: xcap non esiste in questo progetto.**
 `docs/piano-vlm-contesto-visivo.md` dice che «il comando Rust screen_capture.rs
@@ -1048,12 +1049,47 @@ di investire sul contesto visivo (VLM) conviene sistemare questo, che sta a
 monte: un VLM alimentato dai pixel sbagliati risponde benissimo alla domanda
 sbagliata.
 
-**La trappola.** Una cattura che restituisce pixel non e' una cattura di cio' che
-hai chiesto. Ho concluso due volte dai contenuti dell'immagine («e' nera, quindi
-DirectDraw non si cattura») quando la domanda vera era *di chi sono questi
-pixel*. Il controllo che chiude la questione costa una riga —
+**La trappola, a due strati.** Una cattura che restituisce pixel non e' una
+cattura di cio' che hai chiesto. Ho concluso dai contenuti dell'immagine («e'
+nera, quindi DirectDraw non si cattura») quando la domanda vera era *di chi sono
+questi pixel*. Il controllo che chiude la questione costa una riga —
 `WindowFromPoint` sul punto che stai per copiare — e va fatto **prima** di
 interpretare l'immagine.
+
+Ma il secondo strato e' peggiore: anche dopo aver scoperto che i pixel erano di
+Brave, ho continuato a credere alla spiegazione DirectDraw, e l'ho **scritta nel
+codice** come commento. Una spiegazione sbagliata committata e' peggio di
+nessuna spiegazione: sembra conoscenza acquisita e qualcuno ci costruisce sopra.
+A smontarla e' bastato enumerare l'albero delle finestre del processo — una cosa
+che avrei potuto fare all'inizio, e che nessuna delle immagini catturate avrebbe
+mai potuto dirmi.
+
+**Come e' finita (stessa sera, PR #102).** Enumerando le finestre del processo
+con titoli e classi corretti, RPG_RT ne espone **due di primo livello con lo
+STESSO titolo**:
+
+```text
+TApplication      client 0x0     <- fantasma di Delphi/VCL
+TFormLcfGameMain  client 644x484 <- il gioco
+```
+
+`list_windows` le restituiva entrambe, e la ricerca per titolo poteva risolvere
+sul fantasma. Quella cattura non fallisce: restituisce un riquadro vuoto — il
+«nero» da cui era partita tutta la storia.
+
+Puntando alla finestra vera, **`PrintWindow` con `PW_RENDERFULLCONTENT` rende la
+schermata del titolo per intero**: logo, `ver. 0.10a`, il menu New Game / Dream
+Diary / Quit, la firma di KIKIYAMA. Leggibile, pronta per l'OCR. In numeri:
+12,1% di pixel accesi sulla finestra vera contro 6,6% sul fantasma, e quel 6,6%
+era **tutta barra del titolo**, cioe' la cornice che `PrintWindow` disegna
+sempre anche quando il contenuto manca.
+
+Quindi **DirectDraw non c'entrava niente**, e le superfici accelerate non erano
+il problema. La cura e' in due punti: `list_windows` scarta le finestre senza
+area client (ogni app Delphi ne ha una, non e' una stranezza di un gioco), e
+`capture_window` chiede alla finestra di disegnarsi invece di copiare
+dallo schermo.
+
 
 ---
 

--- a/docs/piano-vlm-contesto-visivo.md
+++ b/docs/piano-vlm-contesto-visivo.md
@@ -52,7 +52,13 @@ Nessuna dipendenza nuova obbligatoria — l'infrastruttura c'è già:
 
 Aggiunte opzionali (fase 3+):
 - **Gemini** (`@google/generative-ai`) — il branch `provider: 'gemini'` in `vision-translate.ts` esiste ma va completato; valuta di aggiungere l'SDK invece della fetch grezza.
-- Nessuna libreria di "screen capture" nuova: il comando Rust `screen_capture.rs` (xcap) copre già Windows/Linux/macOS.
+- ⚠️ **Correzione (22/08/2026): `xcap` non è una dipendenza del progetto** — compare
+  zero volte in `Cargo.toml` e in `Cargo.lock`. Di cattura schermo ce ne sono due:
+  `commands/screen_capture.rs` è uno **stub** (tutto `Err`) ed è proprio quello che
+  `lib/ocr/screen-capture.ts:87` invoca, quindi quel percorso ripiega sempre su
+  `getDisplayMedia`; `ocr_translator/screen_capture.rs` è reale ma fa `BitBlt` dalle
+  **coordinate dello schermo**, quindi cattura qualunque finestra stia sopra al gioco.
+  Vedi la voce dedicata in `METODI-DI-TRADUZIONE.md`: va risolto **prima** del VLM.
 
 ---
 


### PR DESCRIPTION
Chasing a real Yume Nikki screenshot for the VLM comparison (#100) turned up something worse than the answer I was looking for.

**`xcap` is not a dependency.** Zero occurrences in `Cargo.toml` and `Cargo.lock`, against `docs/piano-vlm-contesto-visivo.md`'s claim that it "already covers Windows/Linux/macOS". Corrected in place.

**Two modules named `screen_capture`, and the one the frontend calls is a stub:**

| Module | State |
|---|---|
| `src-tauri/src/commands/screen_capture.rs` | Complete stub — `capture_screen`/`capture_window` → `Err`, `get_windows` → `[]`, `get_monitors` → an invented 1920×1080 |
| `src-tauri/src/ocr_translator/screen_capture.rs` | Real — `BitBlt` + `SRCCOPY` from the **screen** DC at the window's coordinates |

`lib/ocr/screen-capture.ts:87` invokes the stub, so that path always falls back to the browser's `getDisplayMedia`.

**The finding: the capture is of an area, not of a window.** Anything on top lands in the frame. Aiming at the game, the capture returned a YouTube video playing in Brave:

```text
pixel (630,460) belongs to PID 13760 (brave)   — game: PID 15224
game window per GetWindowRect: (300,200)-(960,720)
```

The game *said* it was there. The pixels belonged to another process. And the window can't be forced up: `SetForegroundWindow` is refused (foreground lock), `HWND_TOPMOST` loses to a fullscreen browser. `capture_window` — the primitive that targets the window instead of the region — is the one wired to `Err`.

**Why it matters:** for a translation overlay this fails silently. A notification, an overlay, or a browser in front and the OCR reads that instead — no error, no log, just plausible pixels and a translation of something else. This sits upstream of the VLM work: a VLM fed the wrong pixels answers the wrong question very well.

The entry also records the wrong conclusion it replaces — twice I reasoned from the image's contents ("it's black, so DirectDraw can't be captured") when the real question was whose pixels those were. `WindowFromPoint` on the point about to be copied costs one line and settles it before any interpretation.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)