### PR TITLE
Move the Gemini default to 3.7 Flash, and keep the estimate at the full price

### DIFF
--- a/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
+++ b/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
@@ -42,6 +42,22 @@ alla revisione del 16/08, che aveva corretto l'*etichetta* lasciando il *numero*
 Lezione: correggere la nota senza correggere la cifra lascia il bug e toglie
 l'unico indizio che c'era.
 
+### Seguito: il default è passato a Gemini 3.7 Flash
+
+Lo stesso giorno il default del codice è passato da `gemini-3.5-flash` a
+`gemini-3.7-flash` in sette file (`ai-translate-direct`, `ai-post-edit`,
+`reflection-translator`, `smart-content-router`, `lore-assistant`,
+`vision-translate`, `vlm-batch-translate`). 3.7 è stabile, nativamente
+multimodale — verificato prima di toccare i percorsi vision — con 1M di
+contesto e 64k di output, e Google elenca ormai 3.5 come *legacy*.
+
+**Il prezzo però resta `0.0015` ($1.50/1M), non `0.00075`.** 3.7 costa metà
+solo fino al 31/12/2026: dal 1° gennaio torna a $1.50/1M. Abbassare la stima
+adesso significherebbe doverla rialzare a Capodanno, con il rischio concreto
+di non accorgersene — ed è esattamente così che è nato l'errore da 12×
+descritto qui sopra. Fino ad allora la stima sbaglia per eccesso, che è la
+direzione innocua.
+
 ## Prezzi verificati il 23/08/2026
 
 Fonti ufficiali, non stime:

--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -5,7 +5,7 @@
   "pricing": {
     "openai": { "per1kUsd": 0.00015, "note": "GPT-4o mini ($0.15/1M input) · VERIFICATO 23/08/2026 su developers.openai.com" },
     "gpt5": { "per1kUsd": 0.0025, "note": "GPT-4o ($2.50/1M input) · VERIFICATO 23/08/2026. La chiave si chiama gpt5 per ragioni storiche, il modello e GPT-4o." },
-    "gemini": { "per1kUsd": 0.0015, "note": "Gemini 3.5 Flash ($1.50/1M input) · VERIFICATO 23/08/2026 su ai.google.dev. Il precedente 0.000125 era il prezzo di Gemini 2.0 Flash: 12x troppo basso. Gemini 3.7 Flash costa meta' ($0.75/1M fino al 31/12/2026), quindi questa stima sbaglia per eccesso su entrambi." },
+    "gemini": { "per1kUsd": 0.0015, "note": "Gemini 3.7 Flash, il default del codice · VERIFICATO 23/08/2026 su ai.google.dev. Costa $0.75/1M fino al 31/12/2026 e $1.50/1M dal 01/01/2027: qui sta il prezzo pieno, cosi' la stima sbaglia per eccesso invece di dover rincorrere il rialzo a Capodanno." },
     "claude": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input), il default del codice · VERIFICATO 23/08/2026. Claude Opus 5 costa $5/1M: chi sceglie il premium spende ~1.7x questa stima." },
     "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
     "mistral": { "per1kUsd": 0.0005, "note": "Mistral Large 3 ($0.5/1M input) · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Il precedente $2/1M era 4x troppo alto. Il codice chiama Mistral Small 4 ($0.15/1M): qui sta il prezzo del piu caro dei due, perche la stima deve sbagliare per eccesso." },
@@ -25,8 +25,8 @@
       { "id": "claude-haiku-4-5-20251001", "label": "Claude Haiku 4.5" }
     ],
     "gemini": [
-      { "id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash", "recommended": true },
-      { "id": "gemini-3.7-flash", "label": "Gemini 3.7 Flash" },
+      { "id": "gemini-3.7-flash", "label": "Gemini 3.7 Flash", "recommended": true },
+      { "id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash" },
       { "id": "gemini-3.1-flash-lite", "label": "Gemini 3.1 Flash Lite" }
     ],
     "deepseek": [

--- a/lib/ai/ai-post-edit.ts
+++ b/lib/ai/ai-post-edit.ts
@@ -124,13 +124,13 @@ export async function suggestImprovement(req: PostEditRequest): Promise<PostEdit
     clientLogger.warn('[PostEdit] Ollama non disponibile:', e);
   }
 
