### PR TITLE
Put live translation in the menu, where it had never been

### DIFF
--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -20,6 +20,7 @@ import {
   Power,
   Cpu,
   Scan,
+  Radio,
   Puzzle,
   Sparkles,
   Package,
@@ -159,6 +160,10 @@ const getNavGroups = (t: (key: string) => string) => [
     items: [
       { name: t('nav.translate'), href: '/ai-translator', icon: Sparkles },
       { name: t('nav.ocrTranslator'), href: '/ocr-translator', icon: Scan },
+      // La pagina esisteva da tempo e non era raggiungibile: nessun link in
+      // tutta l'applicazione, nessuna voce di menu. Ci si arrivava solo
+      // scrivendo l'URL a mano, cosa che in una finestra Tauri non si puo' fare.
+      { name: t('nav.liveTranslate'), href: '/live-translate', icon: Radio },
       { name: t('nav.voice'), href: '/voice-translator', icon: Mic },
       { name: t('nav.batch'), href: '/batch', icon: FolderTree },
       { name: t('nav.offlineTranslator'), href: '/offline-translator', icon: WifiOff },

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -3090,7 +3090,8 @@
     "activity": "Aktivität",
     "statistics": "Statistiken",
     "tutorialAndGuide": "Tutorial & Anleitung",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Live-Übersetzung"
   },
   "settings": {
     "title": "Einstellungen",

--- a/lib/i18n/locales/el.json
+++ b/lib/i18n/locales/el.json
@@ -3236,7 +3236,8 @@
     "activity": "Δραστηριότητα",
     "statistics": "Στατιστικά",
     "tutorialAndGuide": "Εκμάθηση & Οδηγός",
-    "feedback": "Σχόλια"
+    "feedback": "Σχόλια",
+    "liveTranslate": "Ζωντανή μετάφραση"
   },
   "settings": {
     "title": "Ρυθμίσεις",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -3196,7 +3196,8 @@
     "activity": "Activity",
     "statistics": "Statistics",
     "tutorialAndGuide": "Tutorial & Guide",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Live Translation"
   },
   "settings": {
     "title": "Settings",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -3090,7 +3090,8 @@
     "activity": "Actividad",
     "statistics": "Estadísticas",
     "tutorialAndGuide": "Tutorial y Guía",
-    "feedback": "Comentarios"
+    "feedback": "Comentarios",
+    "liveTranslate": "Traducción en vivo"
   },
   "settings": {
     "title": "Ajustes",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -3090,7 +3090,8 @@
     "activity": "Activité",
     "statistics": "Statistiques",
     "tutorialAndGuide": "Tutoriel et Guide",
-    "feedback": "Retour"
+    "feedback": "Retour",
+    "liveTranslate": "Traduction en direct"
   },
   "settings": {
     "title": "Paramètres",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -3196,7 +3196,8 @@
     "activity": "Attività",
     "statistics": "Statistiche",
     "tutorialAndGuide": "Tutorial Guidato",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Traduzione live"
   },
   "settings": {
     "title": "Impostazioni",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -3090,7 +3090,8 @@
     "activity": "アクティビティ",
     "statistics": "統計",
     "tutorialAndGuide": "チュートリアルとガイド",
-    "feedback": "フィードバック"
+    "feedback": "フィードバック",
+    "liveTranslate": "リアルタイム翻訳"
   },
   "settings": {
     "title": "設定",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -3090,7 +3090,8 @@
     "activity": "활동",
     "statistics": "통계",
     "tutorialAndGuide": "튜토리얼 및 가이드",
-    "feedback": "피드백"
+    "feedback": "피드백",
+    "liveTranslate": "실시간 번역"
   },
   "settings": {
     "title": "설정",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -3090,7 +3090,8 @@
     "activity": "Aktywność",
     "statistics": "Statystyki",
     "tutorialAndGuide": "Samouczek i Przewodnik",
-    "feedback": "Opinie"
+    "feedback": "Opinie",
+    "liveTranslate": "Tłumaczenie na żywo"
   },
   "settings": {
     "title": "Ustawienia",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -3090,7 +3090,8 @@
     "activity": "Atividade",
     "statistics": "Estatísticas",
     "tutorialAndGuide": "Tutorial e Guia",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Tradução ao vivo"
   },
   "settings": {
     "title": "Configurações",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -3090,7 +3090,8 @@
     "activity": "Активность",
     "statistics": "Статистика",
     "tutorialAndGuide": "Руководство и инструкция",
-    "feedback": "Отзывы"
+    "feedback": "Отзывы",
+    "liveTranslate": "Живой перевод"
   },
   "settings": {
     "title": "Настройки",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -3090,7 +3090,8 @@
     "activity": "活动",
     "statistics": "统计",
     "tutorialAndGuide": "教程与指南",
-    "feedback": "反馈"
+    "feedback": "反馈",
+    "liveTranslate": "实时翻译"
   },
   "settings": {
     "title": "设置",


### PR DESCRIPTION
`app/live-translate/page.tsx` has existed for a long time and **could not be reached**: `grep` finds not one link to `/live-translate` anywhere in the application, and there was no navigation entry. The only way in was typing the URL by hand, which a Tauri window does not allow.

It surfaced when the frame-capture wiring (#108, #109) landed on that page and there was no way to open it.

Adds the entry under **Traduzione**, with `nav.liveTranslate` translated across all **twelve** locales — the repository counts Italian left in place as a regression, so none of them is a placeholder:

| | |
|---|---|
| de | Live-Übersetzung |
| el | Ζωντανή μετάφραση |
| en | Live Translation |
| es | Traducción en vivo |
| fr | Traduction en direct |
| it | Traduzione live |
| ja | リアルタイム翻訳 |
| ko | 실시간 번역 |
| pl | Tłumaczenie na żywo |
| pt | Tradução ao vivo |
| ru | Живой перевод |
| zh | 实时翻译 |

Same shape as everything else found today — the stub capture module, the half-finished IPCs, the environment variable nothing could set, the preprocessor with no callers. **The pieces were right and disconnected.**

`tsc --noEmit` clean; `i18n:check` reports no new hardcoded strings against baseline. Verified in the running dev app: the entry appears, is selectable, and the page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)