### PR TITLE
Gate the i18n keys nobody uses

### DIFF
--- a/__tests__/lib/i18n-orphan-keys.test.ts
+++ b/__tests__/lib/i18n-orphan-keys.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guardia sulle chiavi i18n orfane.
+ *
+ * Il 23/08/2026 è stato rimosso `translationRecommendationComp`: 61 chiavi che
+ * nessuna riga di codice referenziava, più una in `common`. 744 stringhe su
+ * dodici lingue. Dentro ci stavano le uniche quattro rimaste che mandavano
+ * l'utente a gdsdecomp, al link UnRPA e a RPG Maker Trans — un tool il cui sito
+ * non esiste più. La prosa viva risultava pulita non perché qualcuno l'avesse
+ * corretta, ma perché quella sbagliata era irraggiungibile.
+ *
+ * `i18n-locale-integrity` non poteva vederle: verifica che una chiave ESISTA IN
+ * TUTTE LE LINGUE, non che QUALCUNO LA USI. Una chiave orfana è perfettamente in
+ * regola per quel controllo.
+ *
+ * Regola: il numero di chiavi orfane può solo SCENDERE. Non zero — ce ne sono
+ * già ~1600, e ripulirle tutte è un lavoro a parte — ma nessuna nuova.
+ *
+ * Cosa conta come "usata":
+ *  1. la chiave compare LETTERALE da qualche parte nel sorgente. Non solo dentro
+ *     `t('...')`: anche `nameKey: 'nav.x'` poi passato a `t(item.nameKey)`.
+ *  2. la chiave inizia per un prefisso costruito dinamicamente in un template
+ *     literal, es. `changelog.v${version}.${i}` copre tutte le changelog.v*.
+ */
+import { describe, expect, it as test } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.join(__dirname, '..', '..');
+
+/** Numero di orfane al 23/08/2026, dopo la rimozione di translationRecommendationComp. */
+const BASELINE = 1601;
+
+function flatten(o: unknown, prefix = '', out: string[] = []): string[] {
+  for (const [k, v] of Object.entries(o as Record<string, unknown>)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object') flatten(v, key, out);
+    else out.push(key);
+  }
+  return out;
+}
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (['node_modules', '.next', 'target', '.git', 'locales'].includes(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) sourceFiles(p, out);
+    else if (/\.(ts|tsx)$/.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+describe('chiavi i18n orfane', () => {
+  const keys = flatten(JSON.parse(fs.readFileSync(path.join(ROOT, 'lib/i18n/locales/en.json'), 'utf8')));
+
+  let src = '';
+  for (const d of ['app', 'components', 'lib', 'scripts']) {
+    const dir = path.join(ROOT, d);
+    if (!fs.existsSync(dir)) continue;
+    for (const f of sourceFiles(dir)) src += fs.readFileSync(f, 'utf8') + '\n';
+  }
+
+  // 1. chiavi citate per intero, in qualunque forma di stringa
+  const literal = new Set(
+    [...src.matchAll(/['"`]([a-zA-Z][\w]*(?:\.[\w]+)+)['"`]/g)].map((m) => m[1]),
+  );
+  // 2. prefissi costruiti a runtime: `ns.qualcosa${...}`. Devono contenere un
+  //    punto, o prefissi come `m` o `d` (variabili in template qualsiasi)
+  //    marcherebbero come usata mezza tabella.
+  const dynamic = [
+    ...new Set([...src.matchAll(/`([a-zA-Z][\w]*\.[\w.]*)\$\{/g)].map((m) => m[1])),
+  ];
+
+  const isUsed = (k: string) => literal.has(k) || dynamic.some((p) => k.startsWith(p));
+  const orphans = keys.filter((k) => !isUsed(k));
+
+  test('il rilevatore riconosce le chiavi realmente usate', () => {
+    // sanity: se questi non risultano usati, il rilevatore è rotto e il
+    // conteggio sotto non vuol dire niente.
+    expect(isUsed('changelog.currentVersion')).toBe(true);
+    expect(keys.length).toBeGreaterThan(5000);
+    expect(orphans.length).toBeLessThan(keys.length / 2);
+  });
+
+  test(`nessuna nuova chiave orfana (baseline ${BASELINE})`, () => {
+    const sample = orphans.slice(0, 15).join('\n  ');
+    expect(
+      orphans.length,
+      orphans.length > BASELINE
+        ? `Chiave i18n non referenziata da nessuna riga di codice.\n` +
+          `Orfane: ${orphans.length} (baseline ${BASELINE}).\n` +
+          `Se la chiave serve, usala; se non serve, toglila da tutti i locale.\n` +
+          `Prime 15:\n  ${sample}`
+        : '',
+    ).toBeLessThanOrEqual(BASELINE);
+  });
+});


### PR DESCRIPTION
`i18n-locale-integrity` checks that a key **exists in every language**, not that anyone **uses** it. The 62 orphaned keys removed earlier today were perfectly compliant with it — they were found **by accident**, looking for something else, and the four stalest strings in the repository were hiding inside them.

## The detector counts a key as used two ways, because one is not enough

| Way | Why it is needed |
|---|---|
| **literal appearance anywhere in the source**, not just inside `t()` | keys reach `t()` through variables — `tools-registry` stores `'nav.contextHarvester'` in a `nameKey` field and the layout passes it on later |
| **a dynamic prefix from a template literal** | `main-layout` builds `` `changelog.v${version}.${index}` ``, covering **551** changelog keys no literal search would ever find |

Dynamic prefixes must contain a dot, or single letters from unrelated templates (`m`, `d`, `a`) would mark half the table as used.

## Baseline is 1601, not zero

There are already that many. Cleaning them all is separate work, and **a gate that fails on day one gets deleted rather than obeyed**. The assertion is `<=`, so the number can only fall.

## The first test guards the detector itself

If `changelog.currentVersion` ever stops reading as used, or orphans exceed half the table, the count means nothing — and the baseline would be measuring a bug in the detector instead of the state of the codebase.

## Verified it bites

```
× nessuna nuova chiave orfana (baseline 1601)
  → Orfane: 1602 (baseline 1601).
```

One unreferenced key added, gate red, key removed again.

## Verification

`npm run typecheck` clean · suite **919 passed**, up from 917 by these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)