### PR TITLE
Merge the two RPG Maker tool entries, since one tool covers both

### DIFF
--- a/src-tauri/src/commands/unity_patcher.rs
+++ b/src-tauri/src/commands/unity_patcher.rs
@@ -1402,14 +1402,11 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
         alternative_tools.push(AlternativeTool {
             name: "Translator++".to_string(),
             url: "https://dreamsavior.net/translator-plusplus/".to_string(),
-            description: "Traduzione per RPG Maker XP/VX/Ace".to_string(),
-            compatible: !rpg_info.can_translate_directly,
-        });
-        alternative_tools.push(AlternativeTool {
-            name: "MTool".to_string(),
-            url: "https://amanatsu.booth.pm/items/1526696".to_string(),
-            description: "Traduzione per RPG Maker MV/MZ (JSON)".to_string(),
-            compatible: rpg_info.can_translate_directly,
+            description: "Traduzione per RPG Maker XP/VX/Ace e MV/MZ".to_string(),
+            // Translator++ copre XP, VX, VX Ace, MV e MZ: sempre compatibile.
+            // 23/08/2026: erano due voci, la seconda era MTool su amanatsu.booth.pm
+            // che dava 404. Fuse in una, perche' un solo tool le copre entrambe.
+            compatible: true,
         });
         
         return Ok(GameEngineCheck {


### PR DESCRIPTION
**MTool** at `amanatsu.booth.pm/items/1526696` returns **404** — the last dead link the sweep turned up.

## Why merged rather than repointed

Pointing MTool at Translator++ as asked would have produced **two entries with the same name and the same URL**, differing only by a `compatible` flag that is the exact negation of the other:

```rust
compatible: !rpg_info.can_translate_directly,   // "Translator++"
compatible:  rpg_info.can_translate_directly,   // "Translator++"
```

Exactly one would ever be marked compatible, and the user would see the same tool listed twice. So they are merged into one.

## Checked that the merge is honest, not just convenient

Translator++ handles **RPG Maker XP, VX, VX Ace, MV and MZ** — the whole range the two entries covered between them. The surviving entry says so, and `compatible` becomes an unconditional `true` rather than a branch.

Sources: [Translator++ – Dreamsavior](https://dreamsavior.net/translator-plusplus/) · [Translator++ - The introduction](https://dreamsavior.net/translator-the-introduction/) · [RPG Maker Forums](https://forums.rpgmakerweb.com/threads/translator-game-translation-tool.102706/)

*(The vendor site returns 403 to automated fetches — it answers a plain `curl -I` with 200. Verified through search rather than asserted from memory.)*

## Verification

- `rpg_info` is still read by `can_patch` and the branch message below, so dropping both `compatible` branches leaves no unused binding — `cargo check` confirms, no new warnings
- suite **917 passed**
- no `MTool` or `amanatsu` references left

🤖 Generated with [Claude Code](https://claude.com/claude-code)