### PR TITLE
Feed the OCR path from inside the game, and fix a switch nothing could flip

### DIFF
--- a/__tests__/lib/screen-capture-game-frame.test.ts
+++ b/__tests__/lib/screen-capture-game-frame.test.ts
@@ -1,0 +1,125 @@
+/**
+ * La scelta della sorgente in `captureScreen`.
+ *
+ * Perché esiste. Il fotogramma dal gioco è l'unica sorgente che garantisce di
+ * riprendere il gioco e non la finestra che gli sta davanti: la cattura dallo
+ * schermo, puntando a un gioco, ha restituito i pixel di un browser (misurato,
+ * vedi `docs/METODI-DI-TRADUZIONE.md`). Questi test fissano l'ordine di
+ * preferenza e — soprattutto — che il ripiego avvenga, perché un gioco non
+ * agganciato deve continuare a funzionare come prima.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invoke = vi.fn();
+vi.mock('@/lib/tauri-wrapper', () => ({
+  safeInvoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { captureScreen, captureGameFrame, detectGameProcess } from '@/lib/ocr/screen-capture';
+
+const FOTOGRAMMA = { image_data: 'DAL-GIOCO', width: 320, height: 240, sequence: 42 };
+
+beforeEach(() => {
+  invoke.mockReset();
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+});
+
+describe('captureGameFrame', () => {
+  it('passa il nome del processo al comando e restituisce il fotogramma', async () => {
+    invoke.mockResolvedValueOnce(FOTOGRAMMA);
+    const r = await captureGameFrame('RPG_RT.exe');
+    expect(invoke).toHaveBeenCalledWith('read_game_frame', { processName: 'RPG_RT.exe' });
+    expect(r).toMatchObject({ success: true, imageData: 'DAL-GIOCO', width: 320, height: 240 });
+  });
+
+  it('riporta il motivo del fallimento invece di inghiottirlo', async () => {
+    invoke.mockRejectedValueOnce(new Error('processo «RPG_RT.exe» non in esecuzione'));
+    const r = await captureGameFrame('RPG_RT.exe');
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('non in esecuzione');
+  });
+});
+
+describe('captureScreen: scelta della sorgente', () => {
+  it('con gameProcess preferisce il gioco e NON tocca lo schermo', async () => {
+    invoke.mockResolvedValueOnce(FOTOGRAMMA);
+    const r = await captureScreen({ gameProcess: 'RPG_RT.exe' });
+
+    expect(r).toMatchObject({ success: true, imageData: 'DAL-GIOCO' });
+    // Una sola chiamata: se comparisse anche `check_screen_capture_available`
+    // vorrebbe dire che la cattura dallo schermo parte comunque, pagandola due
+    // volte e potendo restituire i pixel sbagliati.
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('read_game_frame', { processName: 'RPG_RT.exe' });
+  });
+
+  it('se il gioco non pubblica, ripiega sullo schermo', async () => {
+    invoke
+      .mockRejectedValueOnce(new Error('nessun fotogramma condiviso'))  // read_game_frame
+      .mockResolvedValueOnce(true)                                      // check_screen_capture_available
+      .mockResolvedValueOnce({ image_data: 'DALLO-SCHERMO', width: 800, height: 600 });
+
+    const r = await captureScreen({ gameProcess: 'RPG_RT.exe' });
+    expect(r).toMatchObject({ success: true, imageData: 'DALLO-SCHERMO' });
+    expect(invoke.mock.calls.map((c) => c[0])).toEqual([
+      'read_game_frame',
+      'check_screen_capture_available',
+      'capture_screen',
+    ]);
+  });
+
+  it('il ripiego dice perché, invece di far sembrare tutto normale', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    invoke
+      .mockRejectedValueOnce(new Error('gs-hook non è iniettato'))
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce({ image_data: 'X', width: 1, height: 1 });
+
+    await captureScreen({ gameProcess: 'RPG_RT.exe' });
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('gs-hook non è iniettato'));
+  });
+
+  it('senza gameProcess il comportamento resta quello di prima', async () => {
+    invoke
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce({ image_data: 'DALLO-SCHERMO', width: 800, height: 600 });
+
+    const r = await captureScreen({});
+    expect(r).toMatchObject({ success: true, imageData: 'DALLO-SCHERMO' });
+    // `read_game_frame` non deve essere nemmeno tentato: chi non ha un gioco
+    // agganciato non deve pagare una chiamata che fallirà sempre.
+    expect(invoke.mock.calls.map((c) => c[0])).not.toContain('read_game_frame');
+  });
+});
+
+describe('detectGameProcess: chi pubblica', () => {
+  it('con un solo gioco lo restituisce', async () => {
+    invoke.mockResolvedValueOnce([{ pid: 4242, process_name: 'RPG_RT.exe' }]);
+    await expect(detectGameProcess()).resolves.toBe('RPG_RT.exe');
+  });
+
+  it('senza nessuno restituisce null', async () => {
+    invoke.mockResolvedValueOnce([]);
+    await expect(detectGameProcess()).resolves.toBeNull();
+  });
+
+  /**
+   * Il caso che conta. Con due giochi agganciati, sceglierne uno significa
+   * tradurre in silenzio quello sbagliato: la risposta giusta e' non scegliere,
+   * e dirlo.
+   */
+  it('con due giochi NON sceglie, e spiega perche', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    invoke.mockResolvedValueOnce([
+      { pid: 1, process_name: 'RPG_RT.exe' },
+      { pid: 2, process_name: 'Game2.exe' },
+    ]);
+    await expect(detectGameProcess()).resolves.toBeNull();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('RPG_RT.exe, Game2.exe'));
+  });
+
+  it('se il comando fallisce non rompe la cattura', async () => {
+    invoke.mockRejectedValueOnce(new Error('comando assente'));
+    await expect(detectGameProcess()).resolves.toBeNull();
+  });
+});

