### PR TITLE
Capture the frame where the game hands it over

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1310,6 +1310,61 @@ esperimento ha prodotto 400 dati. **Un filtro che non produce risultati risponde
 a una domanda diversa da quella che hai fatto** — prima si guarda se la funzione
 viene chiamata, solo dopo si sceglie cosa tenere.
 
+### La cattura al present: il fotogramma preso dove il gioco lo consegna
+
+**Cos'e'.** `GS_HOOK_FRAME_DUMP=<prefisso>` fa salvare al hook i primi
+fotogrammi come `.bmp`, presi **dentro l'hook sul blit di present** — quello con
+cui il gioco consegna il frame finito alla finestra. Si riconosce da
+`WindowFromDC(destinazione)`, non dalle dimensioni: 320x240 e' di questo gioco,
+mentre «la destinazione e' una finestra» vale per qualunque motore che presenti
+con un blit.
+
+**La prova che i pixel non vengono dallo schermo.** Non basta catturare e vedere
+il gioco: se la finestra e' in primo piano, anche la cattura dallo schermo
+darebbe la stessa immagine, e le due ipotesi restano indistinguibili. Serve una
+condizione in cui lo schermo NON puo' avere quei pixel.
+
+Primo tentativo: coprire la finestra con un'altra. Fallito due volte — il gioco
+si riprende il primo piano, e lo script l'ha detto («il gioco NON e coperto, il
+test non prova niente») invece di spacciare per riuscito un test che non lo era.
+
+Secondo tentativo, decisivo: **spostare la finestra fuori dallo schermo**.
+
+```text
+schermo virtuale: 2293x960 da (0,0)
+finestra a (2343,100)-(3003,620)  interseca lo schermo: False
+[gs-hook/FRAME] #0 320x240 -> ...fuori-0.bmp (ok)
+[gs-hook/FRAME] #1 320x240 -> ...fuori-1.bmp (ok)
+[gs-hook/FRAME] #2 320x240 -> ...fuori-2.bmp (ok)
+```
+
+I tre BMP contengono la schermata del titolo **completa e corretta**, mentre di
+quella finestra non c'era **un solo pixel** sul monitor. Nessuna cattura dallo
+schermo puo' produrre quel risultato.
+
+**Cosa vale.** Confrontata con la cattura dallo schermo, su cui questo progetto
+ha perso una serata:
+
+| | dallo schermo | al present |
+|---|---|---|
+| finestra coperta | prende i pixel di chi copre | indifferente |
+| finestra fuori schermo | impossibile | **misurato: funziona** |
+| overlay, notifiche, cursore | finiscono nel fotogramma | non esistono ancora |
+| risoluzione | quella della finestra, scalata | nativa, 320x240 |
+| sincronia | «quello che c'era» | esattamente un fotogramma |
+
+**Cosa NON fa, di proposito.** Non consegna i fotogrammi all'applicazione: salva
+un numero limitato di file e si ferma. Quel ponte va costruito con **entrambi i
+lati insieme** — questo progetto ha gia' collezionato IPC a meta', ed e' il
+motivo per cui la catena in-game e' rimasta ferma tanto tempo. Qui si dimostra
+il punto d'aggancio; il trasporto e' un passo successivo e deliberato.
+
+**La trappola.** Un test che non riproduce la condizione da provare non prova
+niente, per quanto il risultato sembri buono. Catturare un gioco in primo piano
+e vedere il gioco e' compatibile con entrambe le spiegazioni. Il test vale solo
+quando la spiegazione sbagliata e' **impossibile**: fuori dallo schermo, i pixel
+dello schermo non ci sono, e resta una sola lettura.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_gdi.cpp
+++ b/gs-hook/src/sources/source_gdi.cpp
@@ -133,12 +133,113 @@ void DiagBlit(const wchar_t* porta, HDC src, int sx, int sy, int w, int h,
     }
 }
 
