### PR TITLE
Wire up window capture, and correct a DeepSeek price that was three times low

### DIFF
--- a/app/live-translate/page.tsx
+++ b/app/live-translate/page.tsx
@@ -6,10 +6,11 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
+import { getCaptureWindows } from '@/lib/ocr/screen-capture';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import {
-  Play, Pause, Square, Monitor, ScanSearch, Zap, Clock, Eye,
+  Play, Pause, Square, Monitor, ScanSearch, AppWindow, Zap, Clock, Eye,
   Languages, Cpu, BarChart3, AlertCircle, CheckCircle, SkipForward
 } from 'lucide-react';
 import { useTranslation } from '@/lib/i18n';
@@ -60,6 +61,12 @@ export default function LiveTranslatePage() {
   const [provider, setProvider] = useState('groq');
   const [intervalMs, setIntervalMs] = useState(2000);
   const [mode, setMode] = useState<TranslationMode>('fast');
+  // Modalita' di cattura. Il selettore esisteva ma non era collegato a niente:
+  // usava `defaultValue` senza `onValueChange`, quindi sceglierne una non
+  // cambiava nulla. Ora la scelta arriva davvero al motore.
+  const [captureMode, setCaptureMode] = useState<'fullscreen' | 'region' | 'window'>('fullscreen');
+  const [windowTitle, setWindowTitle] = useState<string>('');
+  const [windows, setWindows] = useState<{ hwnd: number; title: string }[]>([]);
   const [vlmProvider, setVlmProvider] = useState<VlmProvider>('ollama');
 
   // Engine state
@@ -123,6 +130,21 @@ export default function LiveTranslatePage() {
     logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [logs]);
 
+  // L'elenco si aggiorna quando serve, non di continuo: enumerare le finestre
+  // a ogni render sarebbe lavoro sprecato per un dato che cambia di rado.
+  const aggiornaFinestre = useCallback(async () => {
+    const trovate = await getCaptureWindows();
+    setWindows(trovate);
+    if (trovate.length > 0 && !trovate.some((w) => w.title === windowTitle)) {
+      setWindowTitle(trovate[0].title);
+    }
+  }, [windowTitle]);
+
+  useEffect(() => {
+    if (captureMode === 'window') void aggiornaFinestre();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [captureMode]);
+
   const handleStart = useCallback(() => {
     const config: Partial<LiveTranslationConfig> = {
       targetLanguage: targetLang,
@@ -132,9 +154,13 @@ export default function LiveTranslatePage() {
       captureIntervalMs: intervalMs,
       mode,
       vlmProvider,
+      captureRegion:
+        captureMode === 'window' && windowTitle
+          ? { mode: 'window', windowTitle }
+          : { mode: captureMode === 'window' ? 'fullscreen' : captureMode },
     };
     liveTranslationEngine.start(config);
-  }, [targetLang, sourceLang, ocrLang, provider, intervalMs, mode, vlmProvider]);
+  }, [targetLang, sourceLang, ocrLang, provider, intervalMs, mode, vlmProvider, captureMode, windowTitle]);
 
   const handleStop = useCallback(() => {
     liveTranslationEngine.stop();
@@ -311,11 +337,18 @@ export default function LiveTranslatePage() {
               {/* Capture mode */}
               <div>
                 <label className="text-xs text-muted-foreground mb-1 block">{t('common.modalitaCattura')}</label>
-                <Select defaultValue="fullscreen" disabled={isRunning}>
+                <Select
+                  value={captureMode}
+                  onValueChange={(v) => setCaptureMode(v as 'fullscreen' | 'region' | 'window')}
+                  disabled={isRunning}
+                >
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="fullscreen">
                       <span className="flex items-center gap-2"><Monitor className="h-3 w-3" /> {t('common.ltFullscreen')}</span>
+                    </SelectItem>
+                    <SelectItem value="window">
+                      <span className="flex items-center gap-2"><AppWindow className="h-3 w-3" /> {t('common.ltWindow')}</span>
                     </SelectItem>
                     <SelectItem value="region">
                       <span className="flex items-center gap-2"><ScanSearch className="h-3 w-3" /> {t('common.ltRegion')}</span>
@@ -323,6 +356,28 @@ export default function LiveTranslatePage() {
                   </SelectContent>
                 </Select>
               </div>
+
+              {/* Quale finestra, quando la modalita' e' 'window'. L'elenco viene
+                  dal backend: le finestre senza contenuto sono gia' escluse. */}
+              {captureMode === 'window' && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">{t('common.ltPickWindow')}</label>
+                  <Select
+                    value={windowTitle}
+                    onValueChange={setWindowTitle}
+                    disabled={isRunning || windows.length === 0}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder={windows.length === 0 ? t('common.ltNoWindow') : undefined} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {windows.map((w) => (
+                        <SelectItem key={w.hwnd} value={w.title}>{w.title}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Lade ModelWiz herunter von ",
     "modelwizDownload2": " — Starte den lokalen Server, und GameStringer verwendet ihn automatisch in der Übersetzungskette.",
     "groqApiKeyLabel": "🔑 Groq-API-Schlüssel (Llama 3.3 70B — kostenlos)",
-    "deepseekHint": "~$0.14/1M Tokens, kein aggressives Rate-Limit — ",
+    "deepseekHint": "$0,44/1M Tokens in Spitzenzeiten, $0,22 außerhalb — kein aggressives Rate-Limit — ",
     "otherLlmProviders": "🔧 Weitere LLM-Anbieter (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "25 $ Gratisguthaben — ",
     "deepl500k": "500K Zeichen/Monat kostenlos — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Ordner öffnen",
     "pause": "Pause",
     "resume": "Fortsetzen",
-    "play": "Abspielen"
+    "play": "Abspielen",
+    "ltWindow": "Fenster",
+    "ltPickWindow": "Fenster wählen",
+    "ltNoWindow": "Kein Fenster gefunden"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/el.json
+++ b/lib/i18n/locales/el.json
@@ -1978,7 +1978,7 @@
     "modelwizDownload1": "Κατεβάστε το ModelWiz από ",
     "modelwizDownload2": " — Εκκινήστε τον τοπικό διακομιστή και το GameStringer θα το χρησιμοποιήσει αυτόματα στην αλυσίδα μετάφρασης.",
     "groqApiKeyLabel": "🔑 Κλειδί API Groq (Llama 3.3 70B — Δωρεάν)",
-    "deepseekHint": "~$0.14/1M tokens, χωρίς επιθετικό όριο ρυθμού — ",
+    "deepseekHint": "$0,44/1M tokens σε ώρες αιχμής, $0,22 εκτός — χωρίς επιθετικό όριο ρυθμού — ",
     "otherLlmProviders": "🔧 Άλλοι πάροχοι LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 δωρεάν πίστωση — ",
     "deepl500k": "500K χαρακτήρες/μήνα δωρεάν — ",
@@ -4141,7 +4141,10 @@
     "dryRunPipelineScan": "Dry Run — Σάρωση pipeline",
     "dryRunPipelineScanDesc": "Αυτόματος έλεγχος εντοπισμού και εξαγωγής σε όλα τα εγκατεστημένα παιχνίδια (χωρίς μετάφραση)",
     "stringIt": "String it!",
-    "failed": "απέτυχαν"
+    "failed": "απέτυχαν",
+    "ltWindow": "Παράθυρο",
+    "ltPickWindow": "Επιλογή παραθύρου",
+    "ltNoWindow": "Δεν βρέθηκε παράθυρο"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -1938,7 +1938,7 @@
     "modelwizDownload1": "Download ModelWiz from ",
     "modelwizDownload2": " — Start the local server and GameStringer will use it automatically in the translation chain.",
     "groqApiKeyLabel": "🔑 Groq API Key (Llama 3.3 70B — Free)",
-    "deepseekHint": "~$0.14/1M tokens, no aggressive rate limit — ",
+    "deepseekHint": "$0.44/1M tokens at peak, $0.22 off-peak — no aggressive rate limit — ",
     "otherLlmProviders": "🔧 Other LLM Providers (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 free credit — ",
     "deepl500k": "500K chars/month free — ",
@@ -4111,7 +4111,10 @@
     "openFolder": "Open folder",
     "pause": "Pause",
     "resume": "Resume",
-    "play": "Play"
+    "play": "Play",
+    "ltWindow": "Window",
+    "ltPickWindow": "Choose a window",
+    "ltNoWindow": "No window found"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Descarga ModelWiz desde ",
     "modelwizDownload2": " — Inicia el servidor local y GameStringer lo usará automáticamente en la cadena de traducción.",
     "groqApiKeyLabel": "🔑 Clave API de Groq (Llama 3.3 70B — Gratis)",
-    "deepseekHint": "~$0.14/1M tokens, sin límite de tasa agresivo — ",
+    "deepseekHint": "$0,44/1M tokens en hora punta, $0,22 fuera de punta — sin límite de tasa agresivo — ",
     "otherLlmProviders": "🔧 Otros proveedores LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 de crédito gratis — ",
     "deepl500k": "500K caracteres/mes gratis — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Abrir carpeta",
     "pause": "Pausar",
     "resume": "Reanudar",
-    "play": "Reproducir"
+    "play": "Reproducir",
+    "ltWindow": "Ventana",
+    "ltPickWindow": "Elegir ventana",
+    "ltNoWindow": "No se encontró ninguna ventana"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Téléchargez ModelWiz depuis ",
     "modelwizDownload2": " — Démarrez le serveur local et GameStringer l'utilisera automatiquement dans la chaîne de traduction.",
     "groqApiKeyLabel": "🔑 Clé API Groq (Llama 3.3 70B — Gratuit)",
-    "deepseekHint": "~$0.14/1M tokens, pas de limite de débit agressive — ",
+    "deepseekHint": "$0,44/1M tokens en heure pleine, $0,22 en heures creuses — pas de limite de débit agressive — ",
     "otherLlmProviders": "🔧 Autres fournisseurs LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "25 $ de crédit gratuit — ",
     "deepl500k": "500K caractères/mois gratuits — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Ouvrir le dossier",
     "pause": "Pause",
     "resume": "Reprendre",
-    "play": "Lire"
+    "play": "Lire",
+    "ltWindow": "Fenêtre",
+    "ltPickWindow": "Choisir une fenêtre",
+    "ltNoWindow": "Aucune fenêtre trouvée"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -1938,7 +1938,7 @@
     "modelwizDownload1": "Scarica ModelWiz da ",
     "modelwizDownload2": " — Avvia il server locale e GameStringer lo userà automaticamente nella catena di traduzione.",
     "groqApiKeyLabel": "🔑 Groq API Key (Llama 3.3 70B — Gratuito)",
-    "deepseekHint": "~$0.14/1M token, nessun rate limit aggressivo — ",
+    "deepseekHint": "$0,44/1M token in fascia di picco, $0,22 fuori picco — nessun rate limit aggressivo — ",
     "otherLlmProviders": "🔧 Altri Provider LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "25$ di credito gratis — ",
     "deepl500k": "500K caratteri/mese gratis — ",
@@ -4111,7 +4111,10 @@
     "openFolder": "Apri cartella",
     "pause": "Pausa",
     "resume": "Riprendi",
-    "play": "Riproduci"
+    "play": "Riproduci",
+    "ltWindow": "Finestra",
+    "ltPickWindow": "Scegli una finestra",
+    "ltNoWindow": "Nessuna finestra trovata"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "ModelWiz を以下からダウンロード: ",
     "modelwizDownload2": " — ローカルサーバーを起動すると、GameStringer が翻訳チェーンで自動的に使用します。",
     "groqApiKeyLabel": "🔑 Groq API キー（Llama 3.3 70B — 無料）",
-    "deepseekHint": "~$0.14/100万トークン、厳しいレート制限なし — ",
+    "deepseekHint": "ピーク時 $0.44/100万トークン、オフピーク $0.22 — 厳しいレート制限なし — ",
     "otherLlmProviders": "🔧 その他の LLM プロバイダー（Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras）",
     "together25Credit": "$25 の無料クレジット — ",
     "deepl500k": "月50万文字まで無料 — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "フォルダーを開く",
     "pause": "一時停止",
     "resume": "再開",
-    "play": "再生"
+    "play": "再生",
+    "ltWindow": "ウィンドウ",
+    "ltPickWindow": "ウィンドウを選択",
+    "ltNoWindow": "ウィンドウが見つかりません"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "다음에서 ModelWiz 다운로드: ",
     "modelwizDownload2": " — 로컬 서버를 시작하면 GameStringer가 번역 체인에서 자동으로 사용합니다.",
     "groqApiKeyLabel": "🔑 Groq API 키 (Llama 3.3 70B — 무료)",
-    "deepseekHint": "~$0.14/100만 토큰, 공격적인 속도 제한 없음 — ",
+    "deepseekHint": "피크 시 $0.44/100만 토큰, 비피크 $0.22 — 공격적인 속도 제한 없음 — ",
     "otherLlmProviders": "🔧 기타 LLM 제공업체 (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 무료 크레딧 — ",
     "deepl500k": "월 50만 자 무료 — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "폴더 열기",
     "pause": "일시정지",
     "resume": "재개",
-    "play": "재생"
+    "play": "재생",
+    "ltWindow": "창",
+    "ltPickWindow": "창 선택",
+    "ltNoWindow": "창을 찾을 수 없음"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Pobierz ModelWiz z ",
     "modelwizDownload2": " — Uruchom lokalny serwer, a GameStringer użyje go automatycznie w łańcuchu tłumaczenia.",
     "groqApiKeyLabel": "🔑 Klucz API Groq (Llama 3.3 70B — za darmo)",
-    "deepseekHint": "~$0.14/1M tokenów, bez agresywnego limitu zapytań — ",
+    "deepseekHint": "$0,44/1M tokenów w szczycie, $0,22 poza szczytem — bez agresywnego limitu zapytań — ",
     "otherLlmProviders": "🔧 Inni dostawcy LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "25 $ darmowego kredytu — ",
     "deepl500k": "500K znaków/miesiąc za darmo — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Otwórz folder",
     "pause": "Wstrzymaj",
     "resume": "Wznów",
-    "play": "Odtwórz"
+    "play": "Odtwórz",
+    "ltWindow": "Okno",
+    "ltPickWindow": "Wybierz okno",
+    "ltNoWindow": "Nie znaleziono okna"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Baixe o ModelWiz em ",
     "modelwizDownload2": " — Inicie o servidor local e o GameStringer o usará automaticamente na cadeia de tradução.",
     "groqApiKeyLabel": "🔑 Chave de API Groq (Llama 3.3 70B — Grátis)",
-    "deepseekHint": "~$0.14/1M tokens, sem limite de taxa agressivo — ",
+    "deepseekHint": "$0,44/1M tokens no pico, $0,22 fora do pico — sem limite de taxa agressivo — ",
     "otherLlmProviders": "🔧 Outros provedores de LLM (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 de crédito grátis — ",
     "deepl500k": "500K caracteres/mês grátis — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Abrir pasta",
     "pause": "Pausar",
     "resume": "Retomar",
-    "play": "Reproduzir"
+    "play": "Reproduzir",
+    "ltWindow": "Janela",
+    "ltPickWindow": "Escolher janela",
+    "ltNoWindow": "Nenhuma janela encontrada"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "Скачайте ModelWiz с ",
     "modelwizDownload2": " — Запустите локальный сервер, и GameStringer будет использовать его автоматически в цепочке перевода.",
     "groqApiKeyLabel": "🔑 Ключ API Groq (Llama 3.3 70B — бесплатно)",
-    "deepseekHint": "~$0.14/1М токенов, без жёстких ограничений скорости — ",
+    "deepseekHint": "$0,44/1М токенов в час пик, $0,22 вне пика — без жёстких ограничений скорости — ",
     "otherLlmProviders": "🔧 Другие LLM-провайдеры (Mistral, Cohere, Together, Fireworks, OpenRouter, Cerebras)",
     "together25Credit": "$25 бесплатного кредита — ",
     "deepl500k": "500К символов/месяц бесплатно — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "Открыть папку",
     "pause": "Пауза",
     "resume": "Продолжить",
-    "play": "Воспроизвести"
+    "play": "Воспроизвести",
+    "ltWindow": "Окно",
+    "ltPickWindow": "Выберите окно",
+    "ltNoWindow": "Окно не найдено"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -1876,7 +1876,7 @@
     "modelwizDownload1": "从此处下载 ModelWiz: ",
     "modelwizDownload2": " — 启动本地服务器，GameStringer 将在翻译链中自动使用它。",
     "groqApiKeyLabel": "🔑 Groq API 密钥（Llama 3.3 70B — 免费）",
-    "deepseekHint": "~$0.14/100万 tokens，无激进速率限制 — ",
+    "deepseekHint": "高峰 $0.44/100万 tokens，非高峰 $0.22 — 无激进速率限制 — ",
     "otherLlmProviders": "🔧 其他 LLM 提供商（Mistral、Cohere、Together、Fireworks、OpenRouter、Cerebras）",
     "together25Credit": "$25 免费额度 — ",
     "deepl500k": "每月 50万 字符免费 — ",
@@ -4005,7 +4005,10 @@
     "openFolder": "打开文件夹",
     "pause": "暂停",
     "resume": "继续",
-    "play": "播放"
+    "play": "播放",
+    "ltWindow": "窗口",
+    "ltPickWindow": "选择窗口",
+    "ltNoWindow": "未找到窗口"
   },
   "languages": {
     "cs": "Čeština",

--- a/lib/live-translation-engine.ts
+++ b/lib/live-translation-engine.ts
@@ -298,6 +298,9 @@ class LiveTranslationEngine {
       // gioco: la regione dello schermo non gli si applica ed e' captureScreen
       // a ignorarla in quel caso.
       if (this.config.gameProcess) captureOpts.gameProcess = this.config.gameProcess;
+      if (this.config.captureRegion.mode === 'window' && this.config.captureRegion.windowTitle) {
+        captureOpts.windowTitle = this.config.captureRegion.windowTitle;
+      }
       if (this.config.captureRegion.mode === 'region') {
         captureOpts.x = this.config.captureRegion.x;
         captureOpts.y = this.config.captureRegion.y;

--- a/lib/ocr/screen-capture.ts
+++ b/lib/ocr/screen-capture.ts
@@ -33,6 +33,13 @@ export interface CaptureOptions {
    * non è ancora stato composto.
    */
   gameProcess?: string;
+  /**
+   * Titolo (o parte del titolo) della finestra da catturare. Usato quando il
+   * gioco non e' agganciato: `capture_window` chiede alla finestra di
+   * disegnarsi, quindi funziona anche se e' coperta — a differenza della
+   * cattura per area, che restituisce i pixel di chi le sta davanti.
+   */
+  windowTitle?: string;
 }
 
 export interface MonitorInfo {
@@ -90,6 +97,18 @@ export async function captureScreen(options: CaptureOptions = {}): Promise<Captu
       // genere di silenzio che rende indiagnosticabile una traduzione sbagliata.
       console.info(
         `[capture] fotogramma dal gioco non disponibile (${dalGioco.error}), si ripiega sullo schermo`
+      );
+    }
+
+    // Seconda scelta: la finestra. Non e' buona come il fotogramma dal gioco
+    // (che e' nativo e sincronizzato col rendering) ma e' molto meglio dello
+    // schermo, perche' chiede alla finestra di disegnarsi invece di copiare
+    // un'area: coperta o meno, i pixel sono i suoi.
+    if (options.windowTitle) {
+      const daFinestra = await captureWindow(options.windowTitle);
+      if (daFinestra.success) return daFinestra;
+      console.info(
+        `[capture] cattura finestra non riuscita (${daFinestra.error}), si ripiega sullo schermo`
       );
     }
 
@@ -283,6 +302,23 @@ export async function captureWindow(windowTitle: string): Promise<CaptureResult>
       success: false,
       error: error instanceof Error ? error.message : 'Window capture not available'
     };
+  }
+}
+
+/**
+ * Elenco delle finestre catturabili.
+ *
+ * Usa `list_capture_windows`, che e' il comando VERO: `get_windows` (sotto)
+ * appartiene al modulo stub e ritorna sempre una lista vuota. Le finestre
+ * senza area client — come la finestra fantasma che ogni app Delphi espone —
+ * sono gia' escluse a monte, in `ocr_translator::screen_capture::list_windows`.
+ */
+export async function getCaptureWindows(): Promise<{ hwnd: number; title: string }[]> {
+  try {
+    const w = (await invoke('list_capture_windows')) as { hwnd: number; title: string }[] | null;
+    return w ?? [];
+  } catch {
+    return [];
   }
 }
 


### PR DESCRIPTION
## The capture-mode selector was decorative

It used `defaultValue` with no `onValueChange`, so choosing **Regione** changed nothing either. The choice now reaches the engine, and **Finestra** joins the list.

**Window mode had a value in the type and no handling in the engine.** It now calls `captureWindow` — the `capture_window` fixed earlier today (#102), which asks the window to *draw itself* rather than copying an area, so it works while the window is covered. That is the whole reason that fix exists.

The window list comes from `list_capture_windows`. `getWindows`, which the page could have reached for, calls the stub command that always returns an empty array.

## captureScreen now states its order of preference

| | source | why |
|---|---|---|
| 1 | the game's own frame (gs-hook) | in-process, native resolution, immune to whatever is in front |
| 2 | the window | the pixels are its own even when covered |
| 3 | the screen | the path that once returned a browser instead of the game |

Each fallback logs **why**, so no source is chosen silently.

Three new strings across twelve locales.

## The DeepSeek price was stale

The settings hint read `~$0.14/1M tokens`. The V4 family moved to banded pricing on 16/08: **$0.44 per million input tokens at peak, $0.22 off-peak** — which `lib/remote-config.ts` already records with its own dated verification.

A label three times below the real price is one people read when choosing a provider. All twelve locales now carry the banded figures.

`tsc --noEmit` clean; `i18n:check` reports no new hardcoded strings against baseline. Verified in the running dev app: the three modes appear and the window picker populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)