### PR TITLE
Say Mistral Small 4 everywhere, because that is what the code calls

### DIFF
--- a/app/translator/pro/page.tsx
+++ b/app/translator/pro/page.tsx
@@ -1692,7 +1692,7 @@ export default function TranslatorProPage() {
                       <SelectItem value="mistral">
                         <div className="flex items-center gap-2">
                           <Wind className="h-4 w-4 text-muted-foreground" />
-                          <span>{t('translatorProPage.mistralLarge2')}</span>
+                          <span>{t('translatorProPage.mistralSmall4')}</span>
                           <Badge variant="outline" className="text-micro ml-1 text-muted-foreground">EU</Badge>
                         </div>
                       </SelectItem>

--- a/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
+++ b/docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md
@@ -89,11 +89,24 @@ Sotto ci sta però un disaccordo che il prezzo da solo non risolve:
 | il catalogo (`models.mistral`) | offre solo `mistral-large-latest` |
 | la tendina del Translator Pro (`translatorProPage.mistralLarge2`) | scrive «Mistral Large **2**» |
 
-Tre versioni diverse dello stesso provider in tre punti dell'app. Il prezzo ora
-è quello di Large 3, il più caro dei due modelli realmente in gioco, per la
-stessa ragione della fascia di picco DeepSeek. Restano da riconciliare il
-modello che il codice chiama e l'etichetta della tendina, che è i18n su 12
-lingue e non è una correzione di prezzo.
+Tre versioni diverse dello stesso provider in tre punti dell'app.
+
+**Risolto lo stesso giorno.** La verità scelta è ciò che il codice chiama
+davvero: `mistral-small-latest`, Mistral Small 4. Catalogo e tendina sono stati
+allineati a quello, e il prezzo è sceso da `0.0005` (Large 3) a **`0.00015`**,
+che è quello vero di Small 4.
+
+Notare il cambio di regola: finché il catalogo offriva Large e il codice
+chiamava Small, il prezzo teneva il margine prudenziale della fascia di picco
+DeepSeek, perché non si sapeva quale dei due sarebbe girato. Allineati i tre
+punti, l'ambiguità sparisce e con essa il margine: **la stima ora è esatta, non
+prudente.** Il margine serve quando non sai cosa gira, non come abitudine.
+
+La chiave i18n si chiamava `translatorProPage.mistralLarge2`. Lasciarla con
+dentro «Mistral Small 4» avrebbe ricreato la stessa deriva nome/contenuto che
+questo documento descrive, quindi è stata rinominata in `mistralSmall4` in tutte
+e 12 le lingue — dove il valore era identico ovunque, perché è un nome di
+prodotto e non prosa da tradurre.
 
 ### La chiave `gpt5` non è GPT-5
 

--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -8,7 +8,7 @@
     "gemini": { "per1kUsd": 0.0015, "note": "Gemini 3.7 Flash, il default del codice · VERIFICATO 23/08/2026 su ai.google.dev. Costa $0.75/1M fino al 31/12/2026 e $1.50/1M dal 01/01/2027: qui sta il prezzo pieno, cosi' la stima sbaglia per eccesso invece di dover rincorrere il rialzo a Capodanno." },
     "claude": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input), il default del codice · VERIFICATO 23/08/2026. Claude Opus 5 costa $5/1M: chi sceglie il premium spende ~1.7x questa stima." },
     "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
-    "mistral": { "per1kUsd": 0.0005, "note": "Mistral Large 3 ($0.5/1M input) · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Il precedente $2/1M era 4x troppo alto. Il codice chiama Mistral Small 4 ($0.15/1M): qui sta il prezzo del piu caro dei due, perche la stima deve sbagliare per eccesso." },
+    "mistral": { "per1kUsd": 0.00015, "note": "Mistral Small 4 ($0.15/1M input), il modello che il codice chiama davvero · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Catalogo e tendina allineati al codice il 23/08: prima dicevano Large 3 e 'Large 2'." },
     "openrouter": { "per1kUsd": 0.001, "note": "Varia per modello" },
     "deepl": { "per1kUsd": 0.02, "note": "DeepL Pro" },
     "google": { "per1kUsd": 0.00002, "note": "Google Translate" }
