### PR TITLE
Find out how RPG Maker draws: one whole-frame StretchBlt, nothing else

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1155,6 +1155,50 @@ area client (ogni app Delphi ne ha una, non e' una stranezza di un gioco), e
 dallo schermo.
 
 
+### Il testo di RPG Maker 2000/2003 non passa da GDI — dimostrato, non dedotto
+
+**Cosa e' stato aggiunto.** Il hook GDI ora aggancia anche le varianti **ANSI**
+(`ExtTextOutA`, `TextOutA`, `DrawTextA`), convertendo i byte con la codepage
+implicata dal **charset del font nel DC** e non con quella di sistema: un gioco
+giapponese disegna Shift-JIS, e leggerlo come CP1252 darebbe testo plausibile e
+sbagliato. E' stata aggiunta anche una **diagnostica di esercizio**: le prime 24
+chiamate viste, con porta d'ingresso e testo grezzo, **prima di ogni filtro**.
+
+**Cosa dice la misura.** Yume Nikki portato in partita (menu del titolo, New
+Game, stanza di Madotsuki, interazioni): **zero chiamate**, né W né A, né
+ExtTextOut né TextOut né DrawText.
+
+**Il controllo positivo, che e' la parte che rende quello zero una prova.** La
+stessa DLL iniettata in `charmap.exe`:
+
+```text
+[gs-hook/GDI] #0 DrawTextW "Carattere selezionato:"
+[gs-hook/GDI] OVERLAY: Carattere selezionato:
+[gs-hook/GDI] #1 DrawTextW "U+0021: Exclamation Mark"
+[gs-hook/GDI] OVERLAY: U+0021: Exclamation Mark
+```
+
+Hook, diagnostica, coalescer e inoltro all'overlay **funzionano tutti**. E' la
+prima volta che la catena GDI si dimostra completa da capo a fondo. Quindi il
+silenzio su RPG_RT non e' uno strumento rotto: e' il gioco che non chiama.
+
+**Conseguenza pratica.** Per RPG Maker 2000/2003 la traduzione a runtime via GDI
+e' una **strada chiusa**. La strada giusta per quei giochi e' quella sui file —
+`.ldb`/`.lmu`, gia' supportata (il rilevamento e' arrivato con la PR #95). Le
+varianti ANSI restano comunque utili: valgono per qualunque altro binario
+pre-Unicode che il testo lo disegni davvero con GDI.
+
+**Cosa NON e' stato misurato.** *Come* RPG_RT disegni il testo. Gli import
+mostrano `BitBlt` e `StretchBlt`, il che e' compatibile con un font bitmap
+blittato dalla grafica System — ma e' un'inferenza, non una misura, e va
+verificata prima di costruirci sopra.
+
+**La trappola.** Il silenzio non e' una prova finche' non hai un controllo
+positivo. Un log vuoto vuol dire «il gioco non chiama» oppure «il mio strumento
+non funziona», e le due cose sono indistinguibili dall'interno. Costa poco
+separarle — un'applicazione di cui conosci gia' la risposta — e senza quel passo
+avrei scritto «RPG Maker non usa GDI» avendo in mano soltanto un hook rotto.
+
 ---
 
 ## Come si aggiunge una voce

--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1253,6 +1253,63 @@ non funziona», e le due cose sono indistinguibili dall'interno. Costa poco
 separarle — un'applicazione di cui conosci gia' la risposta — e senza quel passo
 avrei scritto «RPG Maker non usa GDI» avendo in mano soltanto un hook rotto.
 
+### RPG Maker compone il fotogramma in memoria e lo presenta con una sola StretchBlt
+
+**La domanda.** Appurato che RPG Maker 2000/2003 non chiama nessuna funzione di
+testo GDI, restava da capire **come** disegni. L'ipotesi era un font bitmap
+blittato glifo per glifo: in quel caso il rettangolo sorgente identificherebbe
+il carattere, e da li' si risalirebbe al testo.
+
+**La misura (22/08/2026, Yume Nikki in partita, `GS_HOOK_DIAG_BLIT=1`).**
+Quattrocento blit registrati. **Tutti uguali:**
+
+```text
+[gs-hook/BLIT] #0 StretchBlt src=E3011337 (0,0) 320x240 -> (0,0)
+[gs-hook/BLIT] #1 StretchBlt src=BB0113C8 (0,0) 320x240 -> (0,0)
+[gs-hook/BLIT] #2 StretchBlt src=ED011337 (0,0) 320x240 -> (0,0)
+...
+[gs-hook/BLIT] ... 1000 blit finora
+```
+
+Distribuzione: **400 su 400 sono `StretchBlt` di 320x240 dall'origine
+all'origine**. Zero `BitBlt`. Zero blit piccoli. Le DC sorgente si alternano fra
+due famiglie (`…1337` e `…13C8`): doppio buffer.
+
+**Cosa vuol dire.** Il motore disegna **tutto** — tile, sprite, finestre di
+dialogo, testo — dentro una propria bitmap in memoria, scrivendo i pixel
+direttamente, **senza una sola chiamata di disegno GDI**. Poi presenta il
+fotogramma finito con una StretchBlt per frame.
+
+**Prima conseguenza: l'intercettazione del testo a runtime e' impossibile per
+questa famiglia di motori.** Non «difficile»: impossibile per questa via. Il
+testo non esiste mai come testo in nessuna chiamata di sistema — ne' come
+stringa, ne' come glifo. Per RPG Maker 2000/2003 la traduzione va fatta **sui
+file** (`.ldb`/`.lmu`), ed e' la strada che il progetto ha gia'.
+
+**Seconda conseguenza, e qui c'e' un guadagno.** Quella StretchBlt e' un punto
+di aggancio **ideale per la cattura**: una volta per fotogramma passa il
+fotogramma COMPLETO, gia' composto, 320x240, dentro il processo. Confrontata con
+la cattura dallo schermo:
+
+| | dallo schermo | alla StretchBlt |
+|---|---|---|
+| finestra coperta | prende i pixel di chi copre | indifferente |
+| overlay/notifiche | finiscono nel fotogramma | non esistono |
+| ridimensionamento | scala della finestra | risoluzione nativa 320x240 |
+| sincronia | asincrona, prende quel che c'e' | esattamente un fotogramma |
+
+Per i giochi che presentano cosi', questo aggira **tutto** il problema della
+cattura per coordinate — non lo mitiga, lo elimina. Vale la pena tenerlo a mente
+per il percorso OCR/VLM.
+
+**La trappola.** Il primo filtro guardava solo i blit con sorgente piccola
+(<= 32 px), perche' «i glifi sono piccoli». Ha prodotto **zero righe**, e zero
+righe li' non distingue «nessun glifo» da «nessuna chiamata»: sono due risposte
+opposte e il filtro le rendeva identiche. Tolto il filtro, lo stesso identico
+esperimento ha prodotto 400 dati. **Un filtro che non produce risultati risponde
+a una domanda diversa da quella che hai fatto** — prima si guarda se la funzione
+viene chiamata, solo dopo si sceglie cosa tenere.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_gdi.cpp
+++ b/gs-hook/src/sources/source_gdi.cpp
@@ -67,6 +67,90 @@ void DiagChiamata(const wchar_t* porta, const std::wstring& s) {
     }
 }
 