+// ─── Cattura del fotogramma al present (opt-in: GS_HOOK_FRAME_DUMP=<prefisso>) ─
+//
+// PERCHÉ QUI. Misurato il 22/08/2026: RPG Maker 2000/2003 compone l'INTERO
+// fotogramma in una bitmap in memoria — tile, sprite, testo — senza una sola
+// chiamata di disegno GDI, e lo presenta con una `StretchBlt` per frame. Quel
+// blit finale è quindi il posto migliore per prendere l'immagine:
+//
+//   - la finestra può essere coperta, minimizzata, dietro un browser a schermo
+//     intero: qui non cambia niente, perché i pixel non vengono dallo schermo;
+//   - overlay, notifiche e cursori NON possono finirci dentro, perché non
+//     esistono ancora: il fotogramma è quello del gioco, prima della
+//     composizione del desktop;
+//   - si prende ESATTAMENTE un fotogramma, non «quello che c'era sullo schermo».
+//
+// È l'opposto della cattura per coordinate, che ha restituito i pixel di un
+// browser mentre puntava a un gioco (vedi METODI-DI-TRADUZIONE.md).
+//
+// COSA FA E COSA NON FA. Salva un numero LIMITATO di fotogrammi come .bmp, e si
+// ferma. Non espone i frame all'applicazione: quel ponte va costruito con
+// entrambi i lati insieme, e questo progetto ha già collezionato IPC a metà.
+// Qui si dimostra il punto d'aggancio; il trasporto è un passo successivo e
+// deliberato.
+constexpr int kMaxFotogrammiDump = 3;
+std::atomic<int> g_fotogrammiSalvati{0};
+
+const std::wstring& PrefissoDump() {
+    static const std::wstring p = [] {
+        wchar_t buf[MAX_PATH] = {};
+        const DWORD n = GetEnvironmentVariableW(L"GS_HOOK_FRAME_DUMP", buf, MAX_PATH);
+        return (n > 0 && n < MAX_PATH) ? std::wstring(buf, n) : std::wstring();
+    }();
+    return p;
+}
+
+bool DumpFotogrammiAttivo() { return !PrefissoDump().empty(); }
+
+// Scrive un BMP a 32 bit. `bits` è bottom-up, come lo restituisce GetDIBits con
+// altezza positiva: è già il verso naturale del formato, quindi non si gira
+// niente e non c'è un'immagine capovolta da sbagliare.
+bool SalvaBmp(const std::wstring& path, const void* bits, int w, int h) {
+    const DWORD dati = (DWORD)w * (DWORD)h * 4;
+    BITMAPFILEHEADER fh{};
+    fh.bfType    = 0x4D42; // "BM"
+    fh.bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+    fh.bfSize    = fh.bfOffBits + dati;
+
+    BITMAPINFOHEADER ih{};
+    ih.biSize      = sizeof(BITMAPINFOHEADER);
+    ih.biWidth     = w;
+    ih.biHeight    = h;
+    ih.biPlanes    = 1;
+    ih.biBitCount  = 32;
+    ih.biSizeImage = dati;
+
+    HANDLE f = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
+                           CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (f == INVALID_HANDLE_VALUE) return false;
+    DWORD scritti = 0;
+    bool ok = WriteFile(f, &fh, sizeof(fh), &scritti, nullptr) &&
+              WriteFile(f, &ih, sizeof(ih), &scritti, nullptr) &&
+              WriteFile(f, bits, dati, &scritti, nullptr);
+    CloseHandle(f);
+    return ok;
+}
+
+// Il "present" è un blit la cui destinazione è la DC di una FINESTRA. Si
+// riconosce così e non dalle dimensioni: 320×240 è di questo gioco, mentre
+// `WindowFromDC` vale per qualunque motore che presenti con un blit.
+void CatturaSePresent(HDC dst, HDC src, int sw, int sh) {
+    if (!DumpFotogrammiAttivo()) return;
+    if (g_fotogrammiSalvati.load(std::memory_order_relaxed) >= kMaxFotogrammiDump) return;
+    if (sw <= 0 || sh <= 0 || !WindowFromDC(dst)) return;
+
+    HBITMAP bmp = (HBITMAP)GetCurrentObject(src, OBJ_BITMAP);
+    if (!bmp) return;
+
+    BITMAPINFO bi{};
+    bi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
+    bi.bmiHeader.biWidth       = sw;
+    bi.bmiHeader.biHeight      = sh;   // positivo = bottom-up, il verso del BMP
+    bi.bmiHeader.biPlanes      = 1;
+    bi.bmiHeader.biBitCount    = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    std::vector<unsigned char> pixel((size_t)sw * sh * 4);
+    if (!GetDIBits(src, bmp, 0, (UINT)sh, pixel.data(), &bi, DIB_RGB_COLORS)) return;
+
+    const int n = g_fotogrammiSalvati.fetch_add(1, std::memory_order_relaxed);
+    if (n >= kMaxFotogrammiDump) return;
+
+    wchar_t path[MAX_PATH];
+    swprintf_s(path, L"%ls-%d.bmp", PrefissoDump().c_str(), n);
+    const bool ok = SalvaBmp(path, pixel.data(), sw, sh);
+
+    wchar_t riga[MAX_PATH + 80];
+    swprintf_s(riga, L"[gs-hook/FRAME] #%d %dx%d -> %ls (%ls)\n",
+               n, sw, sh, path, ok ? L"ok" : L"scrittura fallita");
+    LogLineW(riga);
+}
+
 using BitBlt_t = BOOL (WINAPI*)(HDC, int, int, int, int, HDC, int, int, DWORD);
 BitBlt_t Original_BitBlt = nullptr;
 
 BOOL WINAPI Hook_BitBlt(HDC dst, int x, int y, int w, int h,
                         HDC src, int sx, int sy, DWORD rop) {
     DiagBlit(L"BitBlt", src, sx, sy, w, h, x, y);
+    CatturaSePresent(dst, src, w, h);
     return Original_BitBlt(dst, x, y, w, h, src, sx, sy, rop);
 }
 
