### PR TITLE
Stop the website from serving prices the app had already fixed

### DIFF
--- a/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
+++ b/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
@@ -1,0 +1,68 @@
+# Il file di config del sito sovrascrive i prezzi corretti dell'app
+
+**Data:** 23/08/2026 · **Stato:** corretto nel repo, **non ancora ridistribuito**
+
+## Il fatto
+
+`lib/remote-config.ts` non è la verità finale sui prezzi. È il *fallback*.
+La verità che arriva agli utenti è questa:
+
+```
+lib/remote-config.ts  →  BUNDLED_MODEL_CONFIG   (spedito con l'app)
+https://gamestringer.ai/config/models.json  →  remoto, TTL 12h
+mergeModelConfig(bundled, remote)  →  { ...bundled.pricing, ...remote.pricing }
+```
+
+**Nel merge il remoto vince**, per chiave di provider e per intero array di
+modelli. Il file remoto non è un'aggiunta: è una sovrascrittura.
+
+Il 23/08 il file live (`HTTP 200`, `updatedAt: 2026-07-15`) conteneva ancora il
+catalogo di luglio e quindi rimetteva in circolo, su **tutte** le installazioni,
+i valori che il repo aveva già corretto:
+
+| Voce | File live (sbagliato) | Repo (corretto) | Effetto sull'utente |
+|---|---|---|---|
+| prezzo `deepseek` | `0.00014` (V3) | `0.00044` (V4 Flash picco) | preventivo **3,1× più basso** del vero |
+| modelli `claude` | `claude-3-5-sonnet`, `claude-3-5-haiku` | `claude-sonnet-4-6`, `claude-opus-5`, Haiku 4.5 | Opus 5 **sparisce** dal menu, ID ritirati verso l'API |
+| modelli `gemini` | `gemini-2.0-flash`, `gemini-1.5-pro` | `gemini-3.5-flash`, `gemini-3.1-flash-lite` | ID vecchi verso l'API |
+
+Il caso DeepSeek è quello che fa male: il prezzo era stato corretto nell'app il
+22/08 (commit `839a4358`, "correct a DeepSeek price that was three times low") e
+il sito lo **ri-rompeva** dodici ore dopo, senza che nessun test potesse
+accorgersene. I test coprono il merge, non il contenuto del file remoto.
+
+## Il secondo errore, trovato per strada
+
+Il prezzo `gemini` nel bundled era `0.000125` — cioè quello di Gemini 2.0 Flash,
+rimasto lì dopo il passaggio del codice a `gemini-3.5-flash`. Prezzo reale
+verificato su `ai.google.dev`: **$1.50/1M input**, cioè `0.0015`. Era **12×
+troppo basso**, un errore quattro volte peggiore di quello DeepSeek e sfuggito
+alla revisione del 16/08, che aveva corretto l'*etichetta* lasciando il *numero*.
+
+Lezione: correggere la nota senza correggere la cifra lascia il bug e toglie
+l'unico indizio che c'era.
+
+## Prezzi verificati il 23/08/2026
+
+Fonti ufficiali, non stime:
+
+- `ai.google.dev/gemini-api/docs/pricing` — Gemini 3.5 Flash $1.50/1M input;
+  Gemini 3.7 Flash $0.75/1M fino al 31/12/2026, poi $1.50/1M; 3.1 Flash Lite $0.25/1M
+- `api-docs.deepseek.com` — `deepseek-v4-flash` $0.22 fuori picco / $0.44 picco
+  per 1M input cache-miss. Picco: 01:00–04:00 e 06:00–10:00 UTC, lun–ven
+- Anthropic — `claude-sonnet-4-6` $3/1M, `claude-opus-5` $5/1M
+
+Restano **non riverificati dal 15/07/2026**: `openai`, `gpt5`, `mistral`.
+
+## Il limite che resta
+
+Il catalogo ha **una sola chiave prezzo per provider**. Il default Claude è
+Sonnet 4.6 ($3/1M) ma la variante premium è Opus 5 ($5/1M): chi sceglie il
+premium paga ~1,7× il preventivo. È l'unico punto in cui questa tabella sbaglia
+per difetto — ovunque altro la regola è sbagliare per eccesso, perché una
+fattura più alta del preventivo è il difetto peggiore che possa fare.
+
+## Da fare
+
+`docs/sito/config/models.json` è corretto **nel repo** ma il sito va
+ridistribuito: finché non lo è, il file di luglio continua a essere servito.