+// ─── Diagnostica dei blit (opt-in: GS_HOOK_DIAG_BLIT=1) ──────────────────────
+//
+// A COSA SERVE. RPG Maker 2000/2003 non chiama nessuna funzione di testo GDI —
+// misurato, con controllo positivo. Resta da capire COME disegni il testo.
+// L'ipotesi è un font bitmap blittato glifo per glifo: se è vera, mentre una
+// frase è a schermo si vede una raffica di `BitBlt` con rettangoli sorgente
+// PICCOLI, dalla STESSA DC sorgente, a X crescente e Y costante — la stessa
+// firma che il coalescer cerca sul testo GDI. E il rettangolo sorgente
+// *identifica il carattere*, perché la sua posizione nel bitmap del font è
+// l'indice del glifo: da lì si potrebbe risalire al testo.
+//
+// PERCHÉ È OPT-IN. `BitBlt` è la chiamata più calda di un gioco 2D: passa per
+// ogni tile, ogni sprite, ogni fotogramma. Agganciarla sempre significherebbe
+// pagare un hook milioni di volte per una domanda che ci si pone una volta.
+// Con `GS_HOOK_DIAG_BLIT=1` il hook non viene nemmeno installato quando non
+// serve.
+//
+// COSA FILTRA. Solo i blit con sorgente piccola (≤ kBlitMaxLatoPx per lato):
+// i glifi lo sono, gli sfondi e le mappe no. Non è una certezza — i tile di
+// RPG Maker sono 16×16 e passano anche loro — ma riduce il rumore abbastanza da
+// far emergere una riga di testo, che si riconosce dalla progressione in X.
+// (soglia conservata per un eventuale filtro futuro; oggi non si filtra)
+constexpr int kBlitMaxLatoPx  = 32;
+constexpr int kDiagPrimiBlit  = 400;
+std::atomic<int> g_blitVisti{0};
+
+bool DiagBlitAttiva() {
+    static const bool attiva = [] {
+        char buf[8] = {};
+        return GetEnvironmentVariableA("GS_HOOK_DIAG_BLIT", buf, sizeof(buf)) > 0 &&
+               buf[0] == '1';
+    }();
+    return attiva;
+}
+
+void DiagBlit(const wchar_t* porta, HDC src, int sx, int sy, int w, int h,
+              int dx, int dy) {
+    const int n = g_blitVisti.fetch_add(1, std::memory_order_relaxed);
+
+    // Le PRIME chiamate si registrano tutte, qualunque dimensione. Filtrare per
+    // «sorgente piccola» sembrava ragionevole — i glifi sono piccoli — ma un
+    // filtro che non produce righe non distingue «nessun glifo» da «nessuna
+    // chiamata», e sono due risposte opposte. Prima si guarda se la funzione
+    // viene invocata; solo dopo ha senso selezionare cosa.
+    if (n < kDiagPrimiBlit) {
+        wchar_t riga[220];
+        // La DC sorgente in esadecimale: glifi dello stesso font arrivano tutti
+        // dalla stessa, ed è il modo più rapido per separarli dai tile.
+        swprintf_s(riga, L"[gs-hook/BLIT] #%d %ls src=%p (%d,%d) %dx%d -> (%d,%d)\n",
+                   n, porta, (void*)src, sx, sy, w, h, dx, dy);
+        LogLineW(riga);
+        return;
+    }
+
+    // Oltre il tetto si smette di scrivere una riga per chiamata — sarebbero
+    // milioni — ma si segna il passaggio alle potenze di dieci, così il log
+    // dice comunque l'ordine di grandezza invece di tacere.
+    for (int soglia = 1000; soglia <= 1000000; soglia *= 10) {
+        if (n == soglia) {
+            wchar_t riga[120];
+            swprintf_s(riga, L"[gs-hook/BLIT] ... %d blit finora\n", n);
+            LogLineW(riga);
+        }
+    }
+}
+
+using BitBlt_t = BOOL (WINAPI*)(HDC, int, int, int, int, HDC, int, int, DWORD);
+BitBlt_t Original_BitBlt = nullptr;
+
+BOOL WINAPI Hook_BitBlt(HDC dst, int x, int y, int w, int h,
+                        HDC src, int sx, int sy, DWORD rop) {
+    DiagBlit(L"BitBlt", src, sx, sy, w, h, x, y);
+    return Original_BitBlt(dst, x, y, w, h, src, sx, sy, rop);
+}
+
+using StretchBlt_t = BOOL (WINAPI*)(HDC, int, int, int, int, HDC, int, int, int, int, DWORD);
+StretchBlt_t Original_StretchBlt = nullptr;
+
+BOOL WINAPI Hook_StretchBlt(HDC dst, int x, int y, int w, int h,
+                            HDC src, int sx, int sy, int sw, int sh, DWORD rop) {
+    DiagBlit(L"StretchBlt", src, sx, sy, sw, sh, x, y);
+    return Original_StretchBlt(dst, x, y, w, h, src, sx, sy, sw, sh, rop);
+}
+
 // Guardia di rientranza: DrawTextW (user32) rende il testo chiamando ExtTextOutW
 // UNA VOLTA PER RIGA VISIVA del word-wrap. Senza questa guardia, il contenuto di
 // DrawText verrebbe catturato due volte: intero dal hook DrawTextW e a pezzi
