### PR TITLE
Send the home "Progetti" button to Projects, not the Editor

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -485,7 +485,13 @@ export default function Dashboard() {
               <Globe className="h-3.5 w-3.5 text-[#8f98a0] group-hover:text-[#67c1f5]" />
               <span className="text-[11px] font-medium text-[#8f98a0] group-hover:text-[#c6d4df]">Community</span>
             </Link>
-            <Link href="/editor" className="group flex items-center gap-2 px-3 py-2 rounded-lg bg-[#2a475e]/20 hover:bg-[#2a475e]/40 border border-[#2a475e]/30 hover:border-[#67c1f5]/30 transition-all hover:-translate-y-0.5">
+            {/* 23/08/2026: puntava a /editor pur essendo etichettato «Progetti».
+                Nella sidebar sono due voci distinte (Progetti → /projects,
+                Editor → /editor), quindi da qui si finiva sull'Editor cliccando
+                Progetti. Le altre quattro Link verso /editor nel repo sono
+                etichettate «editor» e restano come sono: questa era l'unica
+                che diceva una cosa e ne faceva un'altra. */}
+            <Link href="/projects" className="group flex items-center gap-2 px-3 py-2 rounded-lg bg-[#2a475e]/20 hover:bg-[#2a475e]/40 border border-[#2a475e]/30 hover:border-[#67c1f5]/30 transition-all hover:-translate-y-0.5">
               <Layers className="h-3.5 w-3.5 text-[#8f98a0] group-hover:text-[#67c1f5]" />
               <span className="text-[11px] font-medium text-[#8f98a0] group-hover:text-[#c6d4df]">{t('common.projects')}</span>
             </Link>


### PR DESCRIPTION
The hero bar on the dashboard has three links. The one labelled **Progetti** pointed at **`/editor`**.

```
Hero bar:  «Progetti» → /editor
Sidebar:   «Progetti» → /projects   ·   «Editor» → /editor
```

In the sidebar those are **two separate entries**, so clicking Progetti from the home opened the Editor instead.

It reads as a duplicate of the sidebar — which is how it got noticed — but it is worse than a duplicate: **it is a duplicate that lies about where it goes.**

## Checked the neighbours

The other four `Link` elements pointing at `/editor` in the repo are all labelled *"editor"* and are correct. This was the only one saying one thing and doing another.

## Only the href changes

The three buttons stay. **«Traduci un gioco» is the styled primary call to action** — blue gradient, brighter border, larger text — not a plain repeat of the sidebar. Removing it is a product decision, not a bug fix, so it is left alone.

## Verification

`npm run typecheck` clean · `route-integrity` gate passes (`/projects` is a real page) · suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)