### PR TITLE
Point eight dead routes at pages that exist, and gate the rest

### DIFF
--- a/__tests__/lib/route-integrity.test.ts
+++ b/__tests__/lib/route-integrity.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guardia anti-regressione sulle rotte interne.
+ *
+ * Il 23/08/2026 `/danganronpa-tools` è stato trovato per caso, mentre si
+ * toglieva un link nel blocco accanto: la pagina si chiama
+ * `/danganronpa-patcher` e chi cliccava quel tool finiva su un 404. La passata
+ * fatta di proposito subito dopo ne ha trovate altre sette, ferme da chissà
+ * quanto — cinque `route:` nel Rust verso pagine per-motore mai esistite, e tre
+ * `/crawler` rimaste dopo che la pagina era diventata `/context-harvester`.
+ *
+ * Nessuno se n'era accorto perché una rotta sbagliata non rompe la build, non
+ * rompe i tipi e non rompe i test: rompe solo il clic dell'utente.
+ *
+ * Regola: ogni rotta interna citata nel codice deve corrispondere a una pagina
+ * reale sotto `app/`. Le rotte dinamiche (`/library/[id]`) coprono i loro figli.
+ */
+import { describe, expect, it as test } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.join(__dirname, '..', '..');
+
+/** Le pagine che esistono davvero: ogni `page.tsx` sotto app/ è una rotta. */
+function realRoutes(dir: string, base = ''): string[] {
+  const out: string[] = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name.startsWith('.') || e.name === 'node_modules') continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...realRoutes(p, `${base}/${e.name}`));
+    else if (e.name === 'page.tsx' || e.name === 'page.ts') out.push(base || '/');
+  }
+  return out;
+}
+
+function sourceFiles(dir: string, exts: string[], out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (['node_modules', '.next', 'target', '.git'].includes(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) sourceFiles(p, exts, out);
+    else if (exts.some((x) => e.name.endsWith(x))) out.push(p);
+  }
+  return out;
+}
+
+const REAL = new Set(realRoutes(path.join(ROOT, 'app')));
+const DYNAMIC = [...REAL]
+  .filter((r) => r.includes('['))
+  .map((r) => new RegExp(`^${r.replace(/\[[^\]]+\]/g, '[^/]+')}$`));
+
+const routeExists = (r: string) => REAL.has(r) || DYNAMIC.some((re) => re.test(r));
+
+/**
+ * Non sono rotte di pagina, e vanno escluse o il gate urla su cose corrette:
+ * - `/api/...`   → route handler, non pagine
+ * - `/auth`      → prefisso in route-config.ts, non una destinazione
+ * - `/tesseract` → cartella di asset statici in public/, passata a tesseract.js
+ */
+const NOT_PAGES = [/^\/api(\/|$)/, /^\/auth$/, /^\/tesseract(\/|$)/];
+const skip = (r: string) => r === '/' || NOT_PAGES.some((re) => re.test(r));
+
+type Ref = { file: string; line: number; route: string };
+
+function collect(): Ref[] {
+  const refs: Ref[] = [];
+  const push = (file: string, line: number, route: string) => {
+    if (!skip(route)) refs.push({ file: path.relative(ROOT, file).replace(/\\/g, '/'), line, route });
+  };
+
+  for (const f of sourceFiles(path.join(ROOT, 'src-tauri', 'src'), ['.rs'])) {
+    fs.readFileSync(f, 'utf8').split('\n').forEach((l, i) => {
+      const m = l.match(/route: *"(\/[^"]*)"/);
+      if (m) push(f, i + 1, m[1]);
+    });
+  }
+  for (const dir of ['lib', 'components', 'app']) {
+    for (const f of sourceFiles(path.join(ROOT, dir), ['.ts', '.tsx'])) {
+      fs.readFileSync(f, 'utf8').split('\n').forEach((l, i) => {
+        const m = l.match(/(?:href|route|path): *['"](\/[a-z0-9/_[\]-]*)['"]/i);
+        if (m) push(f, i + 1, m[1]);
+      });
+    }
+  }
+  return refs;
+}
+
+describe('integrità delle rotte interne', () => {
+  test('esistono pagine reali sotto app/', () => {
+    expect(REAL.size).toBeGreaterThan(50);
+  });
+
+  test('ogni rotta citata nel codice corrisponde a una pagina', () => {
+    const bad = collect().filter((r) => !routeExists(r.route));
+    const detail = bad.map((b) => `${b.route}  (${b.file}:${b.line})`).join('\n  ');
+    expect(bad.length, bad.length ? `Rotte inesistenti:\n  ${detail}` : '').toBe(0);
+  });
+});

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -1108,7 +1108,7 @@ export default function GuidePage() {
                   { engine: "Ren'Py", tool: "Ren'Py Patcher", href: '/renpy-patcher', desc: g.engineRenpy, color: 'teal' },
                   { engine: 'Wolf RPG', tool: 'Wolf RPG Patcher', href: '/wolfrpg-patcher', desc: g.engineWolfRpg, color: 'orange' },
                   { engine: 'Telltale', tool: 'Telltale Patcher', href: '/telltale-patcher', desc: g.engineTelltale, color: 'violet' },
-                  { engine: 'Godot', tool: 'Crawler + Fixer', href: '/crawler', desc: g.engineGodot, color: 'cyan' },
+                  { engine: 'Godot', tool: 'Crawler + Fixer', href: '/context-harvester', desc: g.engineGodot, color: 'cyan' },
                   { engine: 'GameMaker', tool: 'Auto-Translate', href: '/auto-translate', desc: g.engineGameMaker, color: 'yellow' },
                 ].map((e, i) => (
                   <Link key={i} href={e.href}>

--- a/components/layout/global-search.tsx
+++ b/components/layout/global-search.tsx
@@ -55,7 +55,7 @@ const navigationItems: SearchItem[] = [
   { id: 'voice', title: 'Voice', description: 'Voice translation', icon: Mic, path: '/voice-translator', category: 'navigation' },
   { id: 'patcher', title: 'Patcher', description: 'Unity/Unreal patcher', icon: Wrench, path: '/unity-patcher', category: 'navigation' },
   { id: 'injector', title: 'Injector', description: 'Universal mod injection', icon: Puzzle, path: '/injector', category: 'navigation' },
-  { id: 'crawler', title: 'Crawler', description: 'Extract context from games', icon: Scan, path: '/crawler', category: 'navigation' },
+  { id: 'crawler', title: 'Crawler', description: 'Extract context from games', icon: Scan, path: '/context-harvester', category: 'navigation' },
   { id: 'fixer', title: 'Fixer', description: 'Fix translation tags', icon: Wand2, path: '/fixer', category: 'navigation' },
   { id: 'overlay', title: 'Overlay', description: 'In-game subtitles', icon: Subtitles, path: '/overlay', category: 'navigation' },
   { id: 'community', title: 'Community', description: 'Community translations hub', icon: Users, path: '/community-hub', category: 'navigation' },

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -928,7 +928,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                         { id: 'voice', title: t('nav.voice'), description: t('commandPalette.voiceDesc'), icon: Mic, path: '/voice-translator' },
                         { id: 'patcher', title: t('nav.patcher'), description: t('commandPalette.patcherDesc'), icon: Wrench, path: '/unity-patcher' },
                         { id: 'injector', title: t('nav.injector'), description: t('commandPalette.patcherDesc'), icon: Puzzle, path: '/injector' },
-                        { id: 'crawler', title: t('nav.contextHarvester'), description: t('commandPalette.scanGamesDesc'), icon: Scan, path: '/crawler' },
+                        { id: 'crawler', title: t('nav.contextHarvester'), description: t('commandPalette.scanGamesDesc'), icon: Scan, path: '/context-harvester' },
                         { id: 'fixer', title: t('nav.fixer'), description: t('commandPalette.patcherDesc'), icon: Wand2, path: '/fixer' },
                         { id: 'overlay', title: t('nav.overlay'), description: t('commandPalette.patcherDesc'), icon: Subtitles, path: '/overlay' },
                         { id: 'rom-patcher', title: 'ROM Patcher', description: 'Applica e crea patch IPS/BPS per traduzioni retro', icon: Disc, path: '/rom-patcher' },

--- a/src-tauri/src/commands/unity_patcher.rs
+++ b/src-tauri/src/commands/unity_patcher.rs
@@ -3312,7 +3312,7 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
         name: "Godot PCK Extractor".to_string(),
         description: "Estrae e modifica file .pck di Godot per traduzione".to_string(),
         reliability: if is_godot { 85 } else { 0 },
-        route: "/godot-patcher".to_string(),
+        route: "/godot-translator".to_string(),
         available: is_godot,
         reason: if is_godot { "Gioco Godot rilevato - estrazione PCK disponibile".to_string() } 
                 else { "Solo per giochi Godot".to_string() },
@@ -3395,7 +3395,7 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
         name: "Kirikiri/KAG Translator".to_string(),
         description: "Estrae script .ks e file .xp3 per visual novel Kirikiri".to_string(),
         reliability: if is_kirikiri { 80 } else { 0 },
-        route: "/kirikiri-patcher".to_string(),
+        route: "/injector".to_string(),
         available: is_kirikiri,
         reason: if is_kirikiri { "Kirikiri/KAG rilevato - estrazione XP3 disponibile".to_string() }
                 else { "Solo per Kirikiri/KAG".to_string() },
@@ -3409,7 +3409,7 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
         name: "NScripter Translator".to_string(),
         description: "Decompila e traduce script NScripter/ONScripter".to_string(),
         reliability: if is_nscripter { 78 } else { 0 },
-        route: "/nscripter-patcher".to_string(),
+        route: "/injector".to_string(),
         available: is_nscripter,
         reason: if is_nscripter { "NScripter rilevato".to_string() }
                 else { "Solo per NScripter/ONScripter".to_string() },
@@ -3423,7 +3423,7 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
         name: "GameMaker Translator".to_string(),
         description: "Estrae stringhe da data.win di GameMaker Studio".to_string(),
         reliability: if is_gamemaker { 75 } else { 0 },
-        route: "/gamemaker-patcher".to_string(),
+        route: "/translation-wizard".to_string(),
         available: is_gamemaker,
         reason: if is_gamemaker { "GameMaker Studio rilevato".to_string() }
                 else { "Solo per GameMaker Studio".to_string() },
@@ -3436,7 +3436,7 @@ pub async fn get_translation_recommendation(game_path: String, game_name: String
         name: "Construct Translator".to_string(),
         description: "Estrae stringhe da progetti Construct 2/3".to_string(),
         reliability: if is_construct { 70 } else { 0 },
-        route: "/construct-patcher".to_string(),
+        route: "/injector".to_string(),
         available: is_construct,
         reason: if is_construct { "Construct rilevato".to_string() }
                 else { "Solo per Construct 2/3".to_string() },


### PR DESCRIPTION
`/danganronpa-tools` was found **by accident** yesterday, while removing a link in the block beside it. Sweeping every internal route **on purpose** found eight more.

## What was broken

| Route | Where | Now |
|---|---|---|
| `/godot-patcher` | `unity_patcher.rs` | `/godot-translator` |
| `/gamemaker-patcher` | `unity_patcher.rs` | `/translation-wizard` |
| `/kirikiri-patcher` | `unity_patcher.rs` | `/injector` |
| `/nscripter-patcher` | `unity_patcher.rs` | `/injector` |
| `/construct-patcher` | `unity_patcher.rs` | `/injector` |
| `/crawler` | command palette, global search, guide | `/context-harvester` |

The five per-engine pages **were never built**. The `/crawler` ones were left behind when the page became `/context-harvester` — the label already read `nav.contextHarvester`, so the page had been renamed and the pointers had not.

## Destinations were checked, not guessed

- **`/injector`** mounts `UniversalInjector`, which already lists Kirikiri and NScripter by name
- **`/godot-translator`** handles `.pck` (18 references in the page)
- **`/translation-wizard`** covers the `gamemaker-data` strategy, which is `canDoInline: true` — there is no dedicated GameMaker page, and there was never meant to be one

## Two apparent hits are correct and stay

- **`/auth`** — a prefix in `route-config.ts` listing unprotected routes, not a destination
- **`/tesseract`** — a folder of static assets under `public/` handed to tesseract.js as `workerPath`/`corePath`/`langPath`

Both are excluded by name in the gate, with the reason written next to the exclusion.

## The gate

`__tests__/lib/route-integrity.test.ts` checks every `route:` in the Rust and every internal `href`/`route`/`path` in the TS against the pages that actually exist under `app/`. Dynamic routes (`/library/[id]`) cover their children.

**A wrong route breaks no build, no type and no test — only the user's click.** That is exactly why eight of them sat there unnoticed, and why a one-off sweep would decay by next month.

**Verified the gate bites:** reintroducing `/danganronpa-tools` turns it red and names the file and line.

```
× ogni rotta citata nel codice corrisponde a una pagina
  → Rotte inesistenti:
    /danganronpa-tools  (src-tauri/src/commands/unity_patcher.rs:3458)
```

## Verification

- `cargo check` clean · `npm run typecheck` clean
- suite **917 passed**, 37 skipped, 0 failed (was 915 — the two new ones)
- re-running the sweep after the fix: only the two documented false positives remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)