--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -1,14 +1,14 @@
 {
-  "version": 1,
-  "updatedAt": "2026-07-15",
-  "_comment": "Catalogo modelli/prezzi remoto di GameStringer. Modifica questo file e ridistribuisci il sito per aggiornare modelli, prezzi e raccomandazioni SENZA rilasciare l'app. L'app fa fail-open sui default bundled se il file non e' raggiungibile. Prezzi in USD per 1K token (stima input).",
+  "version": 2,
+  "updatedAt": "2026-08-23",
+  "_comment": "Catalogo modelli/prezzi remoto di GameStringer. Modifica questo file e ridistribuisci il sito per aggiornare modelli, prezzi e raccomandazioni SENZA rilasciare l'app. L'app fa fail-open sui default bundled se il file non e' raggiungibile. Prezzi in USD per 1K token (stima input). ATTENZIONE: nel merge il remoto VINCE sul bundled, per chiave di provider e per intero array modelli. Un file stantio qui non e' inerte: sovrascrive i valori corretti di lib/remote-config.ts su TUTTE le installazioni. Tenere questo file allineato a BUNDLED_MODEL_CONFIG.",
   "pricing": {
-    "openai": { "per1kUsd": 0.00015, "note": "GPT-4o-mini ($0.15/1M input)" },
-    "gpt5": { "per1kUsd": 0.0025, "note": "GPT-4o ($2.50/1M input)" },
-    "gemini": { "per1kUsd": 0.000125, "note": "Gemini 2.0 Flash ($0.10/1M input)" },
-    "claude": { "per1kUsd": 0.003, "note": "Claude 3.5 Sonnet ($3/1M input)" },
-    "deepseek": { "per1kUsd": 0.00014, "note": "DeepSeek V3 ($0.14/1M input)" },
-    "mistral": { "per1kUsd": 0.002, "note": "Mistral Large ($2/1M input)" },
+    "openai": { "per1kUsd": 0.00015, "note": "GPT-4o mini ($0.15/1M input) · prezzo non riverificato dal 15/07/2026" },
+    "gpt5": { "per1kUsd": 0.0025, "note": "GPT-4o ($2.50/1M input) · prezzo non riverificato dal 15/07/2026" },
+    "gemini": { "per1kUsd": 0.0015, "note": "Gemini 3.5 Flash ($1.50/1M input) · VERIFICATO 23/08/2026 su ai.google.dev. Il precedente 0.000125 era il prezzo di Gemini 2.0 Flash: 12x troppo basso. Gemini 3.7 Flash costa meta' ($0.75/1M fino al 31/12/2026), quindi questa stima sbaglia per eccesso su entrambi." },
+    "claude": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input), il default del codice · VERIFICATO 23/08/2026. Claude Opus 5 costa $5/1M: chi sceglie il premium spende ~1.7x questa stima." },
+    "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
+    "mistral": { "per1kUsd": 0.002, "note": "Mistral Large ($2/1M input) · prezzo non riverificato dal 15/07/2026" },
     "openrouter": { "per1kUsd": 0.001, "note": "Varia per modello" },
     "deepl": { "per1kUsd": 0.02, "note": "DeepL Pro" },
     "google": { "per1kUsd": 0.00002, "note": "Google Translate" }
@@ -20,12 +20,14 @@
       { "id": "gpt-4-turbo", "label": "GPT-4 Turbo" }
     ],
     "claude": [
-      { "id": "claude-3-5-sonnet", "label": "Claude 3.5 Sonnet", "recommended": true },
-      { "id": "claude-3-5-haiku", "label": "Claude 3.5 Haiku" }
+      { "id": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6", "recommended": true },
+      { "id": "claude-opus-5", "label": "Claude Opus 5" },
+      { "id": "claude-haiku-4-5-20251001", "label": "Claude Haiku 4.5" }
     ],
     "gemini": [
-      { "id": "gemini-2.0-flash", "label": "Gemini 2.0 Flash", "recommended": true },
-      { "id": "gemini-1.5-pro", "label": "Gemini 1.5 Pro" }
+      { "id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash", "recommended": true },
+      { "id": "gemini-3.7-flash", "label": "Gemini 3.7 Flash" },
+      { "id": "gemini-3.1-flash-lite", "label": "Gemini 3.1 Flash Lite" }
     ],
     "deepseek": [
       { "id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash", "recommended": true }

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -64,12 +64,24 @@ export interface RemoteModelConfig {
 // quando passano da un benchmark, non perché sono nuovi.
 export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
   version: 1,
-  updatedAt: '2026-08-16',
+  updatedAt: '2026-08-23',
   pricing: {
     openai: { per1kUsd: 0.00015, note: 'GPT-4o mini ($0.15/1M input) · prezzo non riverificato dal 15/07/2026' },
     gpt5: { per1kUsd: 0.0025, note: 'GPT-4o ($2.50/1M input) · prezzo non riverificato dal 15/07/2026' },
-    gemini: { per1kUsd: 0.000125, note: 'etichetta corretta il 16/08: il default del codice è gemini-3.5-flash, non 2.0 · ⚠️ PREZZO NON RIVERIFICATO (era quello di Gemini 2.0 Flash)' },
-    claude: { per1kUsd: 0.003, note: 'etichetta corretta il 16/08: il default del codice è claude-sonnet-4-6 · ⚠️ PREZZO NON RIVERIFICATO (era quello di Claude 3.5 Sonnet)' },
+    // ⏰ Gemini — VERIFICATO IL 23/08/2026 su ai.google.dev/gemini-api/docs/pricing.
+    // Il default del codice è gemini-3.5-flash: $1.50/1M input. Il valore precedente
+    // (0.000125) era il prezzo di Gemini 2.0 Flash, rimasto qui dopo il passaggio a 3.5:
+    // 12× troppo basso. Gemini 3.7 Flash, uscito dopo, costa $0.75/1M fino al 31/12/2026
+    // e $1.50/1M dal 01/01/2027 — questa stima quindi sbaglia per eccesso su 3.7 e
+    // esatta su 3.5, che è il comportamento voluto: mai preventivare meno del vero.
+    gemini: { per1kUsd: 0.0015, note: 'Gemini 3.5 Flash ($1.50/1M input) · verificato 23/08/2026 · 3.7 Flash costa metà fino al 31/12/2026' },
+    // ⏰ Claude — VERIFICATO IL 23/08/2026. Il default del codice è claude-sonnet-4-6,
+    // che costa $3/1M input: la cifra storica di Claude 3.5 Sonnet coincide, quindi il
+    // numero era giusto per il motivo sbagliato. Ora è giusto e verificato.
+    // Nota: la variante premium (claude-opus-5) costa $5/1M, ~1.7× questa stima; il
+    // catalogo prezzi ha una sola chiave per provider, quindi chi sceglie Opus paga più
+    // del preventivo. È l'unico caso in cui questa tabella sbaglia per difetto.
+    claude: { per1kUsd: 0.003, note: 'Claude Sonnet 4.6 ($3/1M input), default del codice · verificato 23/08/2026 · Opus 5 costa $5/1M' },
     // ⏰ DeepSeek — VERIFICATO IL 16/08/2026 con ricerca (api-docs.deepseek.com non
     // rispondeva; cifre confermate da due ricerche indipendenti). Dalle 16:00 UTC
     // del 16/08/2026 la famiglia V4 ha tariffe a fasce:
@@ -99,6 +111,7 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     ],
     gemini: [
       { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', recommended: true },
+      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash' },
       { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
     ],
     deepseek: [{ id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', recommended: true }],


### PR DESCRIPTION
## The trap

`lib/remote-config.ts` is not the last word on prices — it is the *fallback*. The app fetches `https://gamestringer.ai/config/models.json` (12h TTL) and merges it:

```ts
pricing: { ...bundled.pricing, ...remote.pricing }
models:  { ...bundled.models,  ...remote.models  }
```

**The remote wins**, per provider key and per whole model array. A stale file there is not inert: it overwrites the corrected values on every install.

## What was actually being served

The live file returned `HTTP 200` with `updatedAt: 2026-07-15`:

| Entry | Live (wrong) | Repo | Effect on users |
|---|---|---|---|
| `deepseek` price | `0.00014` (V3) | `0.00044` (V4 Flash peak) | estimates **3.1x too low** |
| `claude` models | `claude-3-5-sonnet`, `claude-3-5-haiku` | `claude-sonnet-4-6`, `claude-opus-5`, Haiku 4.5 | **Opus 5 vanished** from the menu; retired ids sent to the API |
| `gemini` models | `gemini-2.0-flash`, `gemini-1.5-pro` | `gemini-3.5-flash`, `gemini-3.1-flash-lite` | retired ids sent to the API |

The DeepSeek price had been fixed in the app twelve hours earlier (839a4358, *"correct a DeepSeek price that was three times low"*). The website put it straight back. No test could notice: the tests cover `mergeModelConfig`, not the contents of a file served from somewhere else.

## The worse error, found on the way

The bundled `gemini` price was `0.000125` — Gemini 2.0 Flash's price, left behind when the code moved to `gemini-3.5-flash`. Real price, checked on `ai.google.dev`: **$1.50/1M input**. That is **12x too low**, four times worse than the DeepSeek error.

The 16/08 pass had already looked at this line: it corrected the *label* and left the *number*. That removed the only clue while keeping the bug.

## Prices verified 23/08/2026, from the official pages

- `ai.google.dev` — Gemini 3.5 Flash $1.50/1M; **Gemini 3.7 Flash $0.75/1M** until 31/12/2026, then $1.50/1M; 3.1 Flash Lite $0.25/1M
- `api-docs.deepseek.com` — `deepseek-v4-flash` $0.22 off-peak / $0.44 peak per 1M input cache-miss; peak 01:00-04:00 and 06:00-10:00 UTC, Mon-Fri
- Anthropic — `claude-sonnet-4-6` $3/1M, `claude-opus-5` $5/1M

Gemini 3.7 Flash joins the catalogue. The estimate stays at 3.5 Flash's price, so it now errs high on 3.7 rather than low on both — the rule this table already follows everywhere else.

Still **unverified since 15/07/2026**: `openai`, `gpt5`, `mistral`.

## The one place this table still errs low

There is a single price key per provider. The Claude default is Sonnet 4.6 ($3/1M) but the premium variant is Opus 5 ($5/1M), so anyone picking premium pays ~1.7x the estimate. Recorded rather than papered over; splitting the key is a schema change, not this PR.

## Verification

- `npm run typecheck` — exit 0
- `npx vitest run __tests__/lib/remote-config.test.ts` — 9/9 passed

## Note on deployment

Merging this fires `deploy-site.yml` (`paths: docs/sito/**`), which subtree-splits `docs/sito` onto `gh-pages`. **Until it is merged, the July file keeps being served.**

Evidence and figures: `docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)