@@ -682,12 +766,31 @@ public:
                           (LPVOID*)&Original_EndPaint) == MH_OK) {
             MH_EnableHook((LPVOID)pEnd);
         }
+        // Diagnostica dei blit: installata SOLO su richiesta esplicita, e non
+        // conta per l'attivazione — è uno strumento d'indagine, non una
+        // sorgente di testo.
+        if (DiagBlitAttiva()) {
+            struct { const char* nome; LPVOID hook; LPVOID* orig; } blit[] = {
+                { "BitBlt",     (LPVOID)&Hook_BitBlt,     (LPVOID*)&Original_BitBlt     },
+                { "StretchBlt", (LPVOID)&Hook_StretchBlt, (LPVOID*)&Original_StretchBlt },
+            };
+            for (const auto& b : blit) {
+                auto p = GetProcAddress(gdi, b.nome);
+                if (p && MH_CreateHook((LPVOID)p, b.hook, b.orig) == MH_OK) {
+                    MH_EnableHook((LPVOID)p);
+                }
+            }
+            LogLineW(L"[gs-hook/BLIT] diagnostica blit attiva (GS_HOOK_DIAG_BLIT=1)\n");
+        }
+
         return any ? Activation::Activated : Activation::Failed;
     }
 
     void Deactivate() override {
         if (Original_ExtTextOutW) MH_DisableHook((LPVOID)Original_ExtTextOutW);
         if (Original_DrawTextW)   MH_DisableHook((LPVOID)Original_DrawTextW);
+        if (Original_BitBlt)      MH_DisableHook((LPVOID)Original_BitBlt);
+        if (Original_StretchBlt)  MH_DisableHook((LPVOID)Original_StretchBlt);
         if (Original_ExtTextOutA) MH_DisableHook((LPVOID)Original_ExtTextOutA);
         if (Original_TextOutA)    MH_DisableHook((LPVOID)Original_TextOutA);
         if (Original_DrawTextA)   MH_DisableHook((LPVOID)Original_DrawTextA);

--- a/gs-hook/src/sources/source_gdi.cpp
+++ b/gs-hook/src/sources/source_gdi.cpp
@@ -1,9 +1,17 @@
 //
 // source_gdi.cpp — Livello 2 (UNIVERSALE), sorgente GDI. ⭐ Il pezzo innovativo.
 //
-// Aggancia ExtTextOutW / DrawTextW / TextOutW in gdi32.dll. Moltissimi engine
-// diversi (vecchi, custom, middleware, alcuni RPG Maker, tool, emulatori) e gran
-// parte della UI Win32 passano da qui SENZA saperlo: un solo hook → tanti giochi.
+// Aggancia ExtTextOut / TextOut / DrawText in gdi32+user32, nelle varianti
+// Unicode E ANSI. Moltissimi engine diversi (vecchi, custom, middleware, tool,
+// emulatori) e gran parte della UI Win32 passano da qui SENZA saperlo: un solo
+// hook → tanti giochi.
+//
+// DOVE **NON** ARRIVA (misurato il 22/08/2026, Yume Nikki portato in partita):
+// RPG Maker 2000/2003 non chiama NESSUNA di queste funzioni, né W né A — zero
+// righe di diagnostica in una sessione intera. Disegna il testo per conto suo,
+// e per quei giochi la strada giusta è quella sui file (.ldb/.lmu), non questa.
+// Il controllo positivo che rende attendibile quello zero: la stessa DLL in
+// charmap.exe produce catture e righe OVERLAY regolarmente.
 //
 // IL PROBLEMA DURO (e il senso dello spike): il testo spesso NON arriva come
 // frase intera. Arriva a pezzi — parola per parola, a volte glifo per glifo —
@@ -29,11 +37,35 @@
 #include <chrono>
 #include <climits>
 #include <cwctype>
+#include <atomic>
 
 namespace gs {
 namespace {
 
 TranslateFn g_translate = nullptr;
+
+// ─── Diagnostica di esercizio ────────────────────────────────────────────────
+//
+// Il log diceva «sorgente attiva» perché MH_CreateHook era riuscito — cioè
+// perché la funzione esiste in gdi32, non perché il gioco la chiami. Un hook su
+// una funzione mai invocata è indistinguibile, nel log, da un hook che funziona
+// e non ha ancora visto testo, e su Yume Nikki quella differenza è costata una
+// diagnosi sbagliata.
+//
+// Queste righe la rendono visibile: le PRIME chiamate viste, con la porta
+// d'ingresso e il testo grezzo, PRIMA di ogni filtro. Zero righe `#n` nel log
+// dopo una sessione di gioco significa che il testo non passa da GDI, e lo dice
+// senza doverlo dedurre. Il tetto tiene il costo fisso: non è tracciamento
+// continuo, è una risposta a una domanda.
+constexpr int kDiagPrimeChiamate = 24;
+std::atomic<int> g_chiamateViste{0};
+
+void DiagChiamata(const wchar_t* porta, const std::wstring& s) {
+    const int n = g_chiamateViste.fetch_add(1, std::memory_order_relaxed);
+    if (n < kDiagPrimeChiamate) {
+        LogLineW(L"[gs-hook/GDI] #" + std::to_wstring(n) + L" " + porta + L" \"" + s + L"\"\n");
+    }
+}
 
 // Guardia di rientranza: DrawTextW (user32) rende il testo chiamando ExtTextOutW
 // UNA VOLTA PER RIGA VISIVA del word-wrap. Senza questa guardia, il contenuto di
@@ -358,6 +390,7 @@ BOOL WINAPI Hook_ExtTextOutW(HDC hdc, int x, int y, UINT options, const RECT* re
     // ETO_GLYPH_INDEX: `str` contiene indici di glifo, NON caratteri → non toccare.
     if (str && count > 0 && g_inDrawText == 0 && !(options & ETO_GLYPH_INDEX)) {
         std::wstring s(str, count);
+        DiagChiamata(L"ExtTextOutW", s);
 
         // MODALITÀ PASSIVA (default, real-time/overlay): osserva + coalesce +
         // inoltra all'overlay SENZA mai sopprimere/ridisegnare. Il gioco disegna
@@ -404,6 +437,7 @@ int WINAPI Hook_DrawTextW(HDC hdc, LPCWSTR str, int count, LPRECT rect, UINT for
         if (len > 0) {
             // DrawText passa di solito una frase/paragrafo intero → caso ideale.
             std::wstring whole(str, len);
+            DiagChiamata(L"DrawTextW", whole);
             if (kPassiveOverlayMode) {
                 // Passivo: inoltra l'intera stringa all'overlay, poi disegna
                 // normalmente (la guardia sotto evita la doppia cattura delle
@@ -435,6 +469,130 @@ int WINAPI Hook_DrawTextW(HDC hdc, LPCWSTR str, int count, LPRECT rect, UINT for
     return result;
 }
 
+// ═══ Varianti ANSI ═══════════════════════════════════════════════════════════
+//
+// PERCHÉ ESISTONO (22/08/2026, misurato su Yume Nikki).
+// Il hook agganciava solo le funzioni Unicode. La tabella degli import di
+// RPG_RT.exe dice che il gioco non le chiama MAI:
+//
+//     ExtTextOutA  PRESENTE      ExtTextOutW  assente
+//     TextOutA     PRESENTE      TextOutW     assente
+//     DrawTextA    PRESENTE      DrawTextW    assente
+//
+// E le A non passano dalle W: in gdi32 sono implementazioni separate che
+// scendono entrambe al kernel. Agganciare solo la W non intercetta
+// un'applicazione ANSI in nessun caso. RPG_RT è un binario Delphi pre-Unicode,
+// quindi questo vale per TUTTO RPG Maker 2000/2003 — cioè proprio i giochi per
+// cui questa sorgente di livello 2 esiste.
+
+// La codepage NON è quella di sistema: è quella implicata dal charset del font
+// selezionato nel DC. Un gioco giapponese su Windows italiano disegna byte
+// Shift-JIS con un font SHIFTJIS_CHARSET, e interpretarli con la CP1252 di
+// sistema produce testo plausibile e sbagliato — l'errore peggiore possibile
+// qui, perché non somiglia a un errore.
+UINT CodepageForDC(HDC hdc) {
+    CHARSETINFO csi{};
+    const UINT charset = GetTextCharset(hdc);
+    if (charset != DEFAULT_CHARSET &&
+        TranslateCharsetInfo(reinterpret_cast<DWORD*>(static_cast<UINT_PTR>(charset)),
+                             &csi, TCI_SRCCHARSET)) {
+        return csi.ciACP;
+    }
+    return CP_ACP;
+}
+
+std::wstring AnsiToWide(HDC hdc, const char* str, int count) {
+    if (!str || count <= 0) return std::wstring();
+    const UINT cp = CodepageForDC(hdc);
+    const int need = MultiByteToWideChar(cp, 0, str, count, nullptr, 0);
+    if (need <= 0) return std::wstring();
+    std::wstring out(static_cast<size_t>(need), L'\0');
+    MultiByteToWideChar(cp, 0, str, count, &out[0], need);
+    return out;
+}
+
+// Guardia di rientranza per la famiglia ANSI. Non si sa, senza misurarlo, se
+// TextOutA passi internamente da ExtTextOutA e DrawTextA da entrambe: dipende
+// dalla versione di gdi32. Con questo contatore la cattura la fa solo la
+// chiamata più esterna, quindi agganciarle tutte e tre è sicuro comunque vada,
+// e il tag nel log dice quale porta d'ingresso ha visto il testo.
+thread_local int g_inAnsiText = 0;
+
+struct AnsiGuard {
+    AnsiGuard()  { ++g_inAnsiText; }
+    ~AnsiGuard() { --g_inAnsiText; }
+};
+
+// In modalità passiva si osserva e si inoltra all'overlay, senza toccare il
+// disegno. La SOSTITUZIONE in-place qui NON è implementata di proposito:
+// richiederebbe riconvertire la traduzione nella codepage del gioco, e una
+// codepage giapponese non rappresenta le lettere accentate italiane. La
+// conversione non fallisce: sostituisce i caratteri mancanti, e a schermo
+// comparirebbe «perch?» invece di «perché». Meglio lasciare l'originale che
+// disegnare una traduzione storpiata.
+void OsservaAnsi(HDC hdc, const char* str, int count, const wchar_t* porta,
+                 int x, int y, UINT options) {
+    const std::wstring s = AnsiToWide(hdc, str, count);
+    if (s.empty()) return;
+    DiagChiamata(porta, s);
+
+    if (kPassiveOverlayMode) {
+        DrawCtx ctx = CaptureCtx(hdc, x, y, options);
+        std::wstring closedText;
+        DrawCtx      closedCtx;
+        if (g_coalescer.Add(ctx, s, closedText, closedCtx) && !closedText.empty()) {
+            ForwardToOverlay(closedText);
+        }
+    } else if (kSpikeLogOnly) {
+        LogLineW(std::wstring(L"[gs-hook/GDI] ") + porta + L": " + s + L"\n");
+    }
+}
+
+using ExtTextOutA_t = BOOL (WINAPI*)(HDC, int, int, UINT, const RECT*,
+                                     LPCSTR, UINT, const INT*);
+ExtTextOutA_t Original_ExtTextOutA = nullptr;
+
+BOOL WINAPI Hook_ExtTextOutA(HDC hdc, int x, int y, UINT options, const RECT* rect,
+                             LPCSTR str, UINT count, const INT* dx) {
+    if (str && count > 0 && g_inAnsiText == 0 && !(options & ETO_GLYPH_INDEX)) {
+        OsservaAnsi(hdc, str, (int)count, L"ExtTextOutA", x, y, options);
+    }
+    AnsiGuard g;
+    return Original_ExtTextOutA(hdc, x, y, options, rect, str, count, dx);
+}
+
+using TextOutA_t = BOOL (WINAPI*)(HDC, int, int, LPCSTR, int);
+TextOutA_t Original_TextOutA = nullptr;
+
+BOOL WINAPI Hook_TextOutA(HDC hdc, int x, int y, LPCSTR str, int count) {
+    if (str && count > 0 && g_inAnsiText == 0) {
+        OsservaAnsi(hdc, str, count, L"TextOutA", x, y, 0);
+    }
+    AnsiGuard g;
+    return Original_TextOutA(hdc, x, y, str, count);
+}
+
+using DrawTextA_t = int (WINAPI*)(HDC, LPCSTR, int, LPRECT, UINT);
+DrawTextA_t Original_DrawTextA = nullptr;
+
+int WINAPI Hook_DrawTextA(HDC hdc, LPCSTR str, int count, LPRECT rect, UINT format) {
+    if (str && g_inAnsiText == 0) {
+        const int len = (count < 0) ? (int)strlen(str) : count;
+        if (len > 0) {
+            // DrawText passa di norma una frase intera: va all'overlay così
+            // com'è, senza passare dal coalescer che serve ai frammenti.
+            const std::wstring whole = AnsiToWide(hdc, str, len);
+            if (!whole.empty()) {
+                DiagChiamata(L"DrawTextA", whole);
+                if (kPassiveOverlayMode)      ForwardToOverlay(whole);
+                else if (kSpikeLogOnly)       LogLineW(L"[gs-hook/GDI] DrawTextA: " + whole + L"\n");
+            }
+        }
+    }
+    AnsiGuard g;
+    return Original_DrawTextA(hdc, str, count, rect, format);
+}
+
 // ─── Hook su EndPaint (user32) ───────────────────────────────────────────────
 // A fine frame chiude l'ULTIMA riga ancora bufferizzata e la ridisegna tradotta:
 // i suoi glifi sono stati soppressi e non sono ancora a schermo. Il DC di
@@ -464,7 +622,7 @@ BOOL WINAPI Hook_EndPaint(HWND hwnd, const PAINTSTRUCT* ps) {
 
 class GdiSource : public ITextSource {
 public:
-    const char* Name() const override { return "GDI (ExtTextOutW/DrawTextW)"; }
+    const char* Name() const override { return "GDI (ExtTextOut/TextOut/DrawText, W+A)"; }
     Level GetLevel() const override { return Level::Rasterization; }
 
     bool IsApplicable() const override {
@@ -494,6 +652,29 @@ public:
             MH_EnableHook((LPVOID)pDraw) == MH_OK) {
             any = true;
         }
+        // Varianti ANSI: sono quelle che usano davvero i binari pre-Unicode
+        // (tutto RPG Maker 2000/2003). Si agganciano tutte e tre perché non è
+        // misurato quale passi internamente per quale, e la guardia di
+        // rientranza rende innocua la sovrapposizione.
+        struct { const char* nome; LPVOID hook; LPVOID* orig; } ansi[] = {
+            { "ExtTextOutA", (LPVOID)&Hook_ExtTextOutA, (LPVOID*)&Original_ExtTextOutA },
+            { "TextOutA",    (LPVOID)&Hook_TextOutA,    (LPVOID*)&Original_TextOutA    },
+        };
+        for (const auto& a : ansi) {
+            auto p = GetProcAddress(gdi, a.nome);
+            if (p && MH_CreateHook((LPVOID)p, a.hook, a.orig) == MH_OK &&
+                MH_EnableHook((LPVOID)p) == MH_OK) {
+                any = true;
+            }
+        }
+        auto pDrawA = GetProcAddress(user32, "DrawTextA");
+        if (pDrawA &&
+            MH_CreateHook((LPVOID)pDrawA, (LPVOID)&Hook_DrawTextA,
+                          (LPVOID*)&Original_DrawTextA) == MH_OK &&
+            MH_EnableHook((LPVOID)pDrawA) == MH_OK) {
+            any = true;
+        }
+
         // EndPaint: serve a chiudere/ridisegnare l'ultima riga soppressa del frame
         // (suppress-and-redraw glifo-per-glifo). Non incide sull'attivazione.
         if (pEnd &&
@@ -507,6 +688,9 @@ public:
     void Deactivate() override {
         if (Original_ExtTextOutW) MH_DisableHook((LPVOID)Original_ExtTextOutW);
         if (Original_DrawTextW)   MH_DisableHook((LPVOID)Original_DrawTextW);
+        if (Original_ExtTextOutA) MH_DisableHook((LPVOID)Original_ExtTextOutA);
+        if (Original_TextOutA)    MH_DisableHook((LPVOID)Original_TextOutA);
+        if (Original_DrawTextA)   MH_DisableHook((LPVOID)Original_DrawTextA);
         if (Original_EndPaint)    MH_DisableHook((LPVOID)Original_EndPaint);
     }
 };


### PR DESCRIPTION
Follows #104, which proved RPG Maker calls no GDI text function at all. The open question was **how** it draws. The guess was a bitmap font blitted glyph by glyph — which would have made the source rectangle identify the character.

**An opt-in blit diagnostic answers it.** `GS_HOOK_DIAG_BLIT=1` hooks `BitBlt` and `StretchBlt` and records the first calls with full geometry. Opt-in because `BitBlt` is the hottest call in a 2D game: paying for a hook on every tile of every frame, to answer a question you ask once, is not a trade worth making by default.

**Yume Nikki in gameplay — 400 blits, all identical:**

```text
[gs-hook/BLIT] #0 StretchBlt src=E3011337 (0,0) 320x240 -> (0,0)
[gs-hook/BLIT] #1 StretchBlt src=BB0113C8 (0,0) 320x240 -> (0,0)
...
[gs-hook/BLIT] ... 1000 blit finora
```

400 of 400 are `StretchBlt` of 320×240 origin-to-origin, source DCs alternating between two families (double buffering). **Zero `BitBlt`. Zero small blits.** The engine composes the entire frame — tiles, sprites, message windows, text — into its own memory bitmap by writing pixels directly, with no GDI drawing call at all, then presents it once per frame.

**First consequence.** Runtime text interception is not *hard* for this engine family, it is **impossible** by this route: the text never exists as text in any system call, neither as a string nor as a glyph. Those games belong to the file route (`.ldb`/`.lmu`).

**Second consequence — the gain.** That `StretchBlt` is an ideal capture tap:

| | screen capture | at the StretchBlt |
|---|---|---|
| window covered | grabs the coverer's pixels | irrelevant |
| overlays / notifications | land in the frame | cannot exist |
| synchronisation | takes whatever is there | exactly one frame |

For games that present this way it doesn't mitigate the capture-by-coordinates problem fixed in #102 — it **eliminates** it. Worth remembering for the OCR/VLM path.

**The trap recorded.** The first filter logged only blits with a source of ≤32px, because glyphs are small. It produced **zero lines**, and zero lines there cannot separate "no glyphs" from "no calls" — opposite answers the filter made identical. Removing it turned the same experiment into 400 data points. A filter that yields nothing is answering a different question than the one you asked.

Both architectures build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)