### PR TITLE
Drop the two links that led nowhere, and one route that 404'd

### DIFF
--- a/src-tauri/src/commands/unity_patcher.rs
+++ b/src-tauri/src/commands/unity_patcher.rs
@@ -1278,13 +1278,13 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
         || game_path.to_lowercase().contains("danganronpa");
     
     if is_danganronpa {
-        alternative_tools.push(AlternativeTool {
-            name: "Danganronpa Tools".to_string(),
-            url: "https://github.com/jpmac26/DRV3-Sharp".to_string(),
-            description: "Estrae e modifica file Danganronpa".to_string(),
-            compatible: true,
-        });
-        
+        // 23/08/2026: qui si linkava jpmac26/DRV3-Sharp, che non ha NESSUNA
+        // release: chi ci cliccava non trovava niente da scaricare. Tolto.
+        // Il messaggio diceva «usa tool specifici», ed era diventato falso: dalla
+        // v1.17.0 Danganronpa ha un patcher dentro l'app (pagina dedicata, DR1
+        // tradotto end-to-end, WAD ricostruito in Rust). Ora ci manda lì.
+        // `can_patch` resta false di proposito: instrada il percorso Unity, che
+        // non è quello giusto per questo motore.
         return Ok(GameEngineCheck {
             is_unity: false,
             is_unreal: false,
@@ -1292,7 +1292,7 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
             engine_name: "Spike Chunsoft Engine".to_string(),
             engine_version: None,
             can_patch: false,
-            message: "⚠ Spike Chunsoft Engine - usa tool specifici per Danganronpa".to_string(),
+            message: "✓ Spike Chunsoft Engine - usa il Danganronpa Patcher nel menu dell'app".to_string(),
             alternative_tools,
             has_bepinex: false,
             has_xunity: false,
@@ -1455,12 +1455,9 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
     
     // ========== REN'PY ==========
     if let Some(renpy_version) = detect_renpy_version(game_dir) {
-        alternative_tools.push(AlternativeTool {
-            name: "UnRPA".to_string(),
-            url: "https://github.com/Lattyware/unrpa".to_string(),
-            description: "Estrae file .rpa di Ren'Py".to_string(),
-            compatible: true,
-        });
+        // 23/08/2026: tolto il link a Lattyware/unrpa. Serviva a estrarre i .rpa
+        // a mano, ma dalla v1.17.0 l'app li legge da sola — Scarlet Hollow,
+        // 83.489 stringhe. Resta rpatool per chi vuole manipolare l'archivio.
         alternative_tools.push(AlternativeTool {
             name: "rpatool".to_string(),
             url: "https://github.com/shizmob/rpatool".to_string(),
@@ -3450,12 +3447,17 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
                          || engine_check.engine_name.to_lowercase().contains("danganronpa");
     all_tools.push(TranslationTool {
         id: "spike_chunsoft_patcher".to_string(),
-        name: "Danganronpa Tools".to_string(),
-        description: "Estrai file .pak con DRV3-Sharp, poi traduci i testi estratti".to_string(),
+        name: "Danganronpa Patcher".to_string(),
+        // 23/08/2026: diceva «estrai con DRV3-Sharp», un tool esterno senza
+        // nessuna release. Dalla v1.17.0 l'estrazione .pak/.wad e la ricostruzione
+        // vivono nell'app. E la rotta puntava a /danganronpa-tools, che NON
+        // esiste: la pagina è /danganronpa-patcher, come già dicono il menu,
+        // tools-registry e wizard-strategies. Chi ci cliccava finiva su un 404.
+        description: "Estrae .pak e .wad, traduce e ricostruisce l'archivio dentro l'app".to_string(),
         reliability: if is_spike_chunsoft { 75 } else { 0 },
-        route: "/danganronpa-tools".to_string(),
+        route: "/danganronpa-patcher".to_string(),
         available: is_spike_chunsoft,
-        reason: if is_spike_chunsoft { "🎮 Danganronpa/Spike Chunsoft rilevato - serve DRV3-Sharp".to_string() }
+        reason: if is_spike_chunsoft { "🎮 Danganronpa/Spike Chunsoft rilevato".to_string() }
                 else { "Solo per giochi Spike Chunsoft".to_string() },
     });
     

--- a/src-tauri/src/commands/universal_injector.rs
+++ b/src-tauri/src/commands/universal_injector.rs
@@ -564,13 +564,10 @@ fn detect_renpy(game_dir: &Path) -> Option<EngineDetectionResult> {
         version: None,
         can_inject: true,
         injection_method: "Modifica diretta .rpy o estrazione .rpa".to_string(),
+        // 23/08/2026: tolto UnRPA (Lattyware/unrpa, fermo al 2019). Estraeva i
+        // .rpa a mano, ma dalla v1.17.0 li legge l'app — Scarlet Hollow, 83.489
+        // stringhe. Resta il Ren'Py SDK, che serve per ricompilare gli script.
         tools_required: vec![
-            InjectionTool {
-                name: "UnRPA".to_string(),
-                url: "https://github.com/Lattyware/unrpa".to_string(),
-                description: "Estrae archivi .rpa".to_string(),
-                auto_install: false,
-            },
             InjectionTool {
                 name: "Ren'Py SDK".to_string(),
                 url: "https://www.renpy.org/".to_string(),
@@ -581,7 +578,7 @@ fn detect_renpy(game_dir: &Path) -> Option<EngineDetectionResult> {
         translatable_files: translatable,
         notes: vec![
             "I file .rpy sono script Python modificabili".to_string(),
-            "I file .rpa sono archivi (usa unrpa per estrarre)".to_string(),
+            "I file .rpa sono archivi, estratti direttamente dall'app".to_string(),
             "I dialoghi sono nelle stringhe tra virgolette".to_string(),
         ],
     })


### PR DESCRIPTION
**DRV3-Sharp has no releases at all** — anyone following that link found nothing to download. **unrpa has been still since 2019**, and since v1.17.0 the app reads Ren'Py `.rpa` archives natively (Scarlet Hollow, 83,489 strings). Both removed.

## Removing two links turned up five sites

Grepping for the names found more than the two I set out to remove:

| Where | What it said | Now |
|---|---|---|
| `unity_patcher.rs` — Danganronpa branch of `check_game_engine` | DRV3-Sharp as its **only** alternative tool, message *"usa tool specifici per Danganronpa"* | points at the in-app patcher |
| `unity_patcher.rs` — `TranslationTool` entry | *"estrai con DRV3-Sharp"*, `route: "/danganronpa-tools"` | describes the in-app flow, `route: "/danganronpa-patcher"` |
| `universal_injector.rs` — `tools_required` | UnRPA listed for Ren'Py | removed, Ren'Py SDK stays |
| `universal_injector.rs` — `notes` | *"usa unrpa per estrarre"* | *"estratti direttamente dall'app"* |
| `rpa_extractor.rs` — doc comment | *"senza dipendere da UnRPA/Python"* | **kept** — see below |

## Two things worth calling out

**Removing the link alone would have made things worse.** The Danganronpa branch listed DRV3-Sharp as its *only* tool and told the user to go find specific tools elsewhere. Deleting the link would have left an empty list under a message admitting defeat — for a game the app has translated **end-to-end since v1.17.0**.

**`/danganronpa-tools` does not exist.** The page is `/danganronpa-patcher`, as the menu, `tools-registry` and `wizard-strategies` have always said. Anyone clicking that tool got a 404. Fixed while editing the lines around it — leaving a known-dead route in a block I was already rewriting was not defensible.

## Deliberate non-changes

- **`can_patch` stays `false`** on the Danganronpa branch. It gates the *Unity* patch path, which is not the right one for this engine — the dedicated page is.
- **The `rpa_extractor.rs` doc comment keeps its UnRPA mention.** It explains *why* the native extractor exists — "senza dipendere da UnRPA/Python". That is the point being made, not a pointer being offered.

## Verification

- `cargo check` clean (8 warnings, all pre-existing dead code in `process_utils.rs`)
- no remaining `DRV3-Sharp`, `Lattyware/unrpa`, `usa unrpa` or `/danganronpa-tools` references outside explanatory comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)