### PR TITLE
Name the tool in the RGSS step again, and unbreak main

### DIFF
--- a/src-tauri/src/commands/universal_injector.rs
+++ b/src-tauri/src/commands/universal_injector.rs
@@ -785,7 +785,10 @@ define config.language = "italian"
         }
         "RPGMakerVXAce" | "RPGMakerXP" => {
             steps.push("Gli archivi RGSS (.rgss3a/.rgss2a/.rxdata) sono criptati".to_string());
-            steps.push("Decripta l'archivio RGSS, poi traduci dentro l'app".to_string());
+            // Lo step DEVE nominare il tool: e l'unica indicazione che l'utente
+            // riceve, e gli archivi RGSS un decryptor esterno lo richiedono davvero.
+            // Il test inject_tool_based_engines_return_guidance lo verifica.
+            steps.push("Decripta l'archivio con RGSS Decryptor, poi traduci dentro l'app".to_string());
         }
         "GameMaker" => {
             steps.push("I testi sono dentro data.win (formato GameMaker)".to_string());


### PR DESCRIPTION
**`main` has been red since #130.** This is my regression.

## What broke

The Rust test `inject_tool_based_engines_return_guidance` asserts that engines needing an external tool **name it in their steps**:

| Engine | must appear |
|---|---|
| Kirikiri | GARbro |
| Wolf | Wolf Trans |
| **RPGMakerVXAce** | **RGSS Decryptor** |
| NScripter | nscript.dat |

In #130 I rewrote the RPG Maker VX/Ace step to *"Decripta l'archivio RGSS, poi traduci dentro l'app"* and updated the expectation to `"RGSS Decryptor"` — which the new text no longer contained.

## Restoring the name is the right fix, not relaxing the assertion

RGSS archives **genuinely need an external decryptor** — the app cannot open them, and that step is the only place the user is told which one. Dropping the name made the *guidance* worse, not just the test red.

## Why it went unnoticed for thirteen PRs

**Every Rust change today was verified with `cargo check`, which compiles but runs nothing.**

`check-linux` and `frontend-checks` kept passing because neither runs the Rust test suite. `check-windows` is the job that does — and it had been failing on every PR merged after #130.

## Verification

`cargo test --lib` — **1574 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)