### PR TITLE
Make Delete work on the derived project cards too

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -44,6 +44,7 @@ import { useTranslation } from '@/lib/i18n';
 import { langFlagSrc } from '@/lib/translation/target-languages';
 import { qualityScoringService, type TranslationProject } from '@/lib/quality/quality-scoring';
 import { projectService } from '@/lib/services/translation-projects';
+import { isProjectTombstoned, isProjectsHydrationSettled } from '@/lib/projects-persistence';
 import { loadTranslatedFiles, deleteTranslatedFiles } from '@/lib/services/translated-files-store';
 import { importGspack, createGspack, saveGspackToFile } from '@/lib/gspack-manager';
 import { installGspackAsProject } from '@/lib/services/gspack-install';
@@ -134,7 +135,24 @@ interface GameApiItem {
 
 // ─── Data loader ─────────────────────────────────────────────
 
+/**
+ * I tombstone vivono in una cache idratata dal disco al boot. SettingsBootGate
+ * però sblocca l'app dopo 1500ms ANCHE se l'hydration non ha finito: su un
+ * avvio lento questa pagina leggerebbe un set vuoto e ridisegnerebbe le card
+ * appena eliminate, che sparirebbero al reload dopo. È lo stesso tipo di corsa
+ * chiusa il 04/08 sui settings (vedi persistProjectsToDisk).
+ * Qui aspettiamo che l'hydration si sia posata, con un tetto: oltre quello si
+ * procede comunque, che è il comportamento di prima — mai peggio.
+ */
+async function waitForTombstones(maxMs = 2000): Promise<void> {
+  const step = 50;
+  for (let waited = 0; waited < maxMs && !isProjectsHydrationSettled(); waited += step) {
+    await new Promise((r) => setTimeout(r, step));
+  }
+}
+
 async function loadAllProjects(): Promise<UnifiedProject[]> {
+  await waitForTombstones();
   const projectsMap = new Map<string, UnifiedProject>();
 
   // 0. Active Translation Projects (IndexedDB) - PRIORITÀ MASSIMA
@@ -268,6 +286,10 @@ async function loadAllProjects(): Promise<UnifiedProject[]> {
 
       for (const [key, g] of grouped) {
         const [gameId] = key.split(':');
+        // Eliminata dall'utente: queste card sono DERIVATE e si ricalcolano a
+        // ogni apertura, quindi senza tombstone «Elimina» non poteva funzionare
+        // — e infatti non eliminava, mostrava solo un avviso.
+        if (isProjectTombstoned(gameId, g.tgt)) continue;
         const mapKey = `tm:${key}`;
         projectsMap.set(mapKey, {
           id: mapKey,
@@ -296,6 +318,11 @@ async function loadAllProjects(): Promise<UnifiedProject[]> {
       const data = (await resp.json()) as GameApiItem[];
       for (const game of ensureArray(data) as GameApiItem[]) {
         if (!game.translationStats || game.translationStats.total === 0) continue;
+        // Stesso motivo della card TM sopra: derivata dalla libreria, si
+        // ricostruisce a ogni load. La lingua qui è 'it' come sotto, non un
+        // dato del gioco: se un giorno diventa variabile, va cambiata in
+        // entrambi i punti o il tombstone smette di agganciare.
+        if (isProjectTombstoned(game.id, 'it')) continue;
         const key = `game:${game.id}`;
         if (projectsMap.has(key)) continue;
 
@@ -656,9 +683,21 @@ export default function ProjectsPage() {
       return;
     }
     // translation_memory / game: card DERIVATE (TM condivisa, statistiche di
-    // libreria) — da qui non si possono eliminare, e fino a oggi il click
-    // faceva FINTA di niente dopo la conferma. Meglio dire il perché.
-    toast.info(t('projectsPage.deleteDerivedCard'));
+    // libreria). Non esiste un record da cancellare — si ricalcolano a ogni
+    // apertura della pagina — quindi «Elimina» qui non poteva che dire di no,
+    // e lo diceva con un avviso che è facile scambiare per una conferma.
+    // Ora lascia un tombstone: il dato di origine resta (la TM e le statistiche
+    // di libreria servono altrove), sparisce la card. Una traduzione NUOVA
+    // ripassa dall'apply e registra un progetto vero, che ricompare.
+    try {
+      const { addProjectTombstone } = await import('@/lib/projects-persistence');
+      await addProjectTombstone(p.gameId, p.targetLanguage);
+      toast.success(t('projectsPage.projectDeleted'));
+      reload();
+    } catch (e: unknown) {
+      clientLogger.error(`[Projects] delete derived failed: ${String(e)}`);
+      toast.error(t('projectsPage.deleteError'));
+    }
   };
 
   /**

--- a/lib/i18n/locales/de.json
+++ b/lib/i18n/locales/de.json
@@ -441,8 +441,7 @@
     "projectImported": "Projekt importiert",
     "publishLive": "Der Patch ist online: im Patch Hub sichtbar.",
     "publishViewPack": "Pack ansehen",
-    "openPackTitle": "Veröffentlicht — Pack im Patch Hub öffnen",
-    "deleteDerivedCard": "Diese Karte leitet sich aus anderen Daten ab (Translation Memory oder Bibliothek) und kann hier nicht gelöscht werden"
+    "openPackTitle": "Veröffentlicht — Pack im Patch Hub öffnen"
   },
   "emulatorTranslator": {
     "clipboardError": "Zwischenablage kann nicht gelesen werden",

--- a/lib/i18n/locales/el.json
+++ b/lib/i18n/locales/el.json
@@ -441,8 +441,7 @@
     "projectImported": "το έργο εισήχθη",
     "publishLive": "Το patch είναι online: ορατό στο Patch Hub.",
     "publishViewPack": "Άνοιγμα pack",
-    "openPackTitle": "Δημοσιεύτηκε — άνοιγμα του pack στο Patch Hub",
-    "deleteDerivedCard": "Αυτή η κάρτα προέρχεται από άλλα δεδομένα (Translation Memory ή βιβλιοθήκη) και δεν διαγράφεται από εδώ"
+    "openPackTitle": "Δημοσιεύτηκε — άνοιγμα του pack στο Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Δεν είναι δυνατή η ανάγνωση του προχείρου",

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -441,8 +441,7 @@
     "projectImported": "project imported",
     "publishLive": "The patch is live: visible in the Patch Hub.",
     "publishViewPack": "View pack",
-    "openPackTitle": "Published — open the pack on the Patch Hub",
-    "deleteDerivedCard": "This card is derived from other data (Translation Memory or library) and can't be deleted from here"
+    "openPackTitle": "Published — open the pack on the Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Unable to read clipboard",

--- a/lib/i18n/locales/es.json
+++ b/lib/i18n/locales/es.json
@@ -441,8 +441,7 @@
     "projectImported": "proyecto importado",
     "publishLive": "El parche está publicado: visible en el Patch Hub.",
     "publishViewPack": "Ver el pack",
-    "openPackTitle": "Publicado — abrir el pack en el Patch Hub",
-    "deleteDerivedCard": "Esta tarjeta deriva de otros datos (Translation Memory o biblioteca) y no se puede eliminar desde aquí"
+    "openPackTitle": "Publicado — abrir el pack en el Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "No se puede leer el portapapeles",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -441,8 +441,7 @@
     "projectImported": "projet importé",
     "publishLive": "Le patch est en ligne : visible dans le Patch Hub.",
     "publishViewPack": "Voir le pack",
-    "openPackTitle": "Publié — ouvrir le pack dans le Patch Hub",
-    "deleteDerivedCard": "Cette carte est dérivée d'autres données (Translation Memory ou bibliothèque) et ne peut pas être supprimée ici"
+    "openPackTitle": "Publié — ouvrir le pack dans le Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Impossible de lire le presse-papiers",

--- a/lib/i18n/locales/it.json
+++ b/lib/i18n/locales/it.json
@@ -441,8 +441,7 @@
     "projectImported": "progetto importato",
     "publishLive": "La patch è online: visibile nel Patch Hub.",
     "publishViewPack": "Apri il pack",
-    "openPackTitle": "Pubblicato — apri il pack sul Patch Hub",
-    "deleteDerivedCard": "Questa scheda deriva da altri dati (Translation Memory o libreria) e non si elimina da qui"
+    "openPackTitle": "Pubblicato — apri il pack sul Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Impossibile leggere gli appunti",

--- a/lib/i18n/locales/ja.json
+++ b/lib/i18n/locales/ja.json
@@ -441,8 +441,7 @@
     "projectImported": "プロジェクトをインポートしました",
     "publishLive": "パッチは公開されました。Patch Hub で表示されます。",
     "publishViewPack": "パックを表示",
-    "openPackTitle": "公開済み — Patch Hub でパックを開く",
-    "deleteDerivedCard": "このカードは他のデータ（Translation Memory やライブラリ）から生成されているため、ここからは削除できません"
+    "openPackTitle": "公開済み — Patch Hub でパックを開く"
   },
   "emulatorTranslator": {
     "clipboardError": "クリップボードを読み取れません",

--- a/lib/i18n/locales/ko.json
+++ b/lib/i18n/locales/ko.json
@@ -441,8 +441,7 @@
     "projectImported": "프로젝트를 가져왔습니다",
     "publishLive": "패치가 게시되었습니다. Patch Hub에서 볼 수 있습니다.",
     "publishViewPack": "팩 보기",
-    "openPackTitle": "게시됨 — Patch Hub에서 팩 열기",
-    "deleteDerivedCard": "이 카드는 다른 데이터(Translation Memory 또는 라이브러리)에서 파생되어 여기서 삭제할 수 없습니다"
+    "openPackTitle": "게시됨 — Patch Hub에서 팩 열기"
   },
   "emulatorTranslator": {
     "clipboardError": "클립보드를 읽을 수 없습니다",

--- a/lib/i18n/locales/pl.json
+++ b/lib/i18n/locales/pl.json
@@ -441,8 +441,7 @@
     "projectImported": "projekt zaimportowany",
     "publishLive": "Łatka jest opublikowana: widoczna w Patch Hub.",
     "publishViewPack": "Zobacz pack",
-    "openPackTitle": "Opublikowano — otwórz pack w Patch Hub",
-    "deleteDerivedCard": "Ta karta pochodzi z innych danych (Translation Memory lub biblioteki) i nie można jej stąd usunąć"
+    "openPackTitle": "Opublikowano — otwórz pack w Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Nie można odczytać schowka",

--- a/lib/i18n/locales/pt.json
+++ b/lib/i18n/locales/pt.json
@@ -441,8 +441,7 @@
     "projectImported": "projeto importado",
     "publishLive": "O patch está publicado: visível no Patch Hub.",
     "publishViewPack": "Ver o pack",
-    "openPackTitle": "Publicado — abrir o pack no Patch Hub",
-    "deleteDerivedCard": "Este cartão deriva de outros dados (Translation Memory ou biblioteca) e não pode ser excluído daqui"
+    "openPackTitle": "Publicado — abrir o pack no Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Não foi possível ler a área de transferência",

--- a/lib/i18n/locales/ru.json
+++ b/lib/i18n/locales/ru.json
@@ -441,8 +441,7 @@
     "projectImported": "проект импортирован",
     "publishLive": "Патч опубликован: виден в Patch Hub.",
     "publishViewPack": "Открыть пак",
-    "openPackTitle": "Опубликован — открыть пак в Patch Hub",
-    "deleteDerivedCard": "Эта карточка получена из других данных (Translation Memory или библиотека) и не может быть удалена отсюда"
+    "openPackTitle": "Опубликован — открыть пак в Patch Hub"
   },
   "emulatorTranslator": {
     "clipboardError": "Не удалось прочитать буфер обмена",

--- a/lib/i18n/locales/zh.json
+++ b/lib/i18n/locales/zh.json
@@ -441,8 +441,7 @@
     "projectImported": "项目已导入",
     "publishLive": "补丁已发布：可在 Patch Hub 中查看。",
     "publishViewPack": "查看补丁包",
-    "openPackTitle": "已发布 — 在 Patch Hub 中打开补丁包",
-    "deleteDerivedCard": "此卡片来自其他数据（Translation Memory 或游戏库），无法在此处删除"
+    "openPackTitle": "已发布 — 在 Patch Hub 中打开补丁包"
   },
   "emulatorTranslator": {
     "clipboardError": "无法读取剪贴板",


### PR DESCRIPTION
Deleting a project card wrote a tombstone **only when its source was `active`**.

The cards derived from the library and from the shared Translation Memory are **recomputed on every page load**, so there was no record to remove. Delete could only decline — and it declined with an *info* toast that reads a lot like a confirmation:

> «Questa scheda deriva da altri dati (Translation Memory o libreria) e non si elimina da qui»

The card came back every time, which is exactly what it looked like from outside: **a delete that does not delete.**

## The fix

| | |
|---|---|
| `handleDelete` | the `game` / `translation_memory` branch now leaves a tombstone |
| the two derivation loops | skip anything tombstoned |

The underlying data is untouched — the Translation Memory and the library statistics are used elsewhere and stay. **Only the card goes.**

A new translation still comes back on its own: it goes through apply, which registers a real project without consulting the tombstone. That was already the documented intent for the `active` cards.

## A race that would have made the fix look flaky

Tombstones live in a cache hydrated from disk at boot — but `SettingsBootGate` releases the app after **1500 ms whether hydration finished or not**.

On a slow start this page would read an empty set and repaint the cards just deleted, which then vanish on the next reload — *the same defect wearing a different hat*. `loadAllProjects` now waits for hydration to settle, capped at 2 s, after which it proceeds exactly as before.

This is the same class of race the file already documents closing on 04/08 for settings.

## Housekeeping

`projectsPage.deleteDerivedCard` is gone from all twelve locales — nothing says it any more.

**The orphan-key gate added this morning caught it and named it**, which is the first time it has earned its keep on work that was not about i18n.

## Verification

`npm run typecheck` clean · suite **919 passed** · eslint unchanged at 2 pre-existing warnings

*Not verified in the running app: this is Tauri, and the tombstone cache hydrates through Tauri's filesystem API, so the web dev server cannot exercise it. The browser check confirmed only that the page loads without console errors.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)