@@ -148,6 +249,7 @@ StretchBlt_t Original_StretchBlt = nullptr;
 BOOL WINAPI Hook_StretchBlt(HDC dst, int x, int y, int w, int h,
                             HDC src, int sx, int sy, int sw, int sh, DWORD rop) {
     DiagBlit(L"StretchBlt", src, sx, sy, sw, sh, x, y);
+    CatturaSePresent(dst, src, sw, sh);
     return Original_StretchBlt(dst, x, y, w, h, src, sx, sy, sw, sh, rop);
 }
 
@@ -769,7 +871,10 @@ public:
         // Diagnostica dei blit: installata SOLO su richiesta esplicita, e non
         // conta per l'attivazione — è uno strumento d'indagine, non una
         // sorgente di testo.
-        if (DiagBlitAttiva()) {
+        // Gli hook sui blit servono a due cose — la diagnostica e la cattura del
+        // fotogramma — ma la funzione si aggancia UNA volta sola: due
+        // MH_CreateHook sullo stesso indirizzo sono un guaio, non una comodità.
+        if (DiagBlitAttiva() || DumpFotogrammiAttivo()) {
             struct { const char* nome; LPVOID hook; LPVOID* orig; } blit[] = {
                 { "BitBlt",     (LPVOID)&Hook_BitBlt,     (LPVOID*)&Original_BitBlt     },
                 { "StretchBlt", (LPVOID)&Hook_StretchBlt, (LPVOID*)&Original_StretchBlt },
@@ -780,7 +885,8 @@ public:
                     MH_EnableHook((LPVOID)p);
                 }
             }
-            LogLineW(L"[gs-hook/BLIT] diagnostica blit attiva (GS_HOOK_DIAG_BLIT=1)\n");
+            if (DiagBlitAttiva())       LogLineW(L"[gs-hook/BLIT] diagnostica blit attiva (GS_HOOK_DIAG_BLIT=1)\n");
+            if (DumpFotogrammiAttivo()) LogLineW(L"[gs-hook/FRAME] cattura al present attiva -> " + PrefissoDump() + L"-N.bmp\n");
         }
 
         return any ? Activation::Activated : Activation::Failed;


### PR DESCRIPTION
Follows #105, which measured that RPG Maker composes the whole frame in memory and presents it with a single `StretchBlt`. That blit is the best place to take the image.

`GS_HOOK_FRAME_DUMP=<prefix>` now saves the first frames as `.bmp` from inside the hook, reading the source DC's bitmap directly with `GetDIBits`.

- **The present is recognised by `WindowFromDC(destination)`, not by size.** 320×240 belongs to this game; "the destination is a window" holds for any engine that presents with a blit.
- **The blit hooks are shared with the existing diagnostic** and installed once — two `MH_CreateHook` on one address is a bug, not a convenience.

**Proving the pixels don't come from the screen took two attempts.** Covering the window failed twice: the game takes the foreground back, and the script reported `il gioco NON e coperto, il test non prova niente` rather than passing off a test that hadn't reproduced its own condition.

Moving the window off-screen settled it:

```text
schermo virtuale: 2293x960 da (0,0)
finestra a (2343,100)-(3003,620)  interseca lo schermo: False
[gs-hook/FRAME] #0 320x240 -> ...fuori-0.bmp (ok)
[gs-hook/FRAME] #1 320x240 -> ...fuori-1.bmp (ok)
[gs-hook/FRAME] #2 320x240 -> ...fuori-2.bmp (ok)
```

Not one pixel of that window was on the monitor, and the three captured frames hold the **complete, correct** title screen. No screen capture can produce that.

| | screen capture | at the present |
|---|---|---|
| window covered | grabs the coverer's pixels | irrelevant |
| window off-screen | impossible | **measured: works** |
| overlays, notifications, cursor | land in the frame | don't exist yet |
| resolution | window size, scaled | native 320×240 |
| synchronisation | whatever was there | exactly one frame |

**What it deliberately does not do:** hand frames to the application. It writes a bounded number of files and stops. That bridge needs both sides built together — this repository has collected half-finished IPC before, and that is why the in-game chain stalled for so long. The tap is demonstrated here; the transport is a separate, deliberate step.

Both architectures build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)