### PR TITLE
Give the digest a PR count that cannot go stale

### DIFF
--- a/docs/digests/2026-08-23-digest-traduzioni.md
+++ b/docs/digests/2026-08-23-digest-traduzioni.md
@@ -309,6 +309,14 @@ Verificato invece che la prosa viva che nomina tool esterni sia **vera**: Transl
 - `docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md` — la trappola del merge remoto, i prezzi verificati, il limite della chiave unica per provider
 - `docs/maintenance/2026-08-23-changelog-v1-16-0-disallineato.md` — il disallineamento degli indici, il gate che lo certificava, i difetti misurati della traduzione automatica
 
+**30 PR fuse in giornata**, dalla #115 alla #144. Il conteggio non va tenuto a mente: si ricava.
+
+```bash
+gh pr list --state merged --limit 60 --json number,mergedAt --jq '[.[] | select(.mergedAt | startswith("2026-08-23"))] | length'
+```
+
+Nella tabella qui sotto ne mancano le ultime: **una riga che elenca le PR non può includere la PR che aggiunge quella riga.** Per il totale vale il comando, non l'elenco.
+
 | PR | Cosa |
 |---|---|
 | [#115](https://github.com/rouges78/GameStringer/pull/115) | Il sito smette di rimettere i prezzi vecchi |
@@ -340,6 +348,7 @@ Verificato invece che la prosa viva che nomina tool esterni sia **vera**: Transl
 | [#141](https://github.com/rouges78/GameStringer/pull/141) | 905 chiavi rimosse, dopo che il primo tentativo aveva tolto quelle sbagliate |
 | [#142](https://github.com/rouges78/GameStringer/pull/142) | Digest: il gate che avevo scritto misurava male |
 | [#143](https://github.com/rouges78/GameStringer/pull/143) | Passata di conferma: 3 difetti nuovi, e HEAD non basta |
+| [#144](https://github.com/rouges78/GameStringer/pull/144) | Digest: la passata di conferma e il difetto nel metodo |
 
 ## 🚦 Gate aggiunti oggi
 


### PR DESCRIPTION
The table listed **29** PRs and stated no total. **Thirty** were merged today — and I had said *thirty-two* out loud earlier, miscounting the range #115 to #144.

## What changes

- adds the missing **#144**
- instead of freezing a number that was already wrong once, writes the command that recounts it:

```bash
gh pr list --state merged --limit 60 --json number,mergedAt --jq '[.[] | select(.mergedAt | startswith("2026-08-23"))] | length'
```

The digest already does this for the model catalogue (`curl -s https://gamestringer.ai/config/models.json`). **The verification belongs next to the claim.**

## And names why the table can never be complete

> A row listing the PRs cannot include the PR that adds the row.

This very PR takes the real total to 31 while the table shows 30. Better to state that than to let the next reader find the table short and wonder which number is lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)