### PR TITLE
Bring the PR count to 31, and date it so it reads as a snapshot

### DIFF
--- a/docs/digests/2026-08-23-digest-traduzioni.md
+++ b/docs/digests/2026-08-23-digest-traduzioni.md
@@ -309,7 +309,7 @@ Verificato invece che la prosa viva che nomina tool esterni sia **vera**: Transl
 - `docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md` — la trappola del merge remoto, i prezzi verificati, il limite della chiave unica per provider
 - `docs/maintenance/2026-08-23-changelog-v1-16-0-disallineato.md` — il disallineamento degli indici, il gate che lo certificava, i difetti misurati della traduzione automatica
 
-**30 PR fuse in giornata**, dalla #115 alla #144. Il conteggio non va tenuto a mente: si ricava.
+**31 PR fuse in giornata** dalla #115 alla #145, contate dopo la #145. Il numero sale ancora se il digest viene ritoccato: è per questo che accanto c'è il comando, e non va tenuto a mente.
 
 ```bash
 gh pr list --state merged --limit 60 --json number,mergedAt --jq '[.[] | select(.mergedAt | startswith("2026-08-23"))] | length'
@@ -349,6 +349,7 @@ Nella tabella qui sotto ne mancano le ultime: **una riga che elenca le PR non pu
 | [#142](https://github.com/rouges78/GameStringer/pull/142) | Digest: il gate che avevo scritto misurava male |
 | [#143](https://github.com/rouges78/GameStringer/pull/143) | Passata di conferma: 3 difetti nuovi, e HEAD non basta |
 | [#144](https://github.com/rouges78/GameStringer/pull/144) | Digest: la passata di conferma e il difetto nel metodo |
+| [#145](https://github.com/rouges78/GameStringer/pull/145) | Conteggio PR che non invecchia |
 
 ## 🚦 Gate aggiunti oggi
 


### PR DESCRIPTION
The count said **30** and the table stopped at #144. Adding **#145** took the real total to **31** — exactly as the note beside it predicted.

## The number is now a snapshot, not a fact

> «31 dalla #115 alla #145, **contate dopo la #145**»

It will be **32** the moment this commit merges, and that is fine. The command next to it is the authority; the figure is there only so a reader knows the order of magnitude without running anything.

```bash
gh pr list --state merged --limit 60 --json number,mergedAt --jq '[.[] | select(.mergedAt | startswith("2026-08-23"))] | length'
```

This is the same principle the digest applies to the model catalogue and to the live site config: **a claim that can rot ships with the command that re-checks it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)