@@ -33,7 +33,7 @@
       { "id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash", "recommended": true }
     ],
     "mistral": [
-      { "id": "mistral-large-latest", "label": "Mistral Large 3" }
+      { "id": "mistral-small-latest", "label": "Mistral Small 4" }
     ]
   },
   "recommendations": {

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "API-Schlüssel",

--- a/lib/i18n/locales/el.json
+++ b/lib/i18n/locales/el.json
@@ -1874,7 +1874,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Κλειδί API",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -1834,7 +1834,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "API Key",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Clave API",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Clé API",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -1834,7 +1834,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Chiave API",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "APIキー",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google 번역",
     "apiKey": "API 키",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Klucz API",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "Chave API",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google Translate",
     "apiKey": "API-ключ",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -1991,7 +1991,7 @@
     "gpt4oMini": "GPT-4o Mini",
     "claude35Sonnet": "Claude 3.5 Sonnet",
     "gpt4o": "GPT-4o",
-    "mistralLarge2": "Mistral Large 2",
+    "mistralSmall4": "Mistral Small 4",
     "deeplPro": "DeepL Pro",
     "googleTranslate": "Google 翻译",
     "apiKey": "API密钥",

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -106,15 +106,17 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     // questo numero. Nota per chi lo legge: la fascia di picco 06:00-10:00 UTC è
     // 08:00-12:00 in Italia, cioè la mattina — tradurre il pomeriggio costa metà.
     deepseek: { per1kUsd: 0.00044, note: 'DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss, dal 16/08/2026 16:00 UTC) · fuori picco costa la metà' },
-    // ⏰ Mistral — VERIFICATO IL 23/08/2026 su mistral.ai/pricing/api. Il vecchio 0.002
-    // ($2/1M) non corrisponde più a nulla: Mistral Large 3 (mistral-large-latest) costa
-    // $0.5/1M input, cioè un quarto. Era il peggior sovrapprezzo del catalogo.
-    // C'è però un secondo problema, che il prezzo da solo non risolve: il codice chiama
-    // mistral-small-latest (Mistral Small 4, $0.15/1M), mentre il catalogo offre solo
-    // mistral-large-latest e la tendina lo etichetta 'Mistral Large 2'. Tre verità.
-    // Qui sta il prezzo di Large, il più caro dei due modelli in gioco, per la stessa
-    // ragione della fascia di picco DeepSeek: la stima deve sbagliare per eccesso.
-    mistral: { per1kUsd: 0.0005, note: 'Mistral Large 3 ($0.5/1M input) · verificato 23/08/2026 · il codice chiama Mistral Small 4, che costa $0.15/1M' },
+    // ⏰ Mistral — VERIFICATO IL 23/08/2026 su mistral.ai/pricing/api.
+    // Il 23/08 questo provider diceva tre cose diverse in tre punti: il codice
+    // chiamava mistral-small-latest, il catalogo offriva solo mistral-large-latest
+    // e la tendina del Translator Pro scriveva 'Mistral Large 2' (una versione che
+    // nel frattempo non esisteva più). Il prezzo, 0.002, era il vecchio $2/1M e non
+    // corrispondeva a nessuno dei tre.
+    // Deciso: la verità è ciò che il codice chiama davvero, cioè Mistral Small 4.
+    // Catalogo e tendina sono stati allineati a quello, e il prezzo è il suo:
+    // $0.15/1M input. Non c'è più un modello più caro in gioco, quindi qui non
+    // serve il margine prudenziale che porta la voce deepseek — la stima è esatta.
+    mistral: { per1kUsd: 0.00015, note: 'Mistral Small 4 ($0.15/1M input), il modello che il codice chiama · verificato 23/08/2026' },
     openrouter: { per1kUsd: 0.001, note: 'Varia per modello' },
     deepl: { per1kUsd: 0.02, note: 'DeepL Pro' },
     google: { per1kUsd: 0.00002, note: 'Google Translate' },
@@ -136,7 +138,7 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
       { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
     ],
     deepseek: [{ id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', recommended: true }],
-    mistral: [{ id: 'mistral-large-latest', label: 'Mistral Large 3' }],
+    mistral: [{ id: 'mistral-small-latest', label: 'Mistral Small 4' }],
   },
   recommendations: {
     creative: 'claude',


### PR DESCRIPTION
Closes the last open item from today's catalogue work.

## Three truths, one provider

| Where | What it said |
|---|---|
| the code — `ai-translate-direct.ts:515`, `reflection-translator.ts:388` | calls `mistral-small-latest` — **Mistral Small 4** |
| the catalogue — `models.mistral` | offered only `mistral-large-latest` |
| the Translator Pro dropdown — `translatorProPage.mistralLarge2` | read **"Mistral Large 2"**, a version that no longer existed |

The price, `0.002`, matched none of the three.

## The truth chosen is what actually runs

Catalogue and dropdown now say **Mistral Small 4**, and the price drops from `0.0005` (Large 3) to **`0.00015`** — Small 4's real rate.

## Why the price rule changes here

While the catalogue offered Large and the code called Small, the estimate carried the same prudential margin as the DeepSeek peak band, because **nobody knew which model would run**.

Align the three and the ambiguity disappears — and the margin with it. The estimate is now **exact rather than cautious**. The margin is for not knowing what runs, not a habit.

## The key rename

`translatorProPage.mistralLarge2` holding *"Mistral Small 4"* would have recreated the exact name-versus-content drift this change exists to fix. Renamed to `mistralSmall4` across all 12 locales — where the value was **identical everywhere**, because it is a product name, not prose to translate.

One usage site: `app/translator/pro/page.tsx:1695`.

## Deliberately untouched

`lib/ollama-manager.ts` mentions *"Mistral Small 3 7B"* / `mistral-small3.1:24b`. That is a **local Ollama model pulled by name** — a different thing entirely from the API provider, and not part of this catalogue.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | clean |
| i18n integrity gate | 20/20 |
| `npm run i18n:check` | 802 = baseline, no new hardcoded strings |
| full suite | 915 passed, 37 skipped, 0 failed |
| bundled ↔ site catalogue | both `mistral-small-latest` @ `0.00015` |
| stale `mistralLarge2` / `mistral-large` references | none, except one historical note in a comment |

Merging fires `deploy-site.yml` (`paths: docs/sito/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)