### PR TITLE
Bisect the failing chunk instead of losing the whole language

### DIFF
--- a/scripts/release-all.js
+++ b/scripts/release-all.js
@@ -251,6 +251,12 @@ async function main() {
     if (tr.translated) log.ok(`tradotto con ${tr.provider} → ${tr.langs.join(', ')}`);
     else log.warn('changelog i18n: nessuna traduzione, scritta la sorgente in tutte le lingue.');
     if (tr.fallback && tr.fallback.length) log.warn(`da tradurre a mano: ${tr.fallback.join(', ')}`);
+    // 23/08/2026: la bisezione salva la lingua quando una singola voce non si
+    // traduce, invece di perderla tutta. Il prezzo è che una lingua può essere
+    // ✅ con dei buchi dentro: qui è l'unico punto dove un umano li vede.
+    if (tr.partial && tr.partial.length) {
+      log.warn(`voci rimaste in inglese: ${tr.partial.map((p) => `${p.lang} (${p.missed.length})`).join(', ')}`);
+    }
 
     // PROVA D'EFFETTO (18/08/2026): il gate i18n pretende che ogni chiave di
     // it.json esista in TUTTI i locale. Con la v1.17.0 la traduzione non è

--- a/scripts/release/retranslate-changelog.js
+++ b/scripts/release/retranslate-changelog.js
@@ -51,23 +51,32 @@ async function main() {
   console.log(`changelog.${vKey}: ${raw.length} voci (${voci.length} dopo dedup) · sorgente=${source} · provider=${provider}`);
 
   const failed = [];
+  const partial = [];
   for (const lang of listLocaleLangs()) {
     if (lang === source) {
       setVersionKeys(path.join(LOCALES_DIR, `${lang}.json`), vKey, voci);
       console.log(`  = ${lang} (sorgente, riscritta dedupata)`);
       continue;
     }
-    const translated = await translateArray(provider, lang, voci);
+    const missed = [];
+    const translated = await translateArray(provider, lang, voci, (i) => missed.push(i));
     if (!translated) { failed.push(lang); console.log(`  ⛔ ${lang} FALLITA — locale NON toccato`); continue; }
     setVersionKeys(path.join(LOCALES_DIR, `${lang}.json`), vKey, translated);
-    console.log(`  ✅ ${lang}`);
+    // 23/08/2026: con la bisezione una lingua può tornare quasi tutta tradotta,
+    // con qualche voce ancora in inglese. Stamparla ✅ nasconderebbe il buco.
+    if (missed.length) {
+      partial.push(lang);
+      console.log(`  ⚠️  ${lang} — ${missed.length} voci rimaste in inglese: ${missed.join(', ')}`);
+    } else console.log(`  ✅ ${lang}`);
   }
 
   if (failed.length) {
     console.error(`\nESITO: ${failed.length} lingue fallite (${failed.join(', ')}). Rilancia il runner: le lingue già tradotte verranno ritradotte, è idempotente.`);
     process.exit(1);
   }
-  console.log('\nESITO: tutte le lingue tradotte. Verifica a campione (it e ru) prima di committare.');
+  if (partial.length) {
+    console.log(`\nESITO: tutte le lingue tradotte, ma ${partial.length} con voci rimaste in inglese (${partial.join(', ')}). Rilanciare il runner può recuperarle solo se il provider non è deterministico; altrimenti vanno scritte a mano.`);
+  } else console.log('\nESITO: tutte le lingue tradotte. Verifica a campione (it e ru) prima di committare.');
 }
 
 main().catch((e) => { console.error('ERRORE: ' + e.message); process.exit(1); });

--- a/scripts/release/translate-changelog.js
+++ b/scripts/release/translate-changelog.js
@@ -31,7 +31,11 @@
  * le chiavi mancano davvero, è verifyChangelogKeys() dal passo 5 di release-all.
  *
  * Export: async writeChangelogKeys(versionString, englishChanges, opts)
- *   -> { translated:boolean, provider:string|null, langs:string[], fallback:string[] }
+ *   -> { translated:boolean, provider:string|null, langs:string[],
+ *        fallback:string[], partial:[{lang,missed:number[]}] }
+ *   `partial` elenca le lingue tradotte con qualche voce rimasta in inglese:
+ *   la bisezione le isola invece di perdere l'intera lingua, ma restano un
+ *   debito e vanno dichiarate, non contate come successo.
  */
 
 const fs = require('fs');
@@ -173,18 +177,61 @@ async function translateChunk(provider, targetLang, sourceChanges) {
 }
 
 /**
+ * Traduce UN blocco, e se fallisce lo DIVIDE A METÀ e ritenta, fino alla
+ * singola voce. Ritorna sempre un array lungo quanto `items`: le voci che
+ * falliscono anche da sole restano in inglese e vengono dichiarate via
+ * `onFallback`, mai sostituite in silenzio.
+ *
+ * 23/08/2026: senza bisezione, un blocco che non faceva il parse portava via
+ * tutte e 88 le voci della lingua. Misurato su ru ed el del changelog v1.16.0:
+ * il modello emetteva una virgoletta non escapata a metà del PRIMO blocco, e
+ * translateArray restituiva null per l'intera lingua. Peggio: temperature 0
+ * rende il guasto DETERMINISTICO — tre passate di riprova sono fallite allo
+ * stesso byte (position 511, poi 865). Riprovare uguale non poteva funzionare;
+ * dividere sì, e infatti ha recuperato 88/88 su entrambe le lingue.
+ */
+async function translateBisect(provider, targetLang, items, baseIdx, onFallback) {
+  const got = await translateChunk(provider, targetLang, items);
+  if (got) return got;
+  if (items.length === 1) {
+    if (onFallback) onFallback(baseIdx, items[0]);
+    return items.slice(); // la SORGENTE inglese, dichiarata
+  }
+  const mid = Math.ceil(items.length / 2);
+  const a = await translateBisect(provider, targetLang, items.slice(0, mid), baseIdx, onFallback);
+  const b = await translateBisect(provider, targetLang, items.slice(mid), baseIdx + mid, onFallback);
+  return a.concat(b);
+}
+
+/**
  * Traduce un array di voci -> targetLang, A BLOCCHI (12 voci per chiamata).
  * Il changelog v1.16.0 aveva 90 voci: una chiamata sola sforava max_tokens e
- * falliva in silenzio. Ritorna l'array completo o null se UN blocco fallisce
- * (mai risultati parziali: o tutto tradotto o fallback dichiarato).
+ * falliva in silenzio.
+ *
+ * Ritorna l'array completo, oppure null se il provider è morto (vedi sotto).
+ * Le singole voci che falliscono restano in inglese e sono DICHIARATE via
+ * `onFallback(indice, testo)`: il chiamante deve poterle contare, altrimenti
+ * una lingua quasi-tradotta si spaccia per tradotta — che è esattamente la
+ * bugia che questo file esiste per non raccontare.
  */
-async function translateArray(provider, targetLang, sourceChanges) {
+async function translateArray(provider, targetLang, sourceChanges, onFallback) {
   if (provider === 'deepl') return translateChunk(provider, targetLang, sourceChanges); // già voce-per-voce
   const CHUNK = 12;
   const out = [];
   for (let i = 0; i < sourceChanges.length; i += CHUNK) {
-    const part = await translateChunk(provider, targetLang, sourceChanges.slice(i, i + CHUNK));
-    if (!part) return null;
+    const slice = sourceChanges.slice(i, i + CHUNK);
+    let fellBack = 0;
+    const part = await translateBisect(provider, targetLang, slice, i, (idx, txt) => {
+      fellBack++;
+      if (onFallback) onFallback(idx, txt);
+    });
+    // Provider morto (chiave scaduta, servizio giù): fallisce TUTTO, non una
+    // voce. Distinguerlo dalla voce tossica evita di bisezionare 88 volte a
+    // vuoto — e restituisce il fallback totale, che è la verità in quel caso.
+    if (fellBack === slice.length) {
+      console.warn(`   ⚠️  ${targetLang}: l'intero blocco è fallito voce per voce — provider non utilizzabile`);
+      return null;
+    }
     out.push(...part);
   }
   return out;
@@ -236,22 +283,33 @@ async function writeChangelogKeys(version, sourceChanges, opts = {}) {
   }
 
   // L'italiano NON è più un caso speciale: è una lingua di arrivo come le altre.
-  const done = ['en'];
+  const done = [];
+  const partial = [];
   for (const lang of langs) {
     if (lang === 'en') continue;
-    const translated = await translateArray(provider, lang, sourceChanges);
+    const missed = [];
+    const translated = await translateArray(provider, lang, sourceChanges, (idx) => missed.push(idx));
     const items = translated || sourceChanges; // fallback DICHIARATO: la sorgente inglese se la lingua fallisce
     setVersionKeys(path.join(LOCALES_DIR, `${lang}.json`), vKey, items);
     if (translated) done.push(lang);
-    process.stdout.write(`   ${translated ? '✅' : '↩️ '} ${lang}`);
+    // 23/08/2026: con la bisezione una lingua può tornare quasi tutta tradotta
+    // con qualche voce ancora in inglese. Contarla come ✅ nasconderebbe il
+    // buco: si dichiara, con gli indici, così chi legge sa cosa ripassare.
+    if (translated && missed.length) {
+      partial.push({ lang, missed });
+      process.stdout.write(`   ⚠️  ${lang} (${missed.length} voci in inglese: ${missed.join(', ')})`);
+    } else {
+      process.stdout.write(`   ${translated ? '✅' : '↩️ '} ${lang}`);
+    }
   }
+  done.unshift('en');
   process.stdout.write('\n');
   // 06/08/2026: prima ritornava translated:true anche quando OGNI lingua era
   // andata in fallback (done = solo la sorgente) e la ship stampava «tradotto con
   // anthropic» su un fallimento totale — contatore bugiardo. Tradotto è vero
   // solo se almeno una lingua oltre alla sorgente è stata tradotta davvero.
   const fallback = langs.filter((l) => l !== 'en' && !done.includes(l));
-  return { translated: done.length > 1, provider, langs: done, fallback };
+  return { translated: done.length > 1, provider, langs: done, fallback, partial };
 }
 
 /**


### PR DESCRIPTION
Moves the bisection proposed in `docs/maintenance/2026-08-23-changelog-v1-16-0-disallineato.md` into `translateArray` itself.

## The bug, measured

`translateArray` returned `null` if **one** chunk failed — so one bad chunk out of eight cost **all 88 entries** for that language.

Worse, `translateChunk` sends `temperature: 0`, which makes the failure **deterministic**. Retrying the same call cannot succeed. Both halves were measured on 23/08 while repairing the v1.16.0 changelog:

- `ru` and `el` failed on an unescaped quote in the model's JSON
- three retry passes failed at the **same byte** (`position 511`, then `865`)
- each language lost all 88 entries

This failure mode had already cost a full release's translations **twice**: the 06/08 credit exhaustion recorded in this file's own header, and this one.

## The fix

A failing chunk is split in half and retried, down to the single entry. Recovered **88/88 on both `ru` and `el`**, nothing irreducible.

## The case bisection introduces, and why it is declared

An entry that fails even alone keeps its English text and is reported through the new `onFallback(index, text)` callback rather than being swapped in silently.

That matters: bisection creates a state this file previously did not have — **a language almost entirely translated, with a few entries still in English**. Counting that as ✅ would be the exact lie the header says this file exists to avoid:

> *«mai risultati parziali: o tutto tradotto o fallback dichiarato»*

So:

| Where | What it now does |
|---|---|
| `writeChangelogKeys` | returns `partial: [{lang, missed}]`, prints `⚠️` with the indices instead of `✅` |
| `release-all.js` | surfaces it in the step-5 summary — the only place a human reads it during a ship |
| `retranslate-changelog.js` | per-language line and final verdict |

## Dead provider ≠ toxic entry

A dead provider fails *everything*, not one entry. A chunk whose entries all fall back returns `null` immediately instead of bisecting 88 times against a service that is down.

**Verified:** a bogus `OLLAMA_MODEL` bails in **0.16s** with the reason named, rather than grinding through the whole array.

## Compatibility

The fourth parameter is optional and the return shape only gains a field, so existing callers keep working.

## Verification

| Check | Result |
|---|---|
| bisection on the chunk that killed `ru` | **12/12**, zero fallbacks |
| dead provider (`modello-che-non-esiste:0b`) | `null` in 0.16s, reason logged |
| `node --check` on all three scripts | clean |
| full suite | 915 passed, 37 skipped, 0 failed |
| eslint | 11 errors **unchanged** (pre-existing `no-require-imports` on CommonJS scripts); +3 `no-console` warnings in files already built on `console.log` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)