-  // Fallback: Gemini API (default gemini-3.5-flash, override via NEXT_PUBLIC_GEMINI_MODEL)
+  // Fallback: Gemini API (default gemini-3.7-flash, override via NEXT_PUBLIC_GEMINI_MODEL)
   try {
     const geminiKey = getGeminiKey();
     if (geminiKey) {
       const geminiModel =
         (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) ||
-        'gemini-3.5-flash';
+        'gemini-3.7-flash';
       const resp = await fetch(
         `https://generativelanguage.googleapis.com/v1beta/models/${geminiModel}:generateContent?key=${geminiKey}`,
         {

--- a/lib/ai/ai-translate-direct.ts
+++ b/lib/ai/ai-translate-direct.ts
@@ -138,12 +138,14 @@ export function getApiKeys() {
 }
 
 
-/** Traduzione con Gemini API - Default gemini-3.5-flash (frontier, I/O 2026).
+/** Traduzione con Gemini API - Default gemini-3.7-flash: stabile, nativamente
+ *  multimodale, 1M di contesto e 64k di output. Fino al 31/12/2026 costa $0.75/1M
+ *  input, metà di 3.5 Flash, che Google elenca ormai come modello legacy.
  *  Modello parametrizzabile via NEXT_PUBLIC_GEMINI_MODEL (es. `gemini-3.5-flash`,
- *  `gemini-2.0-flash`, `gemini-3.1-flash-lite`). Stesso pattern di ANTHROPIC_MODEL. */
+ *  `gemini-3.1-flash-lite`). Stesso pattern di ANTHROPIC_MODEL. */
 const GEMINI_MODEL =
   (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) ||
-  'gemini-3.5-flash';
+  'gemini-3.7-flash';
 
 async function translateWithGemini(
   apiKey: string,

--- a/lib/ai/reflection-translator.ts
+++ b/lib/ai/reflection-translator.ts
@@ -213,7 +213,7 @@ export function selectReflectionCandidates(
 
 const GEMINI_MODEL =
   (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) ||
-  'gemini-3.5-flash';
+  'gemini-3.7-flash';
 const ANTHROPIC_MODEL =
   (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_ANTHROPIC_MODEL) ||
   'claude-sonnet-4-6';

--- a/lib/ai/smart-content-router.ts
+++ b/lib/ai/smart-content-router.ts
@@ -340,7 +340,7 @@ export async function translateWithGeminiLongContext(
     gameGenre?: string;
     gameName?: string;
     glossaryHint?: string;
-    model?: string;  // default: gemini-3.5-flash (override globale via NEXT_PUBLIC_GEMINI_MODEL)
+    model?: string;  // default: gemini-3.7-flash (override globale via NEXT_PUBLIC_GEMINI_MODEL)
   }
 ): Promise<TranslateResult> {
   const keys = getApiKeys();
@@ -353,11 +353,11 @@ export async function translateWithGeminiLongContext(
   clientLogger.debug(`[GeminiLongContext] 📜 Traduzione documento intero: ${texts.length} stringhe, ${totalChars} caratteri`);
 
   const srcLang = options?.sourceLanguage || 'en';
-  // Default gemini-3.5-flash (I/O 2026, output 65k token = 8× vs 2.0). Override via opts.model
+  // Default gemini-3.7-flash (multimodale, 1M di contesto, 64k di output). Override via opts.model
   // o tramite env NEXT_PUBLIC_GEMINI_MODEL. Mantenere gemini-3.1-flash-lite per preset low-cost.
   const envGeminiModel =
     (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) || undefined;
-  const model = options?.model || envGeminiModel || 'gemini-3.5-flash';
+  const model = options?.model || envGeminiModel || 'gemini-3.7-flash';
 
   // Costruisci prompt con contesto completo
   let systemPrompt = `You are an expert game translator. Translate the following ${texts.length} numbered lines from ${srcLang} to ${targetLanguage}.

--- a/lib/lore-assistant.ts
+++ b/lib/lore-assistant.ts
@@ -320,14 +320,14 @@ Answer based ONLY on the dialogues above. If you can identify character names, r
       }
     } catch {}
 
-    // 2. Gemini (free) — default gemini-3.5-flash, override via NEXT_PUBLIC_GEMINI_MODEL
+    // 2. Gemini (free) — default gemini-3.7-flash, override via NEXT_PUBLIC_GEMINI_MODEL
     const { getSecureKey } = await import('@/lib/secure-key-store');
     const geminiKey = await getSecureKey('GEMINI_API_KEY');
     if (geminiKey) {
       try {
         const loreGeminiModel =
           (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) ||
-          'gemini-3.5-flash';
+          'gemini-3.7-flash';
         const resp = await fetch(
           `https://generativelanguage.googleapis.com/v1beta/models/${loreGeminiModel}:generateContent?key=${geminiKey}`,
           {

--- a/lib/ocr/vision-translate.ts
+++ b/lib/ocr/vision-translate.ts
@@ -174,10 +174,10 @@ async function translateWithGeminiVision(
     });
   }
 
-  // Vision OCR: default gemini-3.5-flash (multimodale), override via NEXT_PUBLIC_GEMINI_MODEL
+  // Vision OCR: default gemini-3.7-flash (multimodale), override via NEXT_PUBLIC_GEMINI_MODEL
   const visionModel =
     (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_GEMINI_MODEL) ||
-    'gemini-3.5-flash';
+    'gemini-3.7-flash';
   const response = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/${visionModel}:generateContent?key=${apiKey}`,
     {

--- a/lib/ocr/vlm-batch-translate.ts
+++ b/lib/ocr/vlm-batch-translate.ts
@@ -105,7 +105,7 @@ export const vlmBatchResultSchema = z.object({
 
 const DEFAULT_OLLAMA_MODEL = 'llava:13b';
 const DEFAULT_OPENAI_MODEL = 'gpt-4o';
-const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
+const DEFAULT_GEMINI_MODEL = 'gemini-3.7-flash';
 const DEFAULT_DOWNSCALE_MAX_PX = 1280;
 
 const VLM_BATCH_SYSTEM_PROMPT = `You are an expert video game localizer with visual context. You can SEE the game screen.

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -80,12 +80,14 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     // al catalogo è una decisione di prodotto, non una correzione di prezzo.
     gpt5: { per1kUsd: 0.0025, note: 'GPT-4o ($2.50/1M input) · verificato 23/08/2026 · la chiave si chiama gpt5 per ragioni storiche' },
     // ⏰ Gemini — VERIFICATO IL 23/08/2026 su ai.google.dev/gemini-api/docs/pricing.
-    // Il default del codice è gemini-3.5-flash: $1.50/1M input. Il valore precedente
-    // (0.000125) era il prezzo di Gemini 2.0 Flash, rimasto qui dopo il passaggio a 3.5:
-    // 12× troppo basso. Gemini 3.7 Flash, uscito dopo, costa $0.75/1M fino al 31/12/2026
-    // e $1.50/1M dal 01/01/2027 — questa stima quindi sbaglia per eccesso su 3.7 e
-    // esatta su 3.5, che è il comportamento voluto: mai preventivare meno del vero.
-    gemini: { per1kUsd: 0.0015, note: 'Gemini 3.5 Flash ($1.50/1M input) · verificato 23/08/2026 · 3.7 Flash costa metà fino al 31/12/2026' },
+    // Il default del codice è gemini-3.7-flash, che costa $0.75/1M input fino al
+    // 31/12/2026 e $1.50/1M dal 01/01/2027. Qui resta $1.50/1M di proposito: è il
+    // prezzo che il modello avrà comunque fra pochi mesi, e fino ad allora la stima
+    // sbaglia per eccesso anziché per difetto. Abbassarla adesso significherebbe
+    // dover rincorrere il rialzo a Capodanno, con il rischio di non accorgersene.
+    // Il valore precedente (0.000125) era il prezzo di Gemini 2.0 Flash, rimasto qui
+    // dopo il passaggio del codice a 3.5: 12× troppo basso.
+    gemini: { per1kUsd: 0.0015, note: 'Gemini 3.7 Flash · verificato 23/08/2026 · $0.75/1M fino al 31/12/2026, poi $1.50/1M — qui sta il prezzo pieno' },
     // ⏰ Claude — VERIFICATO IL 23/08/2026. Il default del codice è claude-sonnet-4-6,
     // che costa $3/1M input: la cifra storica di Claude 3.5 Sonnet coincide, quindi il
     // numero era giusto per il motivo sbagliato. Ora è giusto e verificato.
@@ -129,8 +131,8 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
       { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
     ],
     gemini: [
-      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', recommended: true },
-      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash' },
+      { id: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash', recommended: true },
+      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
       { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
     ],
     deepseek: [{ id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', recommended: true }],


### PR DESCRIPTION
Google now lists `gemini-3.5-flash` as its **legacy** Flash model. 3.7 Flash is stable ("New Stable"), natively multimodal, 1M context, 64k output — and until 31/12/2026 costs **$0.75/1M input, half of 3.5**.

## The check that had to come first

Three of the seven call sites are vision paths: `vision-translate.ts`, `vlm-batch-translate.ts`, and the visual-context branch of `smart-content-router.ts`. Pointing those at a text-only model would have broken OCR **silently** — the request succeeds, the image is ignored.

The model name does not tell you this, so it was verified before anything was edited: 3.7 Flash is natively multimodal, and can even reason over images with code execution (zoom, crop, annotate).

## What moved

| File | |
|---|---|
| `ai-translate-direct.ts` | main translation path |
| `ai-post-edit.ts` | post-edit fallback |
| `reflection-translator.ts` | self-correcting second pass |
| `smart-content-router.ts` | long-context / visual routing |
| `lore-assistant.ts` | lore lookups |
| `vision-translate.ts` | vision OCR |
| `vlm-batch-translate.ts` | VLM batch |

Every one keeps its `NEXT_PUBLIC_GEMINI_MODEL` override, so getting 3.5 back is one environment variable. 3.5 stays in the catalogue as a selectable alternative and `gemini-3.1-flash-lite` is untouched — it is the low-cost preset.

## Why the price does *not* halve

`per1kUsd` stays at **`0.0015`** ($1.50/1M), not `0.00075`.

The half rate expires 31/12/2026 and reverts to $1.50/1M. Lowering the estimate now would mean having to raise it again at New Year — and failing to notice is precisely how the **12× Gemini error** got into this file in the first place: the code moved to 3.5 and the 2.0 price stayed behind.

Until January the estimate errs high. That is the harmless direction, and the rule this table already follows for the DeepSeek peak band.

## Two comments rewritten, not string-replaced

They asserted things that stop being true:

- the `ai-translate-direct` docblock offered `gemini-2.0-flash` as an override example — a retired id
- `smart-content-router` described the output budget as *"65k = 8× vs 2.0"*

## Verification

- `npm run typecheck` — clean
- `npm test` — **915 passed**, 37 skipped, **0 failed**
- No test hardcodes a Gemini model id
- 4 remaining `gemini-3.5-flash` mentions audited and intentional: one override example, one historical comment, two catalogue entries

Merging fires `deploy-site.yml` (`paths: docs/sito/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)