### PR TITLE
Carry frames from the hook to the backend, both sides in one change

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1365,6 +1365,65 @@ e vedere il gioco e' compatibile con entrambe le spiegazioni. Il test vale solo
 quando la spiegazione sbagliata e' **impossibile**: fuori dallo schermo, i pixel
 dello schermo non ci sono, e resta una sola lettura.
 
+### Il trasporto dei fotogrammi, con i due lati costruiti insieme
+
+**Cos'e'.** `GS_HOOK_FRAME_SHARE=1` fa pubblicare a gs-hook l'ultimo fotogramma
+in memoria condivisa (`Local\gs-hook-frame-<pid>`); il backend lo legge col
+comando Tauri `read_game_frame(pid)`. Il contratto sta in
+`gs-hook/include/gs_frame_share.h`, il lettore in
+`src-tauri/src/commands/game_frame.rs`.
+
+**Perche' memoria condivisa e non una pipe.** Un fotogramma va sempre
+SOSTITUITO, mai accodato: al consumatore interessa l'ultimo, non la storia. Una
+pipe accumulerebbe fotogrammi che nessuno vuole, e un lettore lento
+riempirebbe il buffer bloccando il gioco. Un buffer che si sovrascrive non puo'
+ingolfarsi: se il lettore e' lento salta dei fotogrammi, che e' il
+comportamento giusto. Per lo stesso motivo **non c'e' un canale di richiesta**:
+il thread di rendering del gioco non deve mai aspettare nessuno.
+
+**Il ritmo.** Copiare 300 KB a 60 fotogrammi al secondo sono 18 MB/s di memcpy
+dentro il rendering, per un OCR che ne usera' dieci. Si pubblica al massimo ogni
+100 ms (`GS_HOOK_FRAME_MS`). Misurato: il contatore avanza di 8 in 400 ms, e
+avanza di **2 per fotogramma** (vedi sotto), quindi 4 fotogrammi in 400 ms —
+esattamente il ritmo dichiarato.
+
+**Il contatore in stile seqlock.** Il produttore lo porta a dispari prima di
+scrivere e a pari dopo; il lettore accetta la copia solo se il valore era pari
+ed e' rimasto identico. Senza, si prende meta' fotogramma vecchio e meta' nuovo:
+il risultato **sembra un'immagine**, quindi non si nota. Nessun lock, cosi' un
+consumatore che muore non puo' bloccare il gioco — cosa che un mutex condiviso
+farebbe.
+
+**I due lati nascono insieme, ed e' il punto.** Questo repository ha gia'
+collezionato IPC monchi — memoria condivisa senza lettore, pipe di richiesta
+senza risposta — ed e' il motivo per cui la catena in-game e' rimasta ferma a
+lungo. Qui il produttore C++, il lettore Rust, nove test e una prova a due
+processi arrivano nello stesso cambiamento.
+
+**Due difetti trovati SOLO dalla prova a due processi**, entrambi della stessa
+famiglia: risultato plausibile, contenuto sbagliato. I nove test unitari
+passavano in entrambi i casi.
+
+1. **Il quarto byte non e' alpha.** Le DIB a 32 bit di GDI sono BGR**X**: quel
+   byte resta a zero. Copiarlo come alpha dava un PNG **interamente
+   trasparente**. La misura che l'ha inchiodato: `5180 pixel con RGB non nero,
+   0 pixel con alpha non zero` — l'immagine era corretta e invisibile. E il
+   test che avrebbe dovuto vederlo passava un alpha di 255 in ingresso, quindi
+   **concordava col codice invece di verificarlo**. Ora passa zero, come fa GDI.
+   Lo stesso difetto era in `capture_window` (PR #102), scritto poche ore prima:
+   corretto anche li'.
+2. **Le righe erano capovolte.** `GetDIBits` con altezza positiva le
+   restituisce dal basso — il verso del BMP, sbagliato per tutto il resto. Il
+   fotogramma arrivava specchiato in verticale. Ora il contratto dichiara
+   **top-down**, il produttore chiede altezza negativa, e il BMP di diagnostica
+   si adegua (il formato ammette altezze negative).
+
+**La trappola.** «Il trasporto funziona» sembrava provato da tre segnali
+concordi: sequenza che avanza, uscita 0, PNG di 16 KB. Erano tutti veri, e
+l'immagine consegnata era un rettangolo vuoto. Un canale si verifica guardando
+**cosa e' arrivato**, non se e' arrivato qualcosa — e conviene guardarlo con
+occhi, non con un conteggio di byte.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/CMakeLists.txt
+++ b/gs-hook/CMakeLists.txt
@@ -24,6 +24,7 @@ set(GS_HOOK_SOURCES
     src/dllmain.cpp
     src/registry.cpp
     src/gs_overlay_ipc.cpp
+    src/gs_frame_share.cpp
     src/sources/source_unity_mono.cpp
     src/sources/source_unreal_ftext.cpp
     src/sources/source_gdi.cpp

--- a/gs-hook/include/gs_frame_share.h
+++ b/gs-hook/include/gs_frame_share.h
@@ -1,0 +1,121 @@
+#pragma once
+//
+// gs_frame_share.h — il formato con cui gs-hook pubblica i fotogrammi.
+//
+// QUESTO FILE È IL CONTRATTO. La controparte che lo legge è
+// `src-tauri/src/commands/game_frame.rs`: se qui cambia un campo, là va
+// cambiato lo stesso, e il numero di versione serve proprio a far fallire in
+// modo esplicito chi si dimentica. Il progetto ha già collezionato IPC in cui
+// mancava un lato; qui i due lati nascono insieme e hanno un test che li mette
+// uno di fronte all'altro.
+//
+// PERCHÉ MEMORIA CONDIVISA E NON UNA PIPE. Un fotogramma è grosso e va sempre
+// SOSTITUITO, mai accodato: al consumatore interessa l'ultimo, non la storia.
+// Una pipe accumulerebbe fotogrammi vecchi che nessuno vuole, e basterebbe un
+// lettore lento per riempire il buffer e bloccare il gioco. Un buffer che si
+// sovrascrive non può ingolfarsi: se il lettore è lento, salta dei fotogrammi,
+// che è esattamente il comportamento giusto.
+//
+// PERCHÉ NESSUNA RICHIESTA. Non c'è un canale «dammi un fotogramma». Il
+// produttore pubblica, il consumatore legge quando vuole. Un percorso di
+// richiesta significherebbe che il thread di rendering del gioco aspetta
+// qualcuno, e un consumatore fermo diventerebbe un gioco fermo.
+//
+#include <cstdint>
+
+namespace gs {
+namespace frame {
+
+// 'G','S','F','R' in little-endian. Un lettore che apre la mappatura sbagliata
+// se ne accorge subito invece di interpretare byte a caso come pixel.
+constexpr uint32_t kMagic = 0x52465347u;
+
+// Da alzare a ogni modifica del formato. Il lettore rifiuta ciò che non conosce.
+constexpr uint32_t kVersione = 1;
+
+// Unico formato per ora: 8 bit per canale, ordine BGR**X** come lo restituisce
+// GDI, righe dall'ALTO in basso. La conversione la fa il consumatore, che sa
+// cosa gli serve. Due dettagli che vanno dichiarati qui perché sbagliarli
+// produce un'immagine plausibile invece di un errore:
+//
+//   - IL QUARTO BYTE NON È ALPHA. Le DIB a 32 bit di GDI lo lasciano a zero:
+//     è riempimento. Copiarlo come alpha dà un fotogramma corretto nei colori
+//     e completamente trasparente — misurato, 5180 pixel giusti e nessuno
+//     visibile.
+//   - LE RIGHE VANNO DALL'ALTO IN BASSO. `GetDIBits` con altezza positiva le
+//     restituisce dal basso, che è il verso del formato BMP; per il resto del
+//     mondo è capovolto. Il produttore chiede quindi altezza NEGATIVA e
+//     pubblica dall'alto. Anche questo è stato misurato al contrario prima di
+//     essere scritto qui.
+constexpr uint32_t kFormatoBGRA32 = 0;
+
+// I pixel iniziano qui. Fisso e generoso: aggiungere un campo
+// all'intestazione non deve spostare i pixel, altrimenti un produttore nuovo e
+// un consumatore vecchio si disallineano in silenzio.
+constexpr uint32_t kOffsetPixel = 64;
+
+// Nome della mappatura: `Local\` la tiene nella sessione dell'utente, senza i
+// privilegi che `Global\` richiede. Il PID del gioco fa parte del nome perché
+// più giochi possono essere agganciati insieme.
+//   Local\gs-hook-frame-<pid>
+constexpr wchar_t kPrefissoNome[] = L"Local\\gs-hook-frame-";
+
+// Disposizione in memoria condivisa. Campi a larghezza fissa e in un ordine che
+// dà lo stesso allineamento a 32 e a 64 bit: il gioco può essere x86 mentre il
+// backend è x64, e i due DEVONO vedere gli stessi offset.
+//
+//   0  magic          4
+//   4  versione       4
+//   8  larghezza      4
+//  12  altezza        4
+//  16  formato        4
+//  20  byteFotogramma 4
+//  24  scrittura      8   (allineato a 8 in entrambe le architetture)
+//  32  pid            4
+//  36  riservato      4
+//  64  pixel...
+//
+struct Intestazione {
+    uint32_t magic;
+    uint32_t versione;
+    uint32_t larghezza;
+    uint32_t altezza;
+    uint32_t formato;
+    uint32_t byteFotogramma;
+    uint64_t scrittura;      // vedi sotto: contatore in stile seqlock
+    uint32_t pid;
+    uint32_t riservato;
+};
+static_assert(sizeof(Intestazione) == 40, "il formato è un contratto: non cambiarne la dimensione senza alzare kVersione");
+
+// IL CONTATORE `scrittura`, che è la parte che evita letture stracciate.
+//
+// Il produttore scrive mentre il consumatore legge: senza precauzioni il
+// lettore può prendere metà del fotogramma vecchio e metà del nuovo, e il
+// risultato **sembra un'immagine**, quindi l'errore non si nota. È lo stesso
+// modo di sbagliare che questo progetto ha già incontrato: un risultato
+// plausibile e falso.
+//
+// Convenzione (seqlock):
+//   dispari → scrittura IN CORSO, i pixel non sono affidabili
+//   pari    → stabile
+//
+// Il lettore legge il contatore, copia, rilegge: la copia vale solo se il
+// valore era pari ED è rimasto identico. Nessun lock, quindi un consumatore
+// che muore non può bloccare il gioco — che con un mutex condiviso, invece,
+// succederebbe.
+
+// Avvia la pubblicazione per questo processo. Idempotente.
+// Ritorna false se la mappatura non si può creare (e allora non si pubblica,
+// senza far fallire nient'altro).
+bool Inizializza(uint32_t larghezza, uint32_t altezza);
+
+// Pubblica un fotogramma BGRA32. `byte` deve valere larghezza*altezza*4.
+// Silenziosa e a costo fisso: viene chiamata dal thread di rendering del gioco.
+void Pubblica(const void* pixel, uint32_t byte);
+
+// Chiude la mappatura. Da chiamare allo spegnimento del hook.
+void Chiudi();
+
+} // namespace frame
+} // namespace gs

--- a/gs-hook/src/gs_frame_share.cpp
+++ b/gs-hook/src/gs_frame_share.cpp
@@ -1,0 +1,130 @@
+//
+// gs_frame_share.cpp — pubblicazione dei fotogrammi in memoria condivisa.
+//
+// Il contratto sta in include/gs_frame_share.h; qui c'è solo l'attuazione.
+//
+#include "gs_frame_share.h"
+#include "gs_log.h"
+
+#include <Windows.h>
+#include <atomic>
+#include <mutex>
+#include <string>
+
+namespace gs {
+namespace frame {
+namespace {
+
+HANDLE   g_mappatura = nullptr;
+void*    g_base      = nullptr;
+uint32_t g_larghezza = 0;
+uint32_t g_altezza   = 0;
+std::mutex g_mutex;   // serializza Inizializza/Chiudi, NON il percorso caldo
+
+Intestazione* Testa() { return static_cast<Intestazione*>(g_base); }
+
+unsigned char* Pixel() {
+    return static_cast<unsigned char*>(g_base) + kOffsetPixel;
+}
+
+// Il contatore va letto e scritto come atomico a 64 bit: su x86 e x64 è
+// lock-free, quindi funziona anche fra un gioco a 32 bit e un backend a 64.
+std::atomic<uint64_t>* Contatore() {
+    return reinterpret_cast<std::atomic<uint64_t>*>(
+        static_cast<unsigned char*>(g_base) + offsetof(Intestazione, scrittura));
+}
+
+} // namespace
+
+bool Inizializza(uint32_t larghezza, uint32_t altezza) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_base) return true;                       // già pronto
+    if (larghezza == 0 || altezza == 0) return false;
+
+    const uint64_t byteFotogramma = (uint64_t)larghezza * altezza * 4;
+    const uint64_t totale = kOffsetPixel + byteFotogramma;
+
+    // La mappatura è dimensionata sul fotogramma VERO, non su un massimo
+    // prudenziale: un buffer da «tanto per stare larghi» sarebbe memoria
+    // committata e mai usata, e la dimensione la sappiamo qui.
+    const std::wstring nome = kPrefissoNome + std::to_wstring(GetCurrentProcessId());
+    g_mappatura = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE,
+                                     (DWORD)(totale >> 32), (DWORD)(totale & 0xFFFFFFFFu),
+                                     nome.c_str());
+    if (!g_mappatura) {
+        LogLineW(L"[gs-hook/FRAME] CreateFileMapping fallita: niente pubblicazione\n");
+        return false;
+    }
+    g_base = MapViewOfFile(g_mappatura, FILE_MAP_ALL_ACCESS, 0, 0, (SIZE_T)totale);
+    if (!g_base) {
+        CloseHandle(g_mappatura);
+        g_mappatura = nullptr;
+        LogLineW(L"[gs-hook/FRAME] MapViewOfFile fallita: niente pubblicazione\n");
+        return false;
+    }
+
+    g_larghezza = larghezza;
+    g_altezza   = altezza;
+
+    // L'intestazione si compila PRIMA di dichiarare il buffer valido: il magic
+    // va scritto per ultimo, così un lettore che apre la mappatura mentre la
+    // stiamo preparando non trova mai un magic giusto su campi non ancora
+    // scritti.
+    Intestazione* h = Testa();
+    h->versione       = kVersione;
+    h->larghezza      = larghezza;
+    h->altezza        = altezza;
+    h->formato        = kFormatoBGRA32;
+    h->byteFotogramma = (uint32_t)byteFotogramma;
+    h->pid            = GetCurrentProcessId();
+    h->riservato      = 0;
+    Contatore()->store(0, std::memory_order_release);
+    std::atomic_thread_fence(std::memory_order_release);
+    h->magic          = kMagic;
+
+    wchar_t riga[200];
+    swprintf_s(riga, L"[gs-hook/FRAME] pubblicazione attiva: %ls (%ux%u, %llu byte)\n",
+               nome.c_str(), larghezza, altezza, (unsigned long long)totale);
+    LogLineW(riga);
+    return true;
+}
+
+void Pubblica(const void* pixel, uint32_t byte) {
+    if (!g_base || !pixel) return;
+    if (byte != Testa()->byteFotogramma) return;   // dimensione cambiata: si salta
+
+    auto* seq = Contatore();
+    const uint64_t s = seq->load(std::memory_order_relaxed);
+
+    // Dispari: «sto scrivendo». Il lettore che vede un valore dispari scarta e
+    // riprova, invece di copiare pixel a metà.
+    seq->store(s + 1, std::memory_order_release);
+    std::atomic_thread_fence(std::memory_order_release);
+
+    memcpy(Pixel(), pixel, byte);
+
+    // Pari e diverso dal precedente: «fotogramma nuovo e stabile». Il lettore
+    // usa proprio la disuguaglianza per accorgersi di aver letto durante una
+    // scrittura.
+    std::atomic_thread_fence(std::memory_order_release);
+    seq->store(s + 2, std::memory_order_release);
+}
+
+void Chiudi() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_base) {
+        // Il magic si azzera per primo: un lettore che arriva mentre smontiamo
+        // deve vedere «non valido», non un'intestazione buona su memoria che
+        // sta per sparire.
+        Testa()->magic = 0;
+        UnmapViewOfFile(g_base);
+        g_base = nullptr;
+    }
+    if (g_mappatura) {
+        CloseHandle(g_mappatura);
+        g_mappatura = nullptr;
+    }
+}
+
+} // namespace frame
+} // namespace gs

--- a/gs-hook/src/sources/source_gdi.cpp
+++ b/gs-hook/src/sources/source_gdi.cpp
@@ -29,6 +29,7 @@
 #include "text_source.h"
 #include "gs_log.h"
 #include "gs_overlay_ipc.h"
+#include "gs_frame_share.h"
 #include <Windows.h>
 #include <MinHook.h>
 #include <string>
@@ -169,9 +170,9 @@ const std::wstring& PrefissoDump() {
 
 bool DumpFotogrammiAttivo() { return !PrefissoDump().empty(); }
 
-// Scrive un BMP a 32 bit. `bits` è bottom-up, come lo restituisce GetDIBits con
-// altezza positiva: è già il verso naturale del formato, quindi non si gira
-// niente e non c'è un'immagine capovolta da sbagliare.
+// Scrive un BMP a 32 bit. `bits` arriva TOP-DOWN (vedi il contratto in
+// gs_frame_share.h), quindi l'intestazione dichiara un'altezza negativa: il
+// formato BMP lo prevede, e cosi' non si gira niente in memoria.
 bool SalvaBmp(const std::wstring& path, const void* bits, int w, int h) {
     const DWORD dati = (DWORD)w * (DWORD)h * 4;
     BITMAPFILEHEADER fh{};
@@ -182,7 +183,7 @@ bool SalvaBmp(const std::wstring& path, const void* bits, int w, int h) {
     BITMAPINFOHEADER ih{};
     ih.biSize      = sizeof(BITMAPINFOHEADER);
     ih.biWidth     = w;
-    ih.biHeight    = h;
+    ih.biHeight    = -h;   // top-down: i pixel arrivano gia' in quel verso
     ih.biPlanes    = 1;
     ih.biBitCount  = 32;
     ih.biSizeImage = dati;
@@ -198,13 +199,65 @@ bool SalvaBmp(const std::wstring& path, const void* bits, int w, int h) {
     return ok;
 }
 
+// ─── Pubblicazione dei fotogrammi (opt-in: GS_HOOK_FRAME_SHARE=1) ────────────
+//
+// Il dump su file dimostra il punto d'aggancio ma non serve all'applicazione.
+// Questa è la consegna vera: l'ultimo fotogramma finisce in memoria condivisa,
+// dove il backend lo legge quando gli serve (vedi gs_frame_share.h e
+// src-tauri/src/commands/game_frame.rs).
+//
+// IL RITMO. Copiare 300 KB a 60 fotogrammi al secondo sono 18 MB/s di memcpy
+// dentro il thread di rendering del gioco, per un consumatore che ne userà
+// forse dieci al secondo. Si pubblica quindi al massimo ogni
+// kIntervalloPubblicazioneMs: l'OCR non ha bisogno di più, e il gioco non paga
+// lavoro che nessuno guarda. Chi ne vuole di più cambia l'intervallo con
+// GS_HOOK_FRAME_MS.
+constexpr DWORD kIntervalloPubblicazioneMsDefault = 100;
+
+bool CondivisioneAttiva() {
+    static const bool attiva = [] {
+        char buf[8] = {};
+        return GetEnvironmentVariableA("GS_HOOK_FRAME_SHARE", buf, sizeof(buf)) > 0 &&
+               buf[0] == '1';
+    }();
+    return attiva;
+}
+
+DWORD IntervalloPubblicazioneMs() {
+    static const DWORD ms = [] {
+        char buf[16] = {};
+        if (GetEnvironmentVariableA("GS_HOOK_FRAME_MS", buf, sizeof(buf)) > 0) {
+            const int v = atoi(buf);
+            if (v >= 0) return (DWORD)v;
+        }
+        return kIntervalloPubblicazioneMsDefault;
+    }();
+    return ms;
+}
+
 // Il "present" è un blit la cui destinazione è la DC di una FINESTRA. Si
 // riconosce così e non dalle dimensioni: 320×240 è di questo gioco, mentre
 // `WindowFromDC` vale per qualunque motore che presenti con un blit.
 void CatturaSePresent(HDC dst, HDC src, int sw, int sh) {
-    if (!DumpFotogrammiAttivo()) return;
-    if (g_fotogrammiSalvati.load(std::memory_order_relaxed) >= kMaxFotogrammiDump) return;
+    const bool dump      = DumpFotogrammiAttivo() &&
+                           g_fotogrammiSalvati.load(std::memory_order_relaxed) < kMaxFotogrammiDump;
+    const bool condividi = CondivisioneAttiva();
+    if (!dump && !condividi) return;
     if (sw <= 0 || sh <= 0 || !WindowFromDC(dst)) return;
+
+    // Freno sul ritmo: si applica solo alla pubblicazione. Il dump è già
+    // limitato nel numero e serve a guardare i primi fotogrammi, quindi non
+    // deve aspettare.
+    static DWORD ultimaPubblicazione = 0;
+    bool pubblicaOra = false;
+    if (condividi) {
+        const DWORD ora = GetTickCount();
+        if (ora - ultimaPubblicazione >= IntervalloPubblicazioneMs()) {
+            ultimaPubblicazione = ora;
+            pubblicaOra = true;
+        }
+    }
+    if (!dump && !pubblicaOra) return;   // niente da fare in questo fotogramma
 
     HBITMAP bmp = (HBITMAP)GetCurrentObject(src, OBJ_BITMAP);
     if (!bmp) return;
@@ -212,13 +265,28 @@ void CatturaSePresent(HDC dst, HDC src, int sw, int sh) {
     BITMAPINFO bi{};
     bi.bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
     bi.bmiHeader.biWidth       = sw;
-    bi.bmiHeader.biHeight      = sh;   // positivo = bottom-up, il verso del BMP
+    // Altezza NEGATIVA = righe dall'alto in basso. E' il verso che vuole
+    // chiunque tranne il formato BMP, ed e' quello dichiarato nel contratto in
+    // gs_frame_share.h; il BMP di diagnostica si adegua scrivendo a sua volta
+    // un'altezza negativa, che il formato ammette.
+    bi.bmiHeader.biHeight      = -sh;
     bi.bmiHeader.biPlanes      = 1;
     bi.bmiHeader.biBitCount    = 32;
     bi.bmiHeader.biCompression = BI_RGB;
 
     std::vector<unsigned char> pixel((size_t)sw * sh * 4);
     if (!GetDIBits(src, bmp, 0, (UINT)sh, pixel.data(), &bi, DIB_RGB_COLORS)) return;
+
+    if (pubblicaOra) {
+        // La mappatura si crea al primo fotogramma, quando la dimensione vera è
+        // nota: dimensionarla su un massimo prudenziale sarebbe memoria
+        // committata e mai usata.
+        if (frame::Inizializza((uint32_t)sw, (uint32_t)sh)) {
+            frame::Pubblica(pixel.data(), (uint32_t)pixel.size());
+        }
+    }
+
+    if (!dump) return;
 
     const int n = g_fotogrammiSalvati.fetch_add(1, std::memory_order_relaxed);
     if (n >= kMaxFotogrammiDump) return;
@@ -874,7 +942,7 @@ public:
         // Gli hook sui blit servono a due cose — la diagnostica e la cattura del
         // fotogramma — ma la funzione si aggancia UNA volta sola: due
         // MH_CreateHook sullo stesso indirizzo sono un guaio, non una comodità.
-        if (DiagBlitAttiva() || DumpFotogrammiAttivo()) {
+        if (DiagBlitAttiva() || DumpFotogrammiAttivo() || CondivisioneAttiva()) {
             struct { const char* nome; LPVOID hook; LPVOID* orig; } blit[] = {
                 { "BitBlt",     (LPVOID)&Hook_BitBlt,     (LPVOID*)&Original_BitBlt     },
                 { "StretchBlt", (LPVOID)&Hook_StretchBlt, (LPVOID*)&Original_StretchBlt },
@@ -895,6 +963,7 @@ public:
     void Deactivate() override {
         if (Original_ExtTextOutW) MH_DisableHook((LPVOID)Original_ExtTextOutW);
         if (Original_DrawTextW)   MH_DisableHook((LPVOID)Original_DrawTextW);
+        frame::Chiudi();
         if (Original_BitBlt)      MH_DisableHook((LPVOID)Original_BitBlt);
         if (Original_StretchBlt)  MH_DisableHook((LPVOID)Original_StretchBlt);
         if (Original_ExtTextOutA) MH_DisableHook((LPVOID)Original_ExtTextOutA);

--- a/src-tauri/examples/read-game-frame.rs
+++ b/src-tauri/examples/read-game-frame.rs
@@ -1,0 +1,58 @@
+//! Legge l'ultimo fotogramma che gs-hook pubblica per un gioco e lo salva.
+//!
+//! Perché esiste. I test unitari provano il LETTORE contro un'intestazione che
+//! si costruisce da sé: se il produttore C++ scrivesse a offset diversi,
+//! passerebbero lo stesso. Solo due processi veri, uno che scrive e uno che
+//! legge, dimostrano che il contratto in `gs-hook/include/gs_frame_share.h` è
+//! rispettato da entrambi i lati.
+//!
+//! Uso:
+//!   cargo run --example read-game-frame -- <pid> [uscita.png]
+//!
+//! Il gioco deve girare con gs-hook iniettato e `GS_HOOK_FRAME_SHARE=1`.
+
+use gamestringer::commands::game_frame::read_game_frame;
+
+fn main() {
+    let argomenti: Vec<String> = std::env::args().skip(1).collect();
+    let Some(pid) = argomenti.first().and_then(|s| s.parse::<u32>().ok()) else {
+        eprintln!("uso: cargo run --example read-game-frame -- <pid> [uscita.png]");
+        std::process::exit(1);
+    };
+    let uscita = argomenti.get(1).cloned().unwrap_or_else(|| "fotogramma.png".to_string());
+
+    // Due letture di seguito: la seconda serve a vedere se il contatore avanza,
+    // cioè se il gioco sta davvero pubblicando e non ci stiamo rileggendo lo
+    // stesso fotogramma fermo.
+    let primo = match read_game_frame(pid) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("lettura fallita: {e}");
+            std::process::exit(2);
+        }
+    };
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let secondo = read_game_frame(pid).ok();
+
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let png = STANDARD.decode(&primo.image_data).expect("base64");
+    std::fs::write(&uscita, &png).expect("scrittura PNG");
+
+    println!(
+        "letto {}x{} seq={} -> {uscita} ({} byte PNG)",
+        primo.width,
+        primo.height,
+        primo.sequence,
+        png.len()
+    );
+    match secondo {
+        Some(s) if s.sequence > primo.sequence => {
+            println!("seq avanzata {} -> {}: il gioco sta pubblicando", primo.sequence, s.sequence)
+        }
+        Some(s) => println!(
+            "seq ferma a {}: il gioco non ha pubblicato nulla di nuovo in 400 ms",
+            s.sequence
+        ),
+        None => println!("seconda lettura fallita"),
+    }
+}

--- a/src-tauri/src/commands/game_frame.rs
+++ b/src-tauri/src/commands/game_frame.rs
@@ -1,0 +1,345 @@
+//! Lettura dei fotogrammi che gs-hook pubblica in memoria condivisa.
+//!
+//! LA CONTROPARTE È `gs-hook/include/gs_frame_share.h`. Quel file è il
+//! contratto; qui c'è il lettore. Se là cambia un campo, qui va cambiato lo
+//! stesso, e `VERSIONE` serve a far fallire in modo esplicito chi se ne
+//! dimentica invece di leggere byte a caso come pixel.
+//!
+//! PERCHÉ ESISTE. La cattura dallo schermo prende ciò che è composito alle
+//! coordinate della finestra: puntando a un gioco ha restituito i pixel di un
+//! browser che gli stava davanti (vedi `docs/METODI-DI-TRADUZIONE.md`). Qui i
+//! pixel arrivano da dentro il gioco, presi nel punto in cui consegna il
+//! fotogramma finito: coperta, minimizzata o fuori dallo schermo, la finestra
+//! non fa differenza.
+//!
+//! I DUE LATI NASCONO INSIEME. Questo repository ha già collezionato IPC in cui
+//! mancava un capo — memoria condivisa senza lettore, pipe di richiesta senza
+//! risposta — ed è il motivo per cui la catena in-game è rimasta ferma a lungo.
+//! Il test in fondo scrive una mappatura con lo stesso formato del produttore e
+//! la rilegge con questo lettore: se i due si disallineano, fallisce.
+
+use serde::{Deserialize, Serialize};
+
+/// Deve combaciare con `gs::frame::kMagic` ('G','S','F','R' in little-endian).
+const MAGIC: u32 = 0x5246_5347;
+/// Deve combaciare con `gs::frame::kVersione`.
+const VERSIONE: u32 = 1;
+/// Deve combaciare con `gs::frame::kOffsetPixel`.
+const OFFSET_PIXEL: usize = 64;
+/// Deve combaciare con `gs::frame::kFormatoBGRA32`.
+const FORMATO_BGRA32: u32 = 0;
+
+/// Quanti giri fare quando si legge durante una scrittura. Il produttore scrive
+/// una volta ogni ~100 ms e la copia dura microsecondi, quindi due tentativi
+/// bastano ampiamente; il tetto esiste perché un produttore morto a metà
+/// scrittura lascerebbe il contatore dispari per sempre, e un ciclo senza
+/// uscita bloccherebbe il backend.
+const MAX_TENTATIVI: u32 = 8;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GameFrame {
+    /// PNG in base64, come `CaptureResult` altrove: è il formato che il
+    /// frontend già consuma.
+    pub image_data: String,
+    pub width: u32,
+    pub height: u32,
+    /// Contatore di pubblicazione. Chi ripete la lettura lo usa per sapere se
+    /// il fotogramma è nuovo senza confrontare i pixel.
+    pub sequence: u64,
+}
+
+/// Intestazione letta dalla memoria condivisa.
+#[derive(Debug)]
+struct Intestazione {
+    larghezza: u32,
+    altezza: u32,
+    byte_fotogramma: u32,
+}
+
+/// Legge i campi fissi. Separata dal resto perché è pura aritmetica su byte, e
+/// così il test la esercita senza toccare Windows.
+fn leggi_intestazione(testa: &[u8]) -> Result<Intestazione, String> {
+    if testa.len() < OFFSET_PIXEL {
+        return Err("intestazione troncata".into());
+    }
+    let u32a = |off: usize| {
+        u32::from_le_bytes([testa[off], testa[off + 1], testa[off + 2], testa[off + 3]])
+    };
+
+    let magic = u32a(0);
+    if magic != MAGIC {
+        // Anche il caso «tutti zero» finisce qui: è la mappatura in fase di
+        // creazione o già smontata, e va trattata come non pronta, non come
+        // dati validi.
+        return Err(format!("magic {magic:#010x} inatteso: nessun fotogramma pubblicato"));
+    }
+    let versione = u32a(4);
+    if versione != VERSIONE {
+        return Err(format!(
+            "versione {versione} non supportata (attesa {VERSIONE}): gs-hook e backend disallineati"
+        ));
+    }
+    let larghezza = u32a(8);
+    let altezza = u32a(12);
+    let formato = u32a(16);
+    let byte_fotogramma = u32a(20);
+
+    if formato != FORMATO_BGRA32 {
+        return Err(format!("formato {formato} non supportato"));
+    }
+    if larghezza == 0 || altezza == 0 {
+        return Err("dimensioni nulle".into());
+    }
+    // Il conto deve tornare: un `byte_fotogramma` incoerente sarebbe un
+    // puntatore sbagliato mascherato da immagine.
+    let attesi = (larghezza as u64) * (altezza as u64) * 4;
+    if attesi != byte_fotogramma as u64 {
+        return Err(format!(
+            "byte incoerenti: {byte_fotogramma} dichiarati, {attesi} implicati da {larghezza}x{altezza}"
+        ));
+    }
+    Ok(Intestazione { larghezza, altezza, byte_fotogramma })
+}
+
+/// Converte i byte che dà GDI in un PNG base64.
+///
+/// IL QUARTO BYTE NON È ALPHA. Le DIB a 32 bit di GDI sono BGR**X**: il quarto
+/// byte è riempimento e resta a zero. Trattarlo come alpha produce un PNG
+/// interamente trasparente — misurato: 5180 pixel col colore giusto e **zero**
+/// pixel con alpha diverso da zero, cioè un'immagine corretta e invisibile. Il
+/// trasporto sembrava funzionare (sequenza che avanza, uscita 0, PNG di 16 KB)
+/// e consegnava un rettangolo vuoto. Qui l'opacità si impone.
+fn bgra_in_png_base64(bgra: &[u8], larghezza: u32, altezza: u32) -> Result<String, String> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use image::ImageOutputFormat;
+    use std::io::Cursor;
+
+    let mut rgba = bgra.to_vec();
+    for p in rgba.chunks_exact_mut(4) {
+        p.swap(0, 2); // BGRX -> RGBX
+        p[3] = 255;   // X -> alpha opaco
+    }
+    let buf = image::RgbaImage::from_raw(larghezza, altezza, rgba)
+        .ok_or_else(|| "dimensioni incoerenti col buffer".to_string())?;
+    let mut png = Vec::new();
+    image::DynamicImage::ImageRgba8(buf)
+        .write_to(&mut Cursor::new(&mut png), ImageOutputFormat::Png)
+        .map_err(|e| format!("png encode: {e}"))?;
+    Ok(STANDARD.encode(&png))
+}
+
+#[cfg(windows)]
+mod win {
+    use super::*;
+    use std::ffi::c_void;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenFileMappingW(access: u32, inherit: i32, name: *const u16) -> *mut c_void;
+        fn MapViewOfFile(h: *mut c_void, access: u32, hi: u32, lo: u32, bytes: usize) -> *mut c_void;
+        fn UnmapViewOfFile(base: *const c_void) -> i32;
+        fn CloseHandle(h: *mut c_void) -> i32;
+    }
+    const FILE_MAP_READ: u32 = 0x0004;
+
+    /// Chiude mappatura e vista anche se si esce per errore: senza questo, ogni
+    /// lettura fallita lascerebbe un handle aperto nel backend, e il backend è
+    /// un processo che vive quanto l'applicazione.
+    struct Vista {
+        handle: *mut c_void,
+        base: *mut c_void,
+    }
+    impl Drop for Vista {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.base.is_null() {
+                    UnmapViewOfFile(self.base);
+                }
+                if !self.handle.is_null() {
+                    CloseHandle(self.handle);
+                }
+            }
+        }
+    }
+
+    pub fn nome_mappatura(pid: u32) -> Vec<u16> {
+        format!("Local\\gs-hook-frame-{pid}\0").encode_utf16().collect()
+    }
+
+    pub fn leggi(pid: u32) -> Result<GameFrame, String> {
+        let nome = nome_mappatura(pid);
+        let vista = unsafe {
+            let handle = OpenFileMappingW(FILE_MAP_READ, 0, nome.as_ptr());
+            if handle.is_null() {
+                return Err(format!(
+                    "nessun fotogramma condiviso per il PID {pid}: gs-hook non è iniettato, \
+                     oppure gira senza GS_HOOK_FRAME_SHARE=1"
+                ));
+            }
+            let base = MapViewOfFile(handle, FILE_MAP_READ, 0, 0, 0);
+            if base.is_null() {
+                CloseHandle(handle);
+                return Err("MapViewOfFile fallita".into());
+            }
+            Vista { handle, base }
+        };
+
+        // L'intestazione dice quanto è grande il fotogramma; la si legge prima
+        // di toccare i pixel.
+        let testa = unsafe { std::slice::from_raw_parts(vista.base as *const u8, OFFSET_PIXEL) };
+        let h = leggi_intestazione(testa)?;
+
+        let totale = OFFSET_PIXEL + h.byte_fotogramma as usize;
+        let tutto = unsafe { std::slice::from_raw_parts(vista.base as *const u8, totale) };
+        let contatore = unsafe {
+            &*((vista.base as *const u8).add(24) as *const std::sync::atomic::AtomicU64)
+        };
+
+        // Lettura in stile seqlock. Senza, si può prendere metà del fotogramma
+        // vecchio e metà del nuovo: il risultato SEMBRA un'immagine, quindi
+        // l'errore non si vede. È lo stesso modo di sbagliare che questo
+        // progetto ha già incontrato — un risultato plausibile e falso.
+        use std::sync::atomic::Ordering;
+        for _ in 0..MAX_TENTATIVI {
+            let prima = contatore.load(Ordering::Acquire);
+            if prima % 2 != 0 {
+                std::thread::yield_now();
+                continue; // scrittura in corso
+            }
+            let pixel = tutto[OFFSET_PIXEL..totale].to_vec();
+            let dopo = contatore.load(Ordering::Acquire);
+            if prima == dopo {
+                if prima == 0 {
+                    return Err("nessun fotogramma ancora pubblicato".into());
+                }
+                return Ok(GameFrame {
+                    image_data: bgra_in_png_base64(&pixel, h.larghezza, h.altezza)?,
+                    width: h.larghezza,
+                    height: h.altezza,
+                    sequence: prima,
+                });
+            }
+            std::thread::yield_now();
+        }
+        Err("il fotogramma cambia più in fretta di quanto si riesca a leggerlo".into())
+    }
+}
+
+/// Legge l'ultimo fotogramma pubblicato dal gioco con questo PID.
+#[tauri::command]
+pub fn read_game_frame(pid: u32) -> Result<GameFrame, String> {
+    #[cfg(windows)]
+    {
+        win::leggi(pid)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = pid;
+        Err("i fotogrammi condivisi esistono solo su Windows".into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Costruisce un'intestazione valida, come la scrive il produttore C++.
+    fn testa(larghezza: u32, altezza: u32, magic: u32, versione: u32) -> Vec<u8> {
+        let mut b = vec![0u8; OFFSET_PIXEL];
+        let mut put = |off: usize, v: u32| b[off..off + 4].copy_from_slice(&v.to_le_bytes());
+        put(0, magic);
+        put(4, versione);
+        put(8, larghezza);
+        put(12, altezza);
+        put(16, FORMATO_BGRA32);
+        put(20, larghezza * altezza * 4);
+        b
+    }
+
+    #[test]
+    fn intestazione_valida_si_legge() {
+        let h = leggi_intestazione(&testa(320, 240, MAGIC, VERSIONE)).unwrap();
+        assert_eq!((h.larghezza, h.altezza), (320, 240));
+        assert_eq!(h.byte_fotogramma, 320 * 240 * 4);
+    }
+
+    /// Il caso «mappatura appena creata» o «già smontata»: tutto zero. Va
+    /// rifiutato, non interpretato come un fotogramma 0x0.
+    #[test]
+    fn buffer_azzerato_e_rifiutato() {
+        assert!(leggi_intestazione(&vec![0u8; OFFSET_PIXEL]).is_err());
+    }
+
+    /// Il motivo per cui la versione esiste: un gs-hook aggiornato accanto a un
+    /// backend vecchio deve fallire dicendolo, non leggere byte a caso.
+    #[test]
+    fn versione_diversa_e_rifiutata() {
+        let e = leggi_intestazione(&testa(320, 240, MAGIC, VERSIONE + 1)).unwrap_err();
+        assert!(e.contains("disallineati"), "{e}");
+    }
+
+    #[test]
+    fn magic_sbagliato_e_rifiutato() {
+        assert!(leggi_intestazione(&testa(320, 240, 0xDEAD_BEEF, VERSIONE)).is_err());
+    }
+
+    /// Un `byte_fotogramma` che non torna coi lati sarebbe un puntatore
+    /// sbagliato travestito da immagine.
+    #[test]
+    fn byte_incoerenti_col_formato_sono_rifiutati() {
+        let mut b = testa(320, 240, MAGIC, VERSIONE);
+        b[20..24].copy_from_slice(&1234u32.to_le_bytes());
+        let e = leggi_intestazione(&b).unwrap_err();
+        assert!(e.contains("incoerenti"), "{e}");
+    }
+
+    #[test]
+    fn intestazione_troncata_e_rifiutata() {
+        assert!(leggi_intestazione(&[0u8; 8]).is_err());
+    }
+
+    /// I byte arrivano nell'ordine di GDI: il blu è il primo. Se la conversione
+    /// saltasse lo scambio, l'immagine uscirebbe con rosso e blu invertiti —
+    /// plausibile a vedersi, e sbagliata.
+    ///
+    /// NOTA SUL QUARTO BYTE: qui vale **zero**, come lo lascia GDI, non 255. La
+    /// versione precedente di questo test passava 255 e quindi non poteva
+    /// accorgersi che il codice lo copiasse tal quale: un test che concorda col
+    /// codice invece di verificarlo. Il fotogramma consegnato era infatti
+    /// interamente trasparente.
+    #[test]
+    fn bgrx_diventa_png_opaco_coi_colori_giusti() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        // rosso puro come lo dà GDI: B=0, G=0, R=255, X=0
+        let png_b64 = bgra_in_png_base64(&[0, 0, 255, 0], 1, 1).unwrap();
+        let png = STANDARD.decode(png_b64).unwrap();
+        let img = image::load_from_memory(&png).unwrap().to_rgba8();
+        assert_eq!(img.dimensions(), (1, 1));
+        assert_eq!(
+            img.get_pixel(0, 0).0,
+            [255, 0, 0, 255],
+            "atteso rosso OPACO: con alpha 0 l'immagine sarebbe corretta e invisibile"
+        );
+    }
+
+    /// Un fotogramma intero non deve avere nemmeno un pixel trasparente: è la
+    /// forma generale del difetto misurato, dove 5180 pixel avevano il colore
+    /// giusto e nessuno era visibile.
+    #[test]
+    fn nessun_pixel_resta_trasparente() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        let bgrx = vec![0u8; 4 * 16 * 16]; // tutto zero, alpha compreso
+        let png = STANDARD.decode(bgra_in_png_base64(&bgrx, 16, 16).unwrap()).unwrap();
+        let img = image::load_from_memory(&png).unwrap().to_rgba8();
+        assert!(img.pixels().all(|p| p.0[3] == 255), "trovati pixel trasparenti");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn il_nome_della_mappatura_combacia_col_produttore() {
+        // Deve essere identico a `kPrefissoNome` + pid in gs_frame_share.h.
+        let n = win::nome_mappatura(1234);
+        let s = String::from_utf16_lossy(&n[..n.len() - 1]);
+        assert_eq!(s, "Local\\gs-hook-frame-1234");
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -113,6 +113,8 @@ pub mod gs_hook_injector;
 pub mod ue_translator;
 #[cfg(windows)]
 pub mod screen_capture;
+// Lettore dei fotogrammi pubblicati da gs-hook (contratto: gs_frame_share.h)
+pub mod game_frame;
 // Universal Injector: rilevazione engine + setup traduzione file-based (puro filesystem, cross-platform)
 pub mod universal_injector;
 // Auto-Hook Scanner (cross-platform, con stubs per non-Windows)

--- a/src-tauri/src/commands/screen_capture.rs
+++ b/src-tauri/src/commands/screen_capture.rs
@@ -108,9 +108,14 @@ pub fn capture_window(window_title: String) -> Result<CaptureResult, String> {
     // prefisso). La cattura però produce BGRA grezzo, quindi va convertito —
     // restituire i pixel grezzi qui darebbe una stringa valida che a valle
     // diventa un'immagine illeggibile, senza nessun errore.
+    // Il quarto byte NON è alpha: le DIB a 32 bit di GDI sono BGRX, e quel byte
+    // resta a zero. Copiarlo come alpha dà un PNG interamente trasparente —
+    // corretto nei colori e invisibile. Misurato sul percorso dei fotogrammi
+    // condivisi: 5180 pixel col colore giusto, zero pixel opachi.
     let mut rgba = img.data.clone();
     for p in rgba.chunks_exact_mut(4) {
-        p.swap(0, 2); // BGRA → RGBA
+        p.swap(0, 2); // BGRX → RGBX
+        p[3] = 255;   // X → alpha opaco
     }
     let buf = image::RgbaImage::from_raw(img.width, img.height, rgba)
         .ok_or_else(|| "dimensioni incoerenti col buffer catturato".to_string())?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1129,6 +1129,7 @@ fn main() {
             commands::screen_capture::capture_screen,
             commands::screen_capture::get_windows,
             commands::screen_capture::capture_window,
+            commands::game_frame::read_game_frame,
             commands::image_process::downscale_capture,
             // Batch Processor System
             commands::batch_processor::scan_folder_for_translation,


### PR DESCRIPTION
`GS_HOOK_FRAME_SHARE=1` publishes the latest frame into shared memory (`Local\gs-hook-frame-<pid>`); the backend reads it with the Tauri command `read_game_frame(pid)`.

| | |
|---|---|
| Contract | `gs-hook/include/gs_frame_share.h` |
| Producer | `gs-hook/src/gs_frame_share.cpp` |
| Reader | `src-tauri/src/commands/game_frame.rs` |
| Live check | `src-tauri/examples/read-game-frame.rs` |

**Shared memory, not a pipe.** A frame is always *replaced*, never queued — the consumer wants the latest, not the history. A pipe would accumulate frames nobody wants, and a slow reader would fill the buffer and stall the game. An overwritten buffer cannot congest: a slow reader just skips frames, which is the right behaviour. For the same reason there is **no request channel** — the game's render thread must never wait for anyone.

**Throttled to one frame per 100 ms** (`GS_HOOK_FRAME_MS`): copying 300 KB sixty times a second inside the render thread, for an OCR that will use ten, is work nobody looks at.

**A seqlock counter guards torn reads** — odd while writing, even when stable; the reader accepts a copy only if the value was even and unchanged. Without it you get half the old frame and half the new one, which *looks like an image*. No lock, so a consumer that dies cannot stall the game the way a shared mutex would.

**Both sides land together on purpose.** This repository has collected half IPCs before — shared memory with no reader, a request pipe with no reply — and that is why the in-game chain stalled for so long.

## Two defects only the two-process run could find

Both of the same family: plausible result, wrong content. **The nine unit tests passed through both.**

**1. The fourth byte is not alpha.** GDI's 32-bit DIBs are BGR**X** and leave it at zero, so copying it as alpha produced a fully transparent PNG:

```text
pixel totali: 76800
con RGB non nero: 5180
con alpha non zero: 0
```

Correct colours, entirely invisible. The test that should have caught it passed `255` in — so it *agreed with the code instead of checking it*. It now passes zero, as GDI does. `capture_window` (#102, written hours earlier) carried the same defect and is fixed too.

**2. The rows were upside down.** `GetDIBits` with a positive height returns them bottom-up, which suits BMP and nothing else. The contract now states **top-down**, the producer asks for a negative height, and the diagnostic BMP follows suit.

## Verification

- `cargo test --lib` — **1574 passed, 0 failed** (9 new).
- Two-process run against Yume Nikki: an **x64** reader pulled a 320×240 frame out of a **32-bit** game's shared memory, sequence advancing 148 → 156, and the decoded PNG is the game's title screen — correct orientation, opaque, right colours.
- Both gs-hook architectures build clean.

**The trap recorded:** "the transport works" looked proven by three agreeing signals — sequence advancing, exit 0, a 16 KB PNG. All three were true and the delivered image was an empty rectangle. A channel is verified by looking at *what arrived*, not at whether something arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)