--- a/components/game-detail-client.tsx
+++ b/components/game-detail-client.tsx
@@ -2130,6 +2130,12 @@ export default function GameDetailPage() {
     try {
       const res = await invoke<{ success: boolean; message: string }>('inject_gs_hook', {
         processName: plan.processName,
+        // Fa pubblicare al hook i fotogrammi in memoria condivisa, così la
+        // traduzione live può prenderli da dentro il gioco invece che dallo
+        // schermo — dove finirebbero i pixel di qualunque finestra stia davanti.
+        // Va deciso QUI perché la DLL legge l'interruttore quando installa gli
+        // hook: accenderlo dopo non avrebbe effetto sul gioco già agganciato.
+        shareFrames: true,
       });
       if (res.success) {
         toast.success(t('gameDetail.runtimeFallbackReady'), { id: 'gs-runtime-fallback' });

--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -1424,6 +1424,61 @@ l'immagine consegnata era un rettangolo vuoto. Un canale si verifica guardando
 **cosa e' arrivato**, non se e' arrivato qualcosa — e conviene guardarlo con
 occhi, non con un conteggio di byte.
 
+### Il percorso OCR prende i fotogrammi dal gioco, e una env var che non poteva funzionare
+
+**Cosa e' collegato.** `captureScreen` accetta ora `gameProcess`: se valorizzato,
+il fotogramma arriva da dentro il gioco (`read_game_frame`) invece che dallo
+schermo, e si ripiega sullo schermo — dicendolo — quando il gioco non pubblica.
+Il motore live risolve il gioco da solo all'avvio con `list_publishing_games`,
+che prova ad aprire `Local\gs-hook-frame-<pid>` per ogni processo vivo.
+
+**Con due giochi non si sceglie.** `detectGameProcess` ritorna `null` sia con
+zero candidati sia con due o piu': prendere il primo tradurrebbe in silenzio il
+gioco sbagliato, che e' il difetto da cui e' nata tutta questa parte del codice.
+Stessa regola gia' applicata ai titoli ambigui in `capture_window`.
+
+**Il difetto trovato dopo aver scritto la funzione: una variabile d'ambiente
+che l'applicazione non puo' impostare.** La pubblicazione era accesa da
+`GS_HOOK_FRAME_SHARE=1`, letta dentro il processo del gioco. Ma l'iniezione
+avviene in un processo **gia' avviato**, e in un processo avviato una variabile
+d'ambiente non si puo' piu' impostare. Funzionava solo nelle prove da riga di
+comando, dove il gioco lo lanciavo io con la variabile gia' pronta: la
+funzione era irraggiungibile dal flusso vero, e ogni prova fatta fin li' lo
+confermava senza mostrarlo.
+
+Il progetto **aveva gia' incontrato e risolto lo stesso problema**: il
+dizionario usa un percorso convenuto proprio per questo, e il commento che lo
+spiega e' in `gs_hook_injector.rs` da settimane. Non l'ho letto prima di
+ripetere l'errore. La cura e' la stessa: una sentinella,
+`%APPDATA%\GameStringer\gs-hook-frame-share`, che il backend crea PRIMA di
+iniettare (`inject_gs_hook(share_frames)`). La env var resta, ma solo per le
+prove.
+
+**Verificato senza env var**, che e' l'unico modo che conta:
+
+```text
+sentinella creata: ...\GameStringer\gs-hook-frame-share
+[gs-hook/FRAME] pubblicazione attiva: Local\gs-hook-frame-18368 (320x240, 307264 byte)
+letto 320x240 seq=148 -> sentinella.png (16162 byte PNG)
+seq avanzata 148 -> 156: il gioco sta pubblicando
+```
+
+E il PNG e' la schermata del titolo, guardata — non dedotta dai contatori.
+
+**Il percorso caldo, gia' che c'era.** Gli hook sui blit passano a ogni tile di
+ogni fotogramma. Due sprechi tolti: il contatore della diagnostica non si
+incrementa piu' quando la diagnostica e' spenta, e il freno temporale viene
+PRIMA di `WindowFromDC` — nella stragrande maggioranza dei blit la risposta e'
+«non ora», e va data con un confronto fra interi invece che con una chiamata di
+sistema.
+
+**La trappola.** Una funzione puo' essere corretta, compilata, provata e
+irraggiungibile. Tutte le mie prove passavano perche' riproducevano una
+condizione che l'applicazione non puo' creare — il gioco lanciato da me con la
+variabile impostata. Provare una funzione nel modo in cui NON verra' usata non
+la prova: prima di dire «funziona» conviene chiedersi chi, nel flusso vero,
+mette quell'interruttore su acceso.
+
 ---
 
 ## Come si aggiunge una voce

--- a/gs-hook/src/sources/source_gdi.cpp
+++ b/gs-hook/src/sources/source_gdi.cpp
@@ -105,6 +105,11 @@ bool DiagBlitAttiva() {
 
 void DiagBlit(const wchar_t* porta, HDC src, int sx, int sy, int w, int h,
               int dx, int dy) {
+    // Prima cosa: se la diagnostica e' spenta non si paga NIENTE, nemmeno
+    // l'incremento atomico. Gli hook sui blit possono essere installati per la
+    // sola pubblicazione dei fotogrammi, e questo e' il percorso piu' caldo di
+    // un gioco 2D: ogni tile, ogni sprite, ogni fotogramma.
+    if (!DiagBlitAttiva()) return;
     const int n = g_blitVisti.fetch_add(1, std::memory_order_relaxed);
 
     // Le PRIME chiamate si registrano tutte, qualunque dimensione. Filtrare per
@@ -214,11 +219,30 @@ bool SalvaBmp(const std::wstring& path, const void* bits, int w, int h) {
 // GS_HOOK_FRAME_MS.
 constexpr DWORD kIntervalloPubblicazioneMsDefault = 100;
 
+// DUE MODI PER ACCENDERLA, e il secondo è quello che conta.
+//
+// La variabile d'ambiente serve solo alle prove da riga di comando, dove il
+// gioco lo si lancia apposta. Nel flusso vero NON funziona: l'iniezione avviene
+// in un processo GIÀ AVVIATO, e in un processo avviato una variabile
+// d'ambiente non si può più impostare. Gated solo così, questa funzione
+// sarebbe irraggiungibile dall'applicazione — difetto trovato dopo averla
+// scritta, ed è lo stesso motivo per cui il dizionario usa un percorso
+// convenuto invece di una env var.
+//
+// Il secondo modo è quindi un file sentinella che GameStringer crea PRIMA di
+// iniettare:  %APPDATA%\GameStringer\gs-hook-frame-share
+// Il contenuto non conta, conta l'esistenza.
 bool CondivisioneAttiva() {
     static const bool attiva = [] {
         char buf[8] = {};
-        return GetEnvironmentVariableA("GS_HOOK_FRAME_SHARE", buf, sizeof(buf)) > 0 &&
-               buf[0] == '1';
+        if (GetEnvironmentVariableA("GS_HOOK_FRAME_SHARE", buf, sizeof(buf)) > 0 && buf[0] == '1') {
+            return true;
+        }
+        wchar_t appdata[MAX_PATH] = {};
+        if (GetEnvironmentVariableW(L"APPDATA", appdata, MAX_PATH) == 0) return false;
+        const std::wstring sentinella =
+            std::wstring(appdata) + L"\\GameStringer\\gs-hook-frame-share";
+        return GetFileAttributesW(sentinella.c_str()) != INVALID_FILE_ATTRIBUTES;
     }();
     return attiva;
 }
@@ -243,11 +267,13 @@ void CatturaSePresent(HDC dst, HDC src, int sw, int sh) {
                            g_fotogrammiSalvati.load(std::memory_order_relaxed) < kMaxFotogrammiDump;
     const bool condividi = CondivisioneAttiva();
     if (!dump && !condividi) return;
-    if (sw <= 0 || sh <= 0 || !WindowFromDC(dst)) return;
+    if (sw <= 0 || sh <= 0) return;
 
-    // Freno sul ritmo: si applica solo alla pubblicazione. Il dump è già
-    // limitato nel numero e serve a guardare i primi fotogrammi, quindi non
-    // deve aspettare.
+    // Freno sul ritmo PRIMA di ogni chiamata di sistema. `WindowFromDC` costa
+    // poco ma non zero, e qui si passa a ogni blit: nella stragrande
+    // maggioranza dei fotogrammi la risposta e' «non ora», e va data con un
+    // confronto fra interi. Il dump non aspetta: e' limitato nel numero e serve
+    // a guardare i PRIMI fotogrammi.
     static DWORD ultimaPubblicazione = 0;
     bool pubblicaOra = false;
     if (condividi) {
@@ -258,6 +284,9 @@ void CatturaSePresent(HDC dst, HDC src, int sw, int sh) {
         }
     }
     if (!dump && !pubblicaOra) return;   // niente da fare in questo fotogramma
+
+    // Solo adesso si chiede al sistema se questo blit e' il present.
+    if (!WindowFromDC(dst)) return;
 
     HBITMAP bmp = (HBITMAP)GetCurrentObject(src, OBJ_BITMAP);
     if (!bmp) return;

--- a/lib/live-translation-engine.ts
+++ b/lib/live-translation-engine.ts
@@ -8,7 +8,7 @@
  * unchanged frames, and translation caching.
  */
 
-import { captureScreen, type CaptureOptions } from '@/lib/ocr/screen-capture';
+import { captureScreen, detectGameProcess, type CaptureOptions } from '@/lib/ocr/screen-capture';
 import { recognizeText, type OCRLanguage, type OCRLine } from '@/lib/ocr/ocr-service';
 import { translateWithFallback, type TranslateOptions } from '@/lib/ai/ai-translate-direct';
 import {
@@ -50,6 +50,14 @@ export interface LiveTranslationConfig {
   vlmDownscaleMaxPx?: number;
   /** Numero di righe di dialogo precedenti passate come contesto narrativo al VLM. */
   vlmSendContextLines?: number;
+  /**
+   * Nome del processo del gioco (es. 'RPG_RT.exe'). Se valorizzato e gs-hook
+   * sta pubblicando, i fotogrammi arrivano da dentro il gioco invece che dallo
+   * schermo: e' l'unica sorgente che garantisce di riprendere il gioco e non
+   * la finestra che gli sta davanti. Senza, si cattura dallo schermo come
+   * prima.
+   */
+  gameProcess?: string;
 }
 
 export interface CaptureRegion {
@@ -153,6 +161,8 @@ class LiveTranslationEngine {
       vlmModel: '',
       vlmDownscaleMaxPx: 1280,
       vlmSendContextLines: 5,
+      // Vuoto = nessun gioco agganciato, si cattura dallo schermo come prima.
+      gameProcess: '',
     };
   }
 
@@ -186,11 +196,25 @@ class LiveTranslationEngine {
     this.translationCache.clear();
     this.recentDialogue = [];
 
+    // Se nessuno ha indicato un gioco, si guarda chi sta pubblicando fotogrammi.
+    // Non blocca l'avvio: la risoluzione arriva quando arriva, e fino ad allora
+    // si cattura dallo schermo. Un avvio che aspetta un'enumerazione di processi
+    // e' un avvio che sembra rotto.
+    if (!this.config.gameProcess) {
+      void detectGameProcess().then((nome) => {
+        if (nome && this.isRunning) {
+          this.config.gameProcess = nome;
+          clientLogger.info('Fotogrammi presi dal gioco', 'LIVE_TRANSLATE', { gameProcess: nome });
+        }
+      });
+    }
+
     clientLogger.info('Live Translation started', 'LIVE_TRANSLATE', {
       target: this.config.targetLanguage,
       provider: this.config.provider,
       mode: this.config.mode,
       interval: this.config.captureIntervalMs,
+      gameProcess: this.config.gameProcess || '(dallo schermo)',
     });
 
     this.emit({ type: 'started' });
@@ -269,6 +293,10 @@ class LiveTranslationEngine {
     try {
       // 1. CAPTURE
       const captureOpts: CaptureOptions = {};
+      // Il fotogramma dal gioco, quando disponibile, arriva gia' ritagliato sul
+      // gioco: la regione dello schermo non gli si applica ed e' captureScreen
+      // a ignorarla in quel caso.
+      if (this.config.gameProcess) captureOpts.gameProcess = this.config.gameProcess;
       if (this.config.captureRegion.mode === 'region') {
         captureOpts.x = this.config.captureRegion.x;
         captureOpts.y = this.config.captureRegion.y;

--- a/lib/ocr/screen-capture.ts
+++ b/lib/ocr/screen-capture.ts
@@ -19,6 +19,20 @@ export interface CaptureOptions {
   width?: number;
   height?: number;
   monitor?: number;
+  /**
+   * Nome del processo del gioco (es. 'RPG_RT.exe'). Se valorizzato e gs-hook
+   * sta pubblicando, il fotogramma arriva da DENTRO il gioco invece che dallo
+   * schermo.
+   *
+   * Perché conviene: la cattura dallo schermo prende ciò che è composito alle
+   * coordinate della finestra. Puntando a un gioco ha restituito i pixel di un
+   * browser che gli stava davanti — misurato, vedi
+   * `docs/METODI-DI-TRADUZIONE.md`. Dal gioco invece il fotogramma è quello
+   * vero: finestra coperta, minimizzata o fuori schermo non fa differenza, e
+   * overlay, notifiche e cursore non possono finirci dentro perché il desktop
+   * non è ancora stato composto.
+   */
+  gameProcess?: string;
 }
 
 export interface MonitorInfo {
@@ -64,8 +78,23 @@ export async function getMonitors(): Promise<MonitorInfo[]> {
  */
 export async function captureScreen(options: CaptureOptions = {}): Promise<CaptureResult> {
   try {
+    // Il fotogramma del gioco viene PRIMA di tutto il resto, quando c'è: è
+    // l'unica sorgente che garantisce di riprendere il gioco e non ciò che gli
+    // sta davanti. Se non c'è si prosegue con le altre, che restano l'unica
+    // strada per i giochi non agganciati.
+    if (options.gameProcess) {
+      const dalGioco = await captureGameFrame(options.gameProcess);
+      if (dalGioco.success) return dalGioco;
+      // Il motivo non si perde: senza, «cattura riuscita» dallo schermo
+      // nasconderebbe che il percorso migliore non era disponibile, ed è il
+      // genere di silenzio che rende indiagnosticabile una traduzione sbagliata.
+      console.info(
+        `[capture] fotogramma dal gioco non disponibile (${dalGioco.error}), si ripiega sullo schermo`
+      );
+    }
+
     const isNative = await isNativeCaptureAvailable();
-    
+
     if (isNative) {
       return await captureScreenNative(options);
     } else {
@@ -75,6 +104,67 @@ export async function captureScreen(options: CaptureOptions = {}): Promise<Captu
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Capture failed'
+    };
+  }
+}
+
+export interface PublishingGame {
+  pid: number;
+  process_name: string;
+}
+
+/**
+ * Individua il gioco da cui prendere i fotogrammi, se ce n'è esattamente uno.
+ *
+ * Ritorna `null` sia quando non pubblica nessuno — caso normale, si cattura
+ * dallo schermo — sia quando ne pubblicano **più d'uno**. Con due candidati la
+ * scelta giusta è non sceglierne nessuno: prendere il primo tradurrebbe in
+ * silenzio il gioco sbagliato, che è esattamente il difetto da cui è nata
+ * questa parte del codice.
+ */
+export async function detectGameProcess(): Promise<string | null> {
+  try {
+    const giochi = (await invoke('list_publishing_games')) as PublishingGame[] | null;
+    if (!giochi || giochi.length === 0) return null;
+    if (giochi.length > 1) {
+      console.info(
+        `[capture] ${giochi.length} giochi stanno pubblicando ` +
+          `(${giochi.map((g) => g.process_name).join(', ')}): non ne scelgo uno, ` +
+          `si cattura dallo schermo`
+      );
+      return null;
+    }
+    return giochi[0].process_name;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Legge l'ultimo fotogramma che gs-hook pubblica in memoria condivisa.
+ *
+ * Il contratto sta in `gs-hook/include/gs_frame_share.h`; il lettore è il
+ * comando Tauri `read_game_frame` (`src-tauri/src/commands/game_frame.rs`).
+ * Richiede che il gioco giri con gs-hook iniettato e `GS_HOOK_FRAME_SHARE=1`.
+ */
+export async function captureGameFrame(processName: string): Promise<CaptureResult> {
+  try {
+    const result = await invoke('read_game_frame', { processName }) as {
+      image_data: string;
+      width: number;
+      height: number;
+      sequence: number;
+    };
+    return {
+      success: true,
+      imageData: result.image_data,
+      width: result.width,
+      height: result.height
+    };
+  } catch (error: unknown) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }

--- a/src-tauri/examples/read-game-frame.rs
+++ b/src-tauri/examples/read-game-frame.rs
@@ -7,7 +7,7 @@
 //! rispettato da entrambi i lati.
 //!
 //! Uso:
-//!   cargo run --example read-game-frame -- <pid> [uscita.png]
+//!   cargo run --example read-game-frame -- <nome-processo> [uscita.png]
 //!
 //! Il gioco deve girare con gs-hook iniettato e `GS_HOOK_FRAME_SHARE=1`.
 
@@ -15,8 +15,8 @@ use gamestringer::commands::game_frame::read_game_frame;
 
 fn main() {
     let argomenti: Vec<String> = std::env::args().skip(1).collect();
-    let Some(pid) = argomenti.first().and_then(|s| s.parse::<u32>().ok()) else {
-        eprintln!("uso: cargo run --example read-game-frame -- <pid> [uscita.png]");
+    let Some(processo) = argomenti.first().cloned() else {
+        eprintln!("uso: cargo run --example read-game-frame -- <nome-processo> [uscita.png]");
         std::process::exit(1);
     };
     let uscita = argomenti.get(1).cloned().unwrap_or_else(|| "fotogramma.png".to_string());
@@ -24,7 +24,7 @@ fn main() {
     // Due letture di seguito: la seconda serve a vedere se il contatore avanza,
     // cioè se il gioco sta davvero pubblicando e non ci stiamo rileggendo lo
     // stesso fotogramma fermo.
-    let primo = match read_game_frame(pid) {
+    let primo = match read_game_frame(processo.clone()) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("lettura fallita: {e}");
@@ -32,7 +32,7 @@ fn main() {
         }
     };
     std::thread::sleep(std::time::Duration::from_millis(400));
-    let secondo = read_game_frame(pid).ok();
+    let secondo = read_game_frame(processo.clone()).ok();
 
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     let png = STANDARD.decode(&primo.image_data).expect("base64");

--- a/src-tauri/src/commands/game_frame.rs
+++ b/src-tauri/src/commands/game_frame.rs
@@ -166,6 +166,76 @@ mod win {
         format!("Local\\gs-hook-frame-{pid}\0").encode_utf16().collect()
     }
 
+    /// Scorre i processi vivi e tiene quelli che hanno la mappatura aperta.
+    ///
+    /// `OpenFileMapping` è il test: o il nome esiste o no, senza mappare niente
+    /// e senza toccare il processo. Costa una manciata di chiamate di sistema
+    /// per processo, una volta all'avvio della traduzione — non è un ciclo
+    /// caldo.
+    pub fn elenca_pubblicanti() -> Vec<PublishingGame> {
+        use std::ffi::c_void;
+
+        #[repr(C)]
+        struct ProcessEntry32W {
+            dw_size: u32,
+            cnt_usage: u32,
+            th32_process_id: u32,
+            th32_default_heap_id: usize,
+            th32_module_id: u32,
+            cnt_threads: u32,
+            th32_parent_process_id: u32,
+            pc_pri_class_base: i32,
+            dw_flags: u32,
+            sz_exe_file: [u16; 260],
+        }
+
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn CreateToolhelp32Snapshot(flags: u32, pid: u32) -> *mut c_void;
+            fn Process32FirstW(snap: *mut c_void, entry: *mut ProcessEntry32W) -> i32;
+            fn Process32NextW(snap: *mut c_void, entry: *mut ProcessEntry32W) -> i32;
+        }
+        const TH32CS_SNAPPROCESS: u32 = 0x0000_0002;
+        const INVALID: isize = -1;
+
+        let mut trovati = Vec::new();
+        unsafe {
+            let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if snap.is_null() || snap as isize == INVALID {
+                return trovati;
+            }
+            let mut entry: ProcessEntry32W = std::mem::zeroed();
+            entry.dw_size = std::mem::size_of::<ProcessEntry32W>() as u32;
+
+            if Process32FirstW(snap, &mut entry) != 0 {
+                loop {
+                    let pid = entry.th32_process_id;
+                    if pid != 0 {
+                        let nome = nome_mappatura(pid);
+                        let h = OpenFileMappingW(FILE_MAP_READ, 0, nome.as_ptr());
+                        if !h.is_null() {
+                            CloseHandle(h);
+                            let fine = entry
+                                .sz_exe_file
+                                .iter()
+                                .position(|&c| c == 0)
+                                .unwrap_or(entry.sz_exe_file.len());
+                            trovati.push(PublishingGame {
+                                pid,
+                                process_name: String::from_utf16_lossy(&entry.sz_exe_file[..fine]),
+                            });
+                        }
+                    }
+                    if Process32NextW(snap, &mut entry) == 0 {
+                        break;
+                    }
+                }
+            }
+            CloseHandle(snap);
+        }
+        trovati
+    }
+
     pub fn leggi(pid: u32) -> Result<GameFrame, String> {
         let nome = nome_mappatura(pid);
         let vista = unsafe {
@@ -225,16 +295,58 @@ mod win {
     }
 }
 
-/// Legge l'ultimo fotogramma pubblicato dal gioco con questo PID.
+/// Un gioco che sta pubblicando fotogrammi in questo momento.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PublishingGame {
+    pub pid: u32,
+    pub process_name: String,
+}
+
+/// Elenca i processi che hanno una mappatura di fotogrammi aperta.
+///
+/// PERCHÉ ESISTE. Il percorso OCR ha bisogno di sapere DA QUALE gioco prendere
+/// i fotogrammi, e la pagina di traduzione live non ha alcun contesto di gioco:
+/// l'utente sceglie le lingue e preme avvia. Le alternative erano chiedere il
+/// nome del processo all'utente — un campo in dodici lingue per un'informazione
+/// che il sistema può ricavare — oppure indovinare. Qui si guarda: si prova ad
+/// aprire `Local\gs-hook-frame-<pid>` per ogni processo vivo, e chi risponde
+/// sta pubblicando davvero.
+///
+/// Ritorna l'ELENCO, non «il gioco». La scelta fra più candidati la fa il
+/// chiamante, e la scelta giusta con due candidati è non sceglierne nessuno:
+/// prendere il primo significherebbe tradurre in silenzio il gioco sbagliato,
+/// che è il difetto da cui è nata tutta questa parte del codice.
 #[tauri::command]
-pub fn read_game_frame(pid: u32) -> Result<GameFrame, String> {
+pub fn list_publishing_games() -> Vec<PublishingGame> {
     #[cfg(windows)]
     {
+        win::elenca_pubblicanti()
+    }
+    #[cfg(not(windows))]
+    {
+        Vec::new()
+    }
+}
+
+/// Legge l'ultimo fotogramma pubblicato dal gioco con questo nome di processo.
+///
+/// Prende il NOME e non il PID perché è così che il resto del flusso identifica
+/// un gioco: `inject_gs_hook` e `gs_hook_status` ricevono entrambi
+/// `process_name`, e il PID non esce mai da Rust. Farlo passare per la UI
+/// significherebbe tenerci uno stato che si può disallineare — il gioco si
+/// riavvia, il PID cambia, e l'interfaccia continuerebbe a chiedere fotogrammi
+/// a un processo che non c'è più.
+#[tauri::command]
+pub fn read_game_frame(process_name: String) -> Result<GameFrame, String> {
+    #[cfg(windows)]
+    {
+        let pid = crate::commands::gs_hook_injector::find_process_by_name(&process_name)
+            .ok_or_else(|| format!("processo «{process_name}» non in esecuzione"))?;
         win::leggi(pid)
     }
     #[cfg(not(windows))]
     {
-        let _ = pid;
+        let _ = process_name;
         Err("i fotogrammi condivisi esistono solo su Windows".into())
     }
 }

--- a/src-tauri/src/commands/gs_hook_injector.rs
+++ b/src-tauri/src/commands/gs_hook_injector.rs
@@ -63,8 +63,18 @@ pub async fn gs_hook_status(process_name: Option<String>) -> Result<GsHookStatus
 pub async fn inject_gs_hook(
     app: tauri::AppHandle,
     process_name: String,
+    // `share_frames`: se `true`, la DLL pubblicherà i fotogrammi in memoria
+    // condivisa perché il percorso OCR li legga (`read_game_frame`). Costa gli
+    // hook sui blit, quindi resta spento se nessuno li chiede.
+    share_frames: Option<bool>,
 ) -> Result<InjectionResult, String> {
     log::info!("🎯 Injection gs-hook in: {}", process_name);
+
+    // Prima dell'iniezione, non dopo: la DLL legge la sentinella quando
+    // installa gli hook, e dopo non la guarda più.
+    if let Err(e) = imposta_condivisione_fotogrammi(share_frames.unwrap_or(false)) {
+        log::warn!("🖼️ Sentinella fotogrammi non aggiornata ({}), si procede", e);
+    }
 
     #[cfg(target_os = "windows")]
     {
@@ -180,6 +190,42 @@ fn gs_hook_cache_path() -> Result<std::path::PathBuf, String> {
         .join("gs-hook-cache.gstc"))
 }
 
+/// Percorso della sentinella che accende la pubblicazione dei fotogrammi.
+///
+/// È un file e non una variabile d'ambiente per lo stesso motivo del
+/// dizionario: l'iniezione avviene in un processo GIÀ AVVIATO, e in un processo
+/// avviato una variabile d'ambiente non si può più impostare. La DLL controlla
+/// questo percorso all'attivazione (vedi `CondivisioneAttiva` in
+/// `source_gdi.cpp`); il contenuto non conta, conta l'esistenza.
+fn gs_hook_frame_share_path() -> Result<std::path::PathBuf, String> {
+    let appdata = std::env::var("APPDATA").map_err(|_| "APPDATA non impostata".to_string())?;
+    Ok(std::path::Path::new(&appdata)
+        .join("GameStringer")
+        .join("gs-hook-frame-share"))
+}
+
+/// Accende o spegne la pubblicazione dei fotogrammi per le iniezioni SUCCESSIVE.
+///
+/// Non ha effetto su un gioco già agganciato: la DLL legge la sentinella una
+/// volta sola, quando installa gli hook. Dirlo qui evita l'aspettativa
+/// sbagliata che l'interruttore agisca a caldo.
+fn imposta_condivisione_fotogrammi(attiva: bool) -> Result<(), String> {
+    let path = gs_hook_frame_share_path()?;
+    if attiva {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        std::fs::write(&path, b"1").map_err(|e| e.to_string())
+    } else {
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            // Assente = già spenta: non è un errore.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
 /// Scrive la coppia di lingue attiva del Translation Bridge nel file che la DLL
 /// caricherà. Ritorna quante traduzioni sono state scritte.
 fn preload_dictionary(app: &tauri::AppHandle) -> Result<usize, String> {
@@ -236,7 +282,7 @@ fn target_is_wow64(pid: u32) -> Option<bool> {
 /// Trova il PID del primo processo il cui nome contiene `name` (case-insensitive).
 /// Stessa logica di `unity_injector::find_process_by_name`.
 #[cfg(target_os = "windows")]
-fn find_process_by_name(name: &str) -> Option<u32> {
+pub(crate) fn find_process_by_name(name: &str) -> Option<u32> {
     use std::mem::zeroed;
 
     #[repr(C)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1130,6 +1130,7 @@ fn main() {
             commands::screen_capture::get_windows,
             commands::screen_capture::capture_window,
             commands::game_frame::read_game_frame,
+            commands::game_frame::list_publishing_games,
             commands::image_process::downscale_capture,
             // Batch Processor System
             commands::batch_processor::scan_folder_for_translation,


### PR DESCRIPTION
Connects `read_game_frame` (#107) to the OCR path.

**`captureScreen` gains `gameProcess`.** When set, the frame comes from inside the game instead of off the screen; when the game is not publishing it falls back to the screen **and says why**, because a silent fallback would hide that the better source was unavailable.

**The live engine resolves the game itself** at start via a new `list_publishing_games` command, which tries to open `Local\gs-hook-frame-<pid>` for every live process. No new UI, no new strings in twelve locales, for information the system can find by looking.

**With two candidates it picks neither.** `detectGameProcess` returns `null` for zero *and* for two or more alike — taking the first would silently translate the wrong game, which is the defect this whole area grew out of. Same rule already applied to ambiguous titles in `capture_window` (#102).

## The defect found after writing the feature

Publishing was gated on `GS_HOOK_FRAME_SHARE`, an environment variable read **inside the game's process**. Injection happens into an **already-running** process, and a running process's environment cannot be changed — so the application could never turn it on.

It worked only in command-line runs where I launched the game myself with the variable already set. The feature was unreachable from the real flow, and every test so far had confirmed it without showing it.

This repository had **already met and solved the same problem**: the dictionary uses an agreed path for exactly this reason, and the comment explaining it has been in `gs_hook_injector.rs` for weeks. I didn't read it before repeating the mistake.

The cure is the same: a sentinel file, `%APPDATA%\GameStringer\gs-hook-frame-share`, written by the backend before injecting via `inject_gs_hook(share_frames)`. The env var stays, for tests only.

## Verification

With **no environment variable at all** — the only way that counts:

```text
sentinella creata: ...\GameStringer\gs-hook-frame-share
[gs-hook/FRAME] pubblicazione attiva: Local\gs-hook-frame-18368 (320x240, 307264 byte)
letto 320x240 seq=148 -> sentinella.png (16162 byte PNG)
seq avanzata 148 -> 156: il gioco sta pubblicando
```

And the PNG is the title screen — looked at, not inferred from counters.

- 10 new vitest cases covering source preference, the fallback, the reason being reported, and the two-candidate refusal.
- `cargo test --lib` 1574 passed, 0 failed. `tsc --noEmit` clean. Both gs-hook architectures build.

**Hot path, while there.** The blit hooks run on every tile of every frame. The diagnostic counter no longer increments when the diagnostic is off, and the time throttle now comes *before* `WindowFromDC` — for the vast majority of blits the answer is "not now", and that should cost an integer compare, not a system call.

**The trap recorded:** a function can be correct, compiled, tested, and unreachable. Testing a feature the way it will *not* be used does not test it — before saying "it works", ask who, in the real flow, flips that switch on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)