### PR TITLE
Make live OCR actually run: local assets, no blob worker, and errors that name the step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ _gs_split/
 # motivo di /estratti*/ — vedi il commento sopra)
 /gm-strg-translatable.txt
 .release-state.json
+
+# Asset OCR generati da scripts/prepare-tesseract-assets.js (~47 MB)
+/public/tesseract/

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -20,6 +20,7 @@ import {
   Power,
   Cpu,
   Scan,
+  Radio,
   Puzzle,
   Sparkles,
   Package,
@@ -159,6 +160,10 @@ const getNavGroups = (t: (key: string) => string) => [
     items: [
       { name: t('nav.translate'), href: '/ai-translator', icon: Sparkles },
       { name: t('nav.ocrTranslator'), href: '/ocr-translator', icon: Scan },
+      // La pagina esisteva da tempo e non era raggiungibile: nessun link in
+      // tutta l'applicazione, nessuna voce di menu. Ci si arrivava solo
+      // scrivendo l'URL a mano, cosa che in una finestra Tauri non si puo' fare.
+      { name: t('nav.liveTranslate'), href: '/live-translate', icon: Radio },
       { name: t('nav.voice'), href: '/voice-translator', icon: Mic },
       { name: t('nav.batch'), href: '/batch', icon: FolderTree },
       { name: t('nav.offlineTranslator'), href: '/offline-translator', icon: WifiOff },

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -3090,7 +3090,8 @@
     "activity": "Aktivität",
     "statistics": "Statistiken",
     "tutorialAndGuide": "Tutorial & Anleitung",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Live-Übersetzung"
   },
   "settings": {
     "title": "Einstellungen",

--- a/lib/i18n/locales/el.json
+++ b/lib/i18n/locales/el.json
@@ -3236,7 +3236,8 @@
     "activity": "Δραστηριότητα",
     "statistics": "Στατιστικά",
     "tutorialAndGuide": "Εκμάθηση & Οδηγός",
-    "feedback": "Σχόλια"
+    "feedback": "Σχόλια",
+    "liveTranslate": "Ζωντανή μετάφραση"
   },
   "settings": {
     "title": "Ρυθμίσεις",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -3196,7 +3196,8 @@
     "activity": "Activity",
     "statistics": "Statistics",
     "tutorialAndGuide": "Tutorial & Guide",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Live Translation"
   },
   "settings": {
     "title": "Settings",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -3090,7 +3090,8 @@
     "activity": "Actividad",
     "statistics": "Estadísticas",
     "tutorialAndGuide": "Tutorial y Guía",
-    "feedback": "Comentarios"
+    "feedback": "Comentarios",
+    "liveTranslate": "Traducción en vivo"
   },
   "settings": {
     "title": "Ajustes",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -3090,7 +3090,8 @@
     "activity": "Activité",
     "statistics": "Statistiques",
     "tutorialAndGuide": "Tutoriel et Guide",
-    "feedback": "Retour"
+    "feedback": "Retour",
+    "liveTranslate": "Traduction en direct"
   },
   "settings": {
     "title": "Paramètres",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -3196,7 +3196,8 @@
     "activity": "Attività",
     "statistics": "Statistiche",
     "tutorialAndGuide": "Tutorial Guidato",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Traduzione live"
   },
   "settings": {
     "title": "Impostazioni",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -3090,7 +3090,8 @@
     "activity": "アクティビティ",
     "statistics": "統計",
     "tutorialAndGuide": "チュートリアルとガイド",
-    "feedback": "フィードバック"
+    "feedback": "フィードバック",
+    "liveTranslate": "リアルタイム翻訳"
   },
   "settings": {
     "title": "設定",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -3090,7 +3090,8 @@
     "activity": "활동",
     "statistics": "통계",
     "tutorialAndGuide": "튜토리얼 및 가이드",
-    "feedback": "피드백"
+    "feedback": "피드백",
+    "liveTranslate": "실시간 번역"
   },
   "settings": {
     "title": "설정",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -3090,7 +3090,8 @@
     "activity": "Aktywność",
     "statistics": "Statystyki",
     "tutorialAndGuide": "Samouczek i Przewodnik",
-    "feedback": "Opinie"
+    "feedback": "Opinie",
+    "liveTranslate": "Tłumaczenie na żywo"
   },
   "settings": {
     "title": "Ustawienia",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -3090,7 +3090,8 @@
     "activity": "Atividade",
     "statistics": "Estatísticas",
     "tutorialAndGuide": "Tutorial e Guia",
-    "feedback": "Feedback"
+    "feedback": "Feedback",
+    "liveTranslate": "Tradução ao vivo"
   },
   "settings": {
     "title": "Configurações",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -3090,7 +3090,8 @@
     "activity": "Активность",
     "statistics": "Статистика",
     "tutorialAndGuide": "Руководство и инструкция",
-    "feedback": "Отзывы"
+    "feedback": "Отзывы",
+    "liveTranslate": "Живой перевод"
   },
   "settings": {
     "title": "Настройки",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -3090,7 +3090,8 @@
     "activity": "活动",
     "statistics": "统计",
     "tutorialAndGuide": "教程与指南",
-    "feedback": "反馈"
+    "feedback": "反馈",
+    "liveTranslate": "实时翻译"
   },
   "settings": {
     "title": "设置",

--- a/lib/ocr/ocr-service.ts
+++ b/lib/ocr/ocr-service.ts
@@ -61,6 +61,50 @@ export function getAvailableLanguages(): { code: OCRLanguage; name: string }[] {
   }));
 }
 
+/**
+ * Worker Tesseract riusato fra le chiamate.
+ *
+ * PERCHE' NON LA SCORCIATOIA. `Tesseract.recognize` crea un worker, carica il
+ * core wasm e i dati lingua, riconosce, e poi distrugge tutto — a ogni
+ * chiamata. Nel loop live succederebbe ogni due secondi. Tenerne uno vivo
+ * elimina quel lavoro ripetuto, ed e' anche l'unico modo di chiedere `blocks`,
+ * che sulla scorciatoia non si puo' passare.
+ *
+ * ASSET IN LOCALE, NON DA UN CDN. Tesseract.js scarica worker, core e dati
+ * lingua a runtime. In una finestra Tauri quella richiesta NON passa: la CSP
+ * elenca gli host delle API di traduzione e nessun CDN, e in `public/` non
+ * c'era niente. Il risultato era `OCR failed: Unknown error` a ogni fotogramma
+ * — misurato nell'app: 44 catture, zero traduzioni. Serviti da `self` non serve
+ * toccare la CSP, non si aggiunge nessun host, e l'OCR funziona offline.
+ */
+let workerCorrente: { lingua: OCRLanguage; worker: Tesseract.Worker } | null = null;
+
+async function ottieniWorker(
+  language: OCRLanguage,
+  onProgress?: (progress: OCRProgress) => void
+): Promise<Tesseract.Worker> {
+  if (workerCorrente?.lingua === language) return workerCorrente.worker;
+  if (workerCorrente) {
+    await workerCorrente.worker.terminate().catch(() => {});
+    workerCorrente = null;
+  }
+  const worker = await Tesseract.createWorker(language, undefined, {
+    workerPath: '/tesseract/worker.min.js',
+    corePath: '/tesseract',
+    langPath: '/tesseract',
+    // I file di `tessdata_fast` non sono compressi: chiedendo gzip, Tesseract
+    // cercherebbe `eng.traineddata.gz` e fallirebbe.
+    gzip: false,
+    logger: (m: { status?: string; progress?: number }) => {
+      if (onProgress && m.status) {
+        onProgress({ status: translateStatus(m.status), progress: Math.round((m.progress || 0) * 100) });
+      }
+    },
+  });
+  workerCorrente = { lingua: language, worker };
+  return worker;
+}
+
 export async function recognizeText(
   image: string | File | Blob,
   language: OCRLanguage = 'eng',
@@ -69,21 +113,30 @@ export async function recognizeText(
   const startTime = Date.now();
   
   try {
-    const result = await Tesseract.recognize(image, language, {
-      logger: (m) => {
-        if (onProgress && m.status) {
-          onProgress({
-            status: translateStatus(m.status),
-            progress: Math.round((m.progress || 0) * 100)
-          });
-        }
-      }
-    });
+    const worker = await ottieniWorker(language, onProgress);
+    // Il quarto argomento esiste solo sull'API del worker: senza, `blocks`
+    // resta nullo e le righe non arrivano.
+    const result = await worker.recognize(image, {}, { text: true, blocks: true });
 
     interface TesseractWord { text: string; confidence: number; bbox: BoundingBox }
     interface TesseractLine { text: string; confidence: number; bbox: BoundingBox; words: TesseractWord[] }
-    interface TesseractData { words: TesseractWord[]; lines: TesseractLine[] }
-    const data = result.data as unknown as TesseractData;
+    interface TesseractParagraph { lines?: TesseractLine[] }
+    interface TesseractBlock { paragraphs?: TesseractParagraph[] }
+    interface TesseractData { words?: TesseractWord[]; lines?: TesseractLine[]; blocks?: TesseractBlock[] }
+    const raw = result.data as unknown as TesseractData;
+
+    // Le righe stanno DENTRO i blocchi: blocchi → paragrafi → righe. `data.lines`
+    // esiste come campo ma resta vuoto, e leggere solo quello fa concludere
+    // «nessun testo» su immagini perfettamente leggibili. Il ripiego su
+    // `data.lines` resta per non dipendere da un dettaglio di versione.
+    const righeDaiBlocchi: TesseractLine[] = (raw.blocks ?? [])
+      .flatMap((b) => b.paragraphs ?? [])
+      .flatMap((p) => p.lines ?? []);
+
+    const data = {
+      words: raw.words ?? [],
+      lines: righeDaiBlocchi.length > 0 ? righeDaiBlocchi : (raw.lines ?? []),
+    };
 
     const words: OCRWord[] = (data.words || []).map((w: TesseractWord) => ({
       text: w.text,

--- a/lib/ocr/ocr-service.ts
+++ b/lib/ocr/ocr-service.ts
@@ -92,6 +92,17 @@ async function ottieniWorker(
     workerPath: '/tesseract/worker.min.js',
     corePath: '/tesseract',
     langPath: '/tesseract',
+    // NIENTE BLOB URL. Di default tesseract.js scarica lo script del worker e
+    // ne fa un `blob:`, poi ci crea sopra il Worker. La CSP dell'applicazione ha
+    // `default-src 'self'` e non elenca `blob:`, quindi quel Worker non nasce e
+    // `createWorker` rigetta con **undefined** — nessun messaggio, nessun
+    // indizio. Era questo il guasto, non il formato dell'immagine.
+    //
+    // Caricandolo direttamente dal percorso, l'origine e' la stessa
+    // dell'applicazione e `script-src 'self'` lo consente gia': nessuna
+    // modifica alla CSP, che e' una scelta di sicurezza da non fare per far
+    // funzionare una libreria.
+    workerBlobURL: false,
     // I file di `tessdata_fast` non sono compressi: chiedendo gzip, Tesseract
     // cercherebbe `eng.traineddata.gz` e fallirebbe.
     gzip: false,
@@ -105,18 +116,73 @@ async function ottieniWorker(
   return worker;
 }
 
+/** Estrae qualcosa di leggibile da un errore che potrebbe non essere un `Error`. */
+function dettaglioErrore(e: unknown): string {
+  if (e instanceof Error) return e.message || e.name || 'Error senza messaggio';
+  if (typeof e === 'string') return e;
+  if (e === undefined) return 'rigettato con undefined (nessun motivo fornito)';
+  if (e === null) return 'rigettato con null';
+  try { return JSON.stringify(e); } catch { return String(e); }
+}
+
+/**
+ * Rende utilizzabile un'immagine passata come base64 NUDO.
+ *
+ * PERCHE' SERVE (22/08/2026). Tesseract accetta una stringa, ma la interpreta
+ * come URL da SCARICARE a meno che non cominci con `data:`. La cattura schermo
+ * restituisce base64 senza prefisso — sia il percorso Tauri sia il ripiego su
+ * canvas lo tolgono — quindi il motore riceveva quattro megabyte di base64 e
+ * provava a farne una richiesta di rete. Falliva rigettando `undefined`, che il
+ * codice a valle mostrava come «Unknown error»: nessun indizio, per minuti.
+ *
+ * Non e' un difetto introdotto oggi: il codice precedente passava la stessa
+ * stringa nuda. Non se n'era accorto nessuno perche' la pagina di traduzione
+ * live non era raggiungibile dal menu, quindi non l'aveva mai eseguita nessuno.
+ *
+ * Il riconoscimento e' sulle FIRME dei formati, non sulla lunghezza: `iVBORw0KGgo`
+ * per PNG, `/9j/` per JPEG. Un percorso di file o un URL non cominciano cosi',
+ * quindi non c'e' modo di scambiarli per immagini incorporate.
+ */
+function normalizzaImmagine(image: string | File | Blob): string | File | Blob {
+  if (typeof image !== 'string') return image;
+  const s = image.trim();
+  if (s.startsWith('iVBORw0KGgo')) return `data:image/png;base64,${s}`;
+  if (s.startsWith('/9j/')) return `data:image/jpeg;base64,${s}`;
+  return image;
+}
+
 export async function recognizeText(
   image: string | File | Blob,
   language: OCRLanguage = 'eng',
   onProgress?: (progress: OCRProgress) => void
 ): Promise<OCRResult> {
   const startTime = Date.now();
-  
+
   try {
-    const worker = await ottieniWorker(language, onProgress);
+    image = normalizzaImmagine(image);
+
+    // I due passi sono separati di proposito: un solo messaggio per entrambi
+    // non distingue «il motore non si carica» da «il motore non legge questa
+    // immagine», che si curano in modi opposti. Restringere il guasto prima di
+    // ripararlo costa due righe.
+    let worker: Tesseract.Worker;
+    try {
+      worker = await ottieniWorker(language, onProgress);
+    } catch (e) {
+      throw new Error(`OCR: creazione worker fallita — ${dettaglioErrore(e)}`);
+    }
+
     // Il quarto argomento esiste solo sull'API del worker: senza, `blocks`
     // resta nullo e le righe non arrivano.
-    const result = await worker.recognize(image, {}, { text: true, blocks: true });
+    let result: Tesseract.RecognizeResult;
+    try {
+      result = await worker.recognize(image, {}, { text: true, blocks: true });
+    } catch (e) {
+      const tipo = typeof image === 'string'
+        ? (image.startsWith('data:') ? `data url, ${image.length} car.` : `stringa, ${image.length} car.`)
+        : 'blob/file';
+      throw new Error(`OCR: riconoscimento fallito su ${tipo} — ${dettaglioErrore(e)}`);
+    }
 
     interface TesseractWord { text: string; confidence: number; bbox: BoundingBox }
     interface TesseractLine { text: string; confidence: number; bbox: BoundingBox; words: TesseractWord[] }
@@ -178,8 +244,14 @@ export async function recognizeText(
       processingTime: Date.now() - startTime
     };
   } catch (error: unknown) {
-    clientLogger.error(`OCR Error: ${String(error)}`);
-    throw new Error(`OCR failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    // «Unknown error» non è un messaggio, è una rinuncia: buttava via l'unica
+    // informazione utile ogni volta che il motivo NON era un `Error`. E
+    // tesseract.js rigetta spesso con una stringa o un oggetto, quindi era il
+    // caso normale, non l'eccezione. Un fotogramma al secondo per minuti
+    // interi, tutti con la stessa riga che non diceva niente.
+    const dettaglio = dettaglioErrore(error);
+    clientLogger.error(`OCR Error: ${dettaglio}`, 'OCR', { error });
+    throw new Error(dettaglio.startsWith('OCR') ? dettaglio : `OCR failed: ${dettaglio}`);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tauri:check-cmds": "node scripts/check-tauri-commands.js",
     "tauri:check-cmds:report": "node scripts/check-tauri-commands.js --report",
     "tauri:check-cmds:update": "node scripts/check-tauri-commands.js --update",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate && node scripts/prepare-tesseract-assets.js",
     "tauri": "tauri",
     "tauri:dev": "node scripts/unified-dev.js tauri",
     "tauri:build": "npm run version:build && tauri build",
@@ -84,7 +84,8 @@
     "deploy:sito": "node scripts/deploy-sito.js",
     "deploy:sito:watch": "node scripts/deploy-sito-watch.js",
     "icons:generate": "node scripts/generate-icons.js",
-    "icons:preview": "start src-tauri/icons/preview.html"
+    "icons:preview": "start src-tauri/icons/preview.html",
+    "tesseract:assets": "node scripts/prepare-tesseract-assets.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/scripts/prepare-tesseract-assets.js
+++ b/scripts/prepare-tesseract-assets.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Mette gli asset di Tesseract sotto `public/tesseract/`, dove l'applicazione
+ * li serve da sé.
+ *
+ * PERCHÉ ESISTE (22/08/2026). Tesseract.js scarica worker, core wasm e dati
+ * lingua da un CDN a runtime. In una finestra Tauri quella richiesta NON passa:
+ * la CSP elenca gli host delle API di traduzione e nessun CDN. Il risultato,
+ * misurato nell'app, era `OCR failed: Unknown error` a ogni fotogramma — 183
+ * catture, zero traduzioni, e nessun indizio su cosa mancasse.
+ *
+ * Serviti da `self` non serve toccare la CSP, non si aggiunge nessun host di
+ * rete, e l'OCR funziona offline: coerente con un'applicazione che ha un
+ * traduttore offline fra le sue pagine.
+ *
+ * PERCHÉ UNO SCRIPT E NON FILE NEL REPO. Sono ~47 MB: worker, dodici varianti
+ * del core (il worker sceglie in base al supporto SIMD, e sceglierne una sola
+ * significa fallire sulle macchine che ne vogliono un'altra) e i dati lingua.
+ * Copiarli da `node_modules` a ogni installazione li tiene allineati alla
+ * versione del pacchetto e il repository leggero.
+ *
+ * Uso:  node scripts/prepare-tesseract-assets.js [lingua...]
+ *       (senza argomenti: `eng`)
+ */
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const DEST = path.join(__dirname, '..', 'public', 'tesseract');
+const CORE = path.join(__dirname, '..', 'node_modules', 'tesseract.js-core');
+const DIST = path.join(__dirname, '..', 'node_modules', 'tesseract.js', 'dist');
+
+// I dati lingua non stanno in node_modules: vanno presi una volta. `tessdata_fast`
+// e' la variante piccola e veloce, quella che il progetto Tesseract consiglia
+// per l'uso interattivo.
+const TESSDATA = 'https://github.com/tesseract-ocr/tessdata_fast/raw/main';
+
+function copia(da, a) {
+  fs.copyFileSync(da, a);
+  return fs.statSync(a).size;
+}
+
+function scarica(url, dest) {
+  return new Promise((resolve, reject) => {
+    const richiesta = (u, giri = 0) => {
+      if (giri > 5) return reject(new Error('troppi redirect'));
+      https.get(u, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          return richiesta(res.headers.location, giri + 1);
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return reject(new Error(`HTTP ${res.statusCode} su ${u}`));
+        }
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on('finish', () => out.close(() => resolve(fs.statSync(dest).size)));
+        out.on('error', reject);
+      }).on('error', reject);
+    };
+    richiesta(url);
+  });
+}
+
+async function main() {
+  const lingue = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+  if (lingue.length === 0) lingue.push('eng');
+
+  if (!fs.existsSync(CORE) || !fs.existsSync(DIST)) {
+    console.error('tesseract.js non installato: esegui prima `npm install`.');
+    process.exit(1);
+  }
+  fs.mkdirSync(DEST, { recursive: true });
+
+  let totale = 0;
+  totale += copia(path.join(DIST, 'worker.min.js'), path.join(DEST, 'worker.min.js'));
+
+  // TUTTE le varianti del core, non una scelta a caso: il worker decide a
+  // runtime in base a SIMD, e una variante mancante e' un 404 che diventa
+  // «Unknown error» molto piu' avanti.
+  const varianti = fs.readdirSync(CORE).filter((f) => f.endsWith('.wasm') || f.endsWith('.wasm.js'));
+  for (const v of varianti) totale += copia(path.join(CORE, v), path.join(DEST, v));
+  console.log(`worker + ${varianti.length} varianti del core copiate da node_modules`);
+
+  for (const lingua of lingue) {
+    const dest = path.join(DEST, `${lingua}.traineddata`);
+    if (fs.existsSync(dest)) {
+      console.log(`${lingua}.traineddata gia' presente, non riscaricato`);
+      totale += fs.statSync(dest).size;
+      continue;
+    }
+    process.stdout.write(`scarico ${lingua}.traineddata... `);
+    try {
+      const n = await scarica(`${TESSDATA}/${lingua}.traineddata`, dest);
+      console.log(`${(n / 1024 / 1024).toFixed(1)} MB`);
+      totale += n;
+    } catch (e) {
+      // Una lingua mancante non deve far fallire l'installazione: l'OCR
+      // funzionera' con quelle che ci sono, e il messaggio dice quale manca.
+      fs.rmSync(dest, { force: true });
+      console.log(`fallito (${e.message}) — quella lingua non sara' disponibile`);
+    }
+  }
+
+  console.log(`public/tesseract/: ${(totale / 1024 / 1024).toFixed(0)} MB totali`);
+}
+
+main().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Live translation captured frames and failed on every one of them — `OCR failed: Unknown error`, 183 captures, zero translations, and nothing saying what was missing. Seven defects, all older than today, on a page that **had no menu entry and had never been run**.

## The actual fault: the blob worker

tesseract.js downloads its worker script and turns it into a `blob:`, then builds the `Worker` on that. The application's CSP is `default-src 'self'` and does not list `blob:` — so the Worker never came into being and `createWorker` rejected with **`undefined`**.

`workerBlobURL: false` loads the worker straight from its path: same-origin, already allowed by `script-src 'self'`. **Widening the CSP to make a library work would have been the wrong shortcut.**

## What ended three wrong guesses

Splitting the error instead of patching another hypothesis:

```text
OCR: creazione worker fallita — rigettato con undefined (nessun motivo fornito)
OCR: riconoscimento fallito su data url, 412088 car. — ...
```

Different faults, opposite cures — one message for both had been hiding which was happening. The handler also stopped discarding its own cause: it reported `Unknown error` whenever the reason was not an `Error` instance, which for tesseract.js is the normal case.

## The rest

| defect | effect |
|---|---|
| Assets fetched from a CDN the CSP blocks | engine never loaded |
| Bare base64 passed as image | treated as a **URL to fetch** — 4 MB of it |
| `blocks` not requested | `data.lines` empty; every frame reads as no text |
| Worker rebuilt per call | full core+language load every 2 seconds |
| No menu entry (#111) | nobody had ever run any of this |

Assets now come from `public/tesseract/`, generated by `scripts/prepare-tesseract-assets.js` on postinstall — **every** core variant, since the worker picks by SIMD support at runtime and a missing one is a 404 surfacing as "Unknown error" much later. The ~47 MB is generated, not committed.

## Verified in the running application

Against a hooked Yume Nikki: **67 captures, 4 translations**, `(Humber|Key 5)` → `(Humber|Chiave 5)`.

And the frames came **from the game** — proved by killing it. The instant it died the app raised the screen-sharing prompt, the fallback path, which had never appeared while the game was alive. (The prompt was cancelled: granting screen sharing is the user's decision.)

An earlier off-screen test showed `Text unchanged` continuing, but that does not separate the two hypotheses — a static screen reads the same way — so it was reported as inconclusive rather than counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)