### PR TITLE
Stop asking for Python and gdsdecomp, which nothing needs

### DIFF
--- a/lib/wizard-strategies.ts
+++ b/lib/wizard-strategies.ts
@@ -144,7 +144,7 @@ const STRATEGIES: Record<StrategyId, TranslationStrategy> = {
       'Inietta le traduzioni con Resize Injection (nessun troncamento)',
       'Crea backup automatici (.backup)',
     ],
-    requirements: ['Python 3.x', 'Ollama (per traduzione AI locale)'],
+    requirements: ['Ollama (per traduzione AI locale)'],
     estimatedMinutes: 10,
     filePatterns: ['resources.assets', 'sharedassets*.assets', 'level*', 'globalgamemanagers'],
     dedicatedTool: { route: '/unity-csv-translator', name: 'Unity CSV Translator' },
@@ -277,14 +277,15 @@ const STRATEGIES: Record<StrategyId, TranslationStrategy> = {
     difficulty: 'medium',
     canDoInline: true,
     steps: [
-      'Estrae il .pck con gdsdecomp',
+      'Estrae il .pck (lettore nativo, nessun tool esterno)',
       'Trova i file di traduzione (CSV, .translation)',
       'Traduce con AI',
       'Ricrea il .pck con i file tradotti',
     ],
-    requirements: ['gdsdecomp (link fornito)'],
+    requirements: [],
     estimatedMinutes: 15,
     filePatterns: ['*.pck', '*.import', 'project.godot'],
+    dedicatedTool: { route: '/godot-translator', name: 'Godot Translator' },
   },
 
   'binary-patch': {

--- a/src-tauri/src/commands/unity_patcher.rs
+++ b/src-tauri/src/commands/unity_patcher.rs
@@ -1390,7 +1390,11 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
             engine_name: format!("Godot {}", ver_str),
             engine_version: godot_version,
             can_patch: false,
-            message: format!("⚠ Godot {} - usa gdsdecomp per estrarre .pck", ver_str),
+            // 23/08/2026: diceva «usa gdsdecomp per estrarre .pck», ma dalla v1.17.0
+            // l'estrazione e nativa (godot_patcher.rs: scan_godot_pck,
+            // extract_godot_pck). I link a gdsdecomp restano sopra perche quel
+            // tool DECOMPILA, cosa che l'app non fa: e un extra, non il percorso.
+            message: format!("✓ Godot {} - usa il Godot Translator nel menu dell'app", ver_str),
             alternative_tools,
             has_bepinex: false,
             has_xunity: false,


### PR DESCRIPTION
Checked `tools-registry.ts` and `wizard-strategies.ts` — the last two catalogues nobody had read.

## tools-registry is clean

Its twenty i18n keys all resolve in `en.json`, and its `href`s point at internal pages already covered by the route gate. Nothing to fix.

## wizard-strategies asked for two things nothing needs

| Requirement | Reality |
|---|---|
| **"Python 3.x"** on the Unity CSV strategy | `Command::new("python")` appears **nowhere** in the Rust, and the only `python` in the TypeScript is a path-exclusion filter. That path is pure Rust (`unity_csv.rs`) |
| **"gdsdecomp (link fornito)"** for Godot, with a step reading *"Estrae il .pck con gdsdecomp"* | since v1.17.0 extraction is **native** — `godot_patcher.rs` exposes `scan_godot_pck` and `extract_godot_pck` as Tauri commands |

**A user reading the first one went and installed Python for nothing.**

The second is the same *"link fornito"* promise as RPG Maker Trans — and the **third catalogue in a row** whose entries describe a world from before the app learned to do the work itself.

## Two related fixes while there

- `godot-pck` had **no `dedicatedTool`** while `/godot-translator` exists. It now points there.
- the engine-check message read *"⚠ Godot — usa gdsdecomp per estrarre .pck"*. It now points at the in-app translator.

## What stays

The **gdsdecomp links themselves**. That tool *decompiles* Godot projects, which the app does not do — a genuine extra, not the path. Removing it would have been the mistake in reverse.

## Verification

`cargo check` clean · `npm run typecheck` clean · suite **917 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)