### PR TITLE
Price the chain presets from the real catalog, not from a fallback

### DIFF
--- a/__tests__/lib/remote-config.test.ts
+++ b/__tests__/lib/remote-config.test.ts
@@ -11,6 +11,7 @@ import {
   validateModelConfig,
   mergeModelConfig,
   getProviderPrice1k,
+  getProviderPrice1kOrNull,
   getProviderModels,
   getRecommendation,
 } from '@/lib/remote-config';
@@ -77,6 +78,22 @@ describe('getter', () => {
   it('prezzo con fallback 0.002 per provider sconosciuto', () => {
     expect(getProviderPrice1k(BUNDLED_MODEL_CONFIG, 'claude')).toBe(0.003);
     expect(getProviderPrice1k(BUNDLED_MODEL_CONFIG, 'sconosciuto')).toBe(0.002);
+  });
+
+  it('la variante OrNull distingue «gratis» da «non lo so»', () => {
+    // È la distinzione che a chain-cost.ts serviva e non aveva: con il solo
+    // fallback, un provider locale e uno sconosciuto rispondevano lo stesso.
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'claude')).toBe(0.003);
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'hymt')).toBe(0);
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'sconosciuto')).toBeNull();
+  });
+
+  it('le chiavi delle catene sono nel listino, non solo quelle dei vendor', () => {
+    // Il difetto del 24/08: le catene chiedono 'anthropic-premium', il listino
+    // conosceva solo 'claude', e Opus 5 veniva preventivato col ripiego 0.002.
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'anthropic')).toBe(0.003);
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'anthropic-claude4')).toBe(0.003);
+    expect(getProviderPrice1kOrNull(BUNDLED_MODEL_CONFIG, 'anthropic-premium')).toBe(0.005);
   });
 
   it('modelli del provider (vuoto se assente)', () => {

--- a/__tests__/lib/translation/chain-cost.test.ts
+++ b/__tests__/lib/translation/chain-cost.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Test della stima di costo dei chain preset.
+ *
+ * ⛔ PERCHÉ ESISTONO (24/08/2026): chain-cost.ts non aveva un solo test, e il
+ * difetto che aveva non era sottile — era una riga che sembrava giusta. Il
+ * ciclo contava i «provider gratuiti in testa alla catena» chiedendo il prezzo
+ * a getProviderPrice1k, che per un provider fuori catalogo NON risponde «non lo
+ * so» ma 0.002: il contatore restava a zero sempre, e ogni preset veniva
+ * preventivato come il suo primo provider a un prezzo inventato. Il preset
+ * «🆓 Gratis», che parte da un modello sul PC dell'utente, mostrava ~$0,60.
+ *
+ * I test qui sotto guardano perciò le CONSEGUENZE VISIBILI (quale provider
+ * determina il tetto, quanti gratuiti sono stati contati, che stringa legge
+ * l'utente), non la forma interna della funzione: è il livello a cui il difetto
+ * era osservabile, ed è il livello a cui una regressione tornerebbe a esserlo.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CHAIN_PRESETS, type ChainPresetInfo } from '@/lib/translation/chain-presets';
+import {
+  stimaCostoPreset,
+  formattaStima,
+  STRINGHE_RIFERIMENTO,
+  CARATTERI_PER_STRINGA,
+} from '@/lib/translation/chain-cost';
+import { BUNDLED_MODEL_CONFIG, FALLBACK_PRICE_1K } from '@/lib/remote-config';
+
+vi.mock('@/lib/client-logger', () => ({
+  clientLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Token del volume di riferimento: caratteri/4, ×2 per l'output. */
+const TOKEN_RIF = Math.ceil((STRINGHE_RIFERIMENTO * CARATTERI_PER_STRINGA) / 4) * 2;
+const usdA = (per1k: number) => (TOKEN_RIF / 1000) * per1k;
+
+const preset = (providers: string[]): ChainPresetInfo => ({
+  id: 'balanced',
+  name: 'test',
+  description: 'test',
+  quality: '',
+  speed: '',
+  providers,
+});
+
+const trova = (id: string) => CHAIN_PRESETS.find((p) => p.id === id)!;
+
+/**
+ * getModelConfig() legge la cache in localStorage e, se manca o è vecchia,
+ * lancia un refresh via fetch. Nei test si semina la cache: niente rete, e i
+ * casi «la config remota dichiara questo prezzo» diventano scrivibili.
+ */
+function seminaConfig(pricing: Record<string, { per1kUsd: number }> = {}) {
+  localStorage.setItem(
+    'gs-model-config',
+    JSON.stringify({ config: { version: 1, pricing, models: {} }, ts: Date.now() })
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('niente rete nei test'))));
+  seminaConfig();
+});
+
+describe('stimaCostoPreset — i gratuiti in testa alla catena', () => {
+  it('NON fattura i provider locali: «Gratis» non è preventivato come HY-MT', () => {
+    const s = stimaCostoPreset(trova('free'));
+    // Il difetto del 24/08 dava esattamente questo: provider 'hymt', $0,60.
+    expect(s.provider).not.toBe('hymt');
+    expect(s.gratuitiPrima).toBeGreaterThanOrEqual(4);
+  });
+
+  it('conta i gratuiti e nomina il primo a pagamento', () => {
+    const s = stimaCostoPreset(preset(['hymt', 'ollama', 'deepl']));
+    expect(s.gratuitiPrima).toBe(2);
+    expect(s.provider).toBe('deepl');
+    expect(s.usdMax).toBeCloseTo(usdA(0.02), 6);
+    expect(s.prezzoIgnoto).toBe(false);
+  });
+
+  it('una catena di soli provider locali costa zero', () => {
+    const s = stimaCostoPreset(trova('privacy'));
+    expect(s.gratis).toBe(true);
+    expect(s.usdMax).toBeNull();
+    expect(s.gratuitiPrima).toBe(trova('privacy').providers.length);
+    expect(formattaStima(s)).toBe('$0');
+  });
+
+  it('onora un provider dichiarato gratuito dalla config remota', () => {
+    // validateModelConfig accetta per1kUsd >= 0 apposta: il ramo "gratis" deve
+    // scattare anche per un provider che il bundled considera a pagamento.
+    seminaConfig({ deepl: { per1kUsd: 0 } });
+    const s = stimaCostoPreset(preset(['deepl', 'openai']));
+    expect(s.gratuitiPrima).toBe(1);
+    expect(s.provider).toBe('openai');
+  });
+});
+
+describe('stimaCostoPreset — prezzi presi dal catalogo, non inventati', () => {
+  it('le tre chiavi Claude delle catene hanno il prezzo di Claude', () => {
+    // Prima del 24/08 pagavano tutte il ripiego 0.002: Opus 5 preventivato
+    // 2,5× meno del vero, cioè l'errore nel verso che manda la fattura alta.
+    expect(stimaCostoPreset(preset(['anthropic'])).usdMax).toBeCloseTo(usdA(0.003), 6);
+    expect(stimaCostoPreset(preset(['anthropic-claude4'])).usdMax).toBeCloseTo(usdA(0.003), 6);
+    expect(stimaCostoPreset(preset(['anthropic-premium'])).usdMax).toBeCloseTo(usdA(0.005), 6);
+    expect(stimaCostoPreset(preset(['anthropic-premium'])).prezzoIgnoto).toBe(false);
+  });
+
+  it('«Massima Qualità» è preventivata su Opus 5, non sul ripiego', () => {
+    const s = stimaCostoPreset(trova('max_quality'));
+    expect(s.provider).toBe('anthropic-premium');
+    expect(s.usdMax).toBeCloseTo(usdA(0.005), 6);
+    expect(formattaStima(s)).toBe('~$1,5');
+  });
+
+  it('un provider fuori catalogo si stima col ripiego e lo dichiara', () => {
+    const s = stimaCostoPreset(preset(['groq']));
+    expect(s.prezzoIgnoto).toBe(true);
+    expect(s.usdMax).toBeCloseTo(usdA(FALLBACK_PRICE_1K), 6);
+    expect(formattaStima(s)).toBe('~$0,60?');
+  });
+
+  it('un prezzo che cambia in config cambia la stima, senza toccare il codice', () => {
+    seminaConfig({ deepl: { per1kUsd: 0.04 } });
+    expect(stimaCostoPreset(preset(['deepl'])).usdMax).toBeCloseTo(usdA(0.04), 6);
+  });
+
+  it('la catena costruita a runtime non si preventiva', () => {
+    const s = stimaCostoPreset(trova('auto'));
+    expect(s.variabile).toBe(true);
+    expect(formattaStima(s)).toBe('—');
+  });
+
+  it('la stima scala col volume di stringhe', () => {
+    const s = stimaCostoPreset(preset(['deepl']), 1000);
+    expect(s.usdMax).toBeCloseTo(usdA(0.02) / 10, 6);
+  });
+});
+
+describe('formattaStima', () => {
+  it('«fino a» solo quando davanti ci sono dei gratuiti', () => {
+    expect(formattaStima(stimaCostoPreset(preset(['hymt', 'deepl'])))).toBe('fino a $6,0');
+    expect(formattaStima(stimaCostoPreset(preset(['deepl'])))).toBe('~$6,0');
+  });
+
+  it('sotto il centesimo non finge precisione', () => {
+    // Il '~' resta davanti anche qui: è il prefisso di «nessun gratuito prima».
+    expect(formattaStima(stimaCostoPreset(preset(['google']), 10))).toBe('~< $0,01');
+  });
+});
+
+describe('catalogo prezzi — nessun provider entra in silenzio', () => {
+  /**
+   * I provider che restano fuori dal listino di proposito: hanno bisogno di una
+   * API key dell'utente e di un prezzo che nessuno ha ancora verificato. Il
+   * test non chiede che siano prezzati — chiede che l'elenco sia una DECISIONE:
+   * se domani una catena usa un provider nuovo, questo test fallisce e obbliga
+   * a scegliere fra «verifico il listino» e «resta una stima dichiarata».
+   */
+  const SENZA_PREZZO = new Set([
+    'groq', 'groq-gptoss', 'cerebras', 'qwen', 'cohere', 'together', 'fireworks',
+  ]);
+
+  it('ogni provider dei preset è prezzato, o è nell’elenco dei noti-senza-prezzo', () => {
+    const usati = new Set(CHAIN_PRESETS.flatMap((p) => p.providers));
+    const ignoti = [...usati].filter(
+      (p) => BUNDLED_MODEL_CONFIG.pricing[p] === undefined && !SENZA_PREZZO.has(p)
+    );
+    expect(ignoti).toEqual([]);
+  });
+
+  it('i provider locali o senza API key valgono zero, non «assente»', () => {
+    const senzaChiave = ['hymt', 'translategemma', 'ollama', 'lmstudio', 'modelwiz',
+                         'nllb', 'mymemory', 'lingva', 'libretranslate'];
+    for (const p of senzaChiave) {
+      expect(BUNDLED_MODEL_CONFIG.pricing[p]?.per1kUsd).toBe(0);
+    }
+  });
+});

--- a/app/binary-patcher/page.tsx
+++ b/app/binary-patcher/page.tsx
@@ -37,6 +37,7 @@ import {
   hasAvailableProviders,
   type ChainPreset,
 } from '@/lib/ai/ai-translate-direct';
+import { stimaCostoPreset, formattaStima, STRINGHE_RIFERIMENTO } from '@/lib/translation/chain-cost';
 import { addCorrection } from '@/lib/ai/adaptive-mt';
 import { clientLogger } from '@/lib/client-logger';
 import { useDefaultTargetLang } from '@/lib/translation/use-default-target-lang';
@@ -665,6 +666,21 @@ export default function BinaryPatcherPage() {
 
   const stats = useMemo(() => project ? getProjectStats(project) : null, [project]);
 
+  /**
+   * ⛔ 24/08/2026: qui accanto a ogni preset si mostrava `preset.cost`, la
+   * stringa scritta a mano mesi fa («~$0.10», «~$1.00+»). Il picker nuovo
+   * (components/translation/chain-preset-picker.tsx) era stato costruito il
+   * 18/08 apposta per non mostrarla più — ma questa pagina, che è l'altro
+   * punto vivo da cui si sceglie un preset, ha continuato a mostrarla per una
+   * settimana. Stessa fonte per tutti e due, adesso: chain-cost.ts sui prezzi
+   * veri di remote-config. Il campo `cost` non lo legge più nessuno ed è stato
+   * tolto da ChainPresetInfo.
+   */
+  const stimePreset = useMemo(
+    () => new Map(CHAIN_PRESETS.map((p) => [p.id, formattaStima(stimaCostoPreset(p))])),
+    []
+  );
+
   // ============================================================
   // Render
   // ============================================================
@@ -983,7 +999,7 @@ export default function BinaryPatcherPage() {
                         <div className="flex-1">
                           <div className="flex items-center gap-2">
                             <span className="text-xs font-medium text-white">{preset.name}</span>
-                            <span className="text-2xs text-white/30">{preset.cost}</span>
+                            <span className="text-2xs text-white/30">{stimePreset.get(preset.id)}</span>
                             <span className="text-2xs text-white/30">{preset.quality}</span>
                           </div>
                           <p className="text-2xs text-white/40">{preset.description}</p>
@@ -992,6 +1008,9 @@ export default function BinaryPatcherPage() {
                       </div>
                     ))}
                   </div>
+                  <p className="text-2xs leading-snug text-white/30">
+                    {t('chainPreset.disclaimer').replace('{n}', STRINGHE_RIFERIMENTO.toLocaleString())}
+                  </p>
                 </div>
               )}
             </div>

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -120,6 +120,66 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     openrouter: { per1kUsd: 0.001, note: 'Varia per modello' },
     deepl: { per1kUsd: 0.02, note: 'DeepL Pro' },
     google: { per1kUsd: 0.00002, note: 'Google Translate' },
+
+    // ── Le chiavi che le CATENE usano davvero — 24/08/2026 ──────────────────
+    //
+    // ⛔ PERCHÉ ESISTONO: fino a oggi questa tabella era indicizzata con i nomi
+    // dei vendor (`claude`, `gemini`), mentre le catene di chain-presets.ts e il
+    // dispatch di PROVIDER_MAP (ai-translate-direct.ts:1680) usano le chiavi dei
+    // provider (`anthropic-premium`, `hymt`, `gemini-3.1`…). Nomi diversi per la
+    // stessa cosa = nessuna corrispondenza, e getProviderPrice1k rispondeva a
+    // TUTTI con il fallback 0.002. Misurato prima della correzione, su 10.000
+    // stringhe: il preset «🆓 Gratis», che parte da HY-MT locale, era
+    // preventivato $0,60 — un modello che gira sul PC dell'utente, fatturato
+    // come il secondo prezzo più alto del listino.
+    // Le chiavi qui sotto si AGGIUNGONO, non rinominano niente: rinominarle
+    // dall'altra parte romperebbe il dispatch delle traduzioni.
+
+    // Locali o senza API key: costo ZERO per costruzione, che è un fatto, non
+    // una stima — non c'è nessuna fattura da sbagliare. Verificato il
+    // 24/08/2026 leggendo PROVIDER_MAP (`needsKey: false`) e gli endpoint:
+    // Ollama in locale (hymt, translategemma, ollama), localhost:1234
+    // (lmstudio), localhost:8080 (modelwiz), API pubbliche interrogate senza
+    // chiave (mymemory, lingva, nllb via HuggingFace, libretranslate).
+    // Sono anche la ragione per cui `gratuitiPrima` esiste in chain-cost.ts:
+    // senza queste voci quel contatore restava a zero per sempre.
+    hymt: { per1kUsd: 0, note: 'HY-MT su Ollama locale · nessuna API key · verificato in PROVIDER_MAP 24/08/2026' },
+    translategemma: { per1kUsd: 0, note: 'TranslateGemma su Ollama locale · nessuna API key · verificato in PROVIDER_MAP 24/08/2026' },
+    ollama: { per1kUsd: 0, note: 'Ollama locale · nessuna API key · verificato in PROVIDER_MAP 24/08/2026' },
+    lmstudio: { per1kUsd: 0, note: 'LM Studio su localhost:1234 · nessuna API key · verificato in PROVIDER_MAP 24/08/2026' },
+    modelwiz: { per1kUsd: 0, note: 'Alocai ModelWiz su localhost:8080 · nessuna API key · verificato in PROVIDER_MAP 24/08/2026' },
+    nllb: { per1kUsd: 0, note: 'NLLB-200 via HuggingFace Inference, chiamata anonima · verificato in PROVIDER_MAP 24/08/2026' },
+    mymemory: { per1kUsd: 0, note: 'MyMemory API pubblica, nessuna chiave · verificato in PROVIDER_MAP 24/08/2026' },
+    lingva: { per1kUsd: 0, note: 'Lingva istanza pubblica, nessuna chiave · verificato in PROVIDER_MAP 24/08/2026' },
+    libretranslate: { per1kUsd: 0, note: 'LibreTranslate self-hosted o istanza pubblica · nessuna chiave · verificato in PROVIDER_MAP 24/08/2026' },
+
+    // Claude, con le tre chiavi che le catene usano davvero. Le cifre e la data
+    // sono quelle della voce `claude` qui sopra (verificata il 23/08/2026):
+    // `anthropic` e `anthropic-claude4` chiamano entrambe translateWithAnthropic
+    // → claude-sonnet-4-6, $3/1M; `anthropic-premium` chiama
+    // translateWithAnthropicPremium → claude-opus-5, $5/1M
+    // (ai-translate-direct.ts:400 e :408). Prima di oggi pagavano tutte e tre il
+    // fallback 0.002: il preset «👑 Massima Qualità», che parte proprio da
+    // Opus 5, era preventivato a 2,5 volte meno del vero. Questo è il verso
+    // sbagliato dell'errore — una fattura più alta del preventivo.
+    anthropic: { per1kUsd: 0.003, note: 'Claude Sonnet 4.6 ($3/1M input) · stessa cifra e stessa verifica della voce `claude` (23/08/2026)' },
+    'anthropic-claude4': { per1kUsd: 0.003, note: 'Claude Sonnet 4.6 ($3/1M input) · stessa fn di `anthropic` · verificato 23/08/2026' },
+    'anthropic-premium': { per1kUsd: 0.005, note: 'Claude Opus 5 ($5/1M input) · variante premium di ai-translate-direct.ts:408 · verificato 23/08/2026' },
+
+    // Varianti dello stesso vendor, stessa API key, nessun listino separato in
+    // questa tabella: prendono il prezzo della voce base come TETTO. Gemini 3.1
+    // Flash-Lite costa meno di 3.7 Flash, quindi qui la stima sbaglia per
+    // eccesso — il verso giusto, lo stesso della nota `deepseek`.
+    'gemini-3.1': { per1kUsd: 0.0015, note: 'Gemini 3.1 Flash-Lite · tetto: prezzo della voce `gemini` (23/08/2026), il Lite costa meno' },
+    'deepl-voice': { per1kUsd: 0.02, note: 'DeepL Voice · tetto: prezzo della voce `deepl`, nessun listino separato verificato' },
+
+    // ⚠️ RESTANO SENZA PREZZO, di proposito: groq, groq-gptoss, cerebras, qwen,
+    // cohere, together, fireworks, azure. Hanno tutti bisogno di una API key
+    // dell'utente e di un listino che nessuno ha ancora verificato: inventarne
+    // uno qui sarebbe esattamente il difetto che questo blocco corregge.
+    // Finché mancano, chain-cost.ts li stima con il fallback e lo DICHIARA
+    // (StimaCosto.prezzoIgnoto, '?' accanto alla cifra). Chi verifica un
+    // listino, aggiunga la voce qui con data e fonte e il '?' sparisce da solo.
   },
   models: {
     openai: [
@@ -231,9 +291,36 @@ export function mergeModelConfig(
   };
 }
 
+/**
+ * Prezzo di ripiego per un provider che il catalogo non conosce. È una CIFRA
+ * INVENTATA, ereditata dallo storico: sta qui, con un nome, perché chi la usa
+ * possa dire di starla usando (vedi getProviderPrice1kOrNull).
+ */
+export const FALLBACK_PRICE_1K = 0.002;
+
+/**
+ * Prezzo per 1K token del provider, `null` se il provider NON è in catalogo.
+ *
+ * ⛔ PERCHÉ ESISTE (24/08/2026): `getProviderPrice1k` risponde comunque, con
+ * FALLBACK_PRICE_1K, e va benissimo per estimateBatchCost — lì il provider è
+ * uno solo, scelto dall'utente, e una stima prudente è meglio di nessuna. Ma
+ * chi ragiona su una CATENA deve distinguere tre casi, non due: gratis (0),
+ * a pagamento (>0) e ignoto (null). chain-cost.ts li confondeva, e trattava
+ * «assente dal catalogo» come «gratuito»: siccome nessuna voce valeva 0, quel
+ * ramo non scattava mai e i provider locali finivano fatturati a 0.002.
+ *
+ * Nota: 0 è un prezzo LEGITTIMO, non un'assenza — validateModelConfig accetta
+ * `per1kUsd >= 0` apposta, così una config remota può dichiarare gratuito un
+ * provider. Per questo il controllo è sul tipo e non sulla verità del valore.
+ */
+export function getProviderPrice1kOrNull(config: RemoteModelConfig, provider: string): number | null {
+  const p = config.pricing[provider]?.per1kUsd;
+  return typeof p === 'number' ? p : null;
+}
+
 /** Prezzo per 1K token del provider (fallback: 0.002, come lo storico). */
 export function getProviderPrice1k(config: RemoteModelConfig, provider: string): number {
-  return config.pricing[provider]?.per1kUsd ?? 0.002;
+  return getProviderPrice1kOrNull(config, provider) ?? FALLBACK_PRICE_1K;
 }
 
 /** Catalogo modelli del provider (vuoto se assente). */

--- a/lib/translation/chain-cost.ts
+++ b/lib/translation/chain-cost.ts
@@ -19,14 +19,34 @@
  * ⚠️ COSA RESTA STIMA, e va detto a chi legge:
  *   - la lunghezza media di una riga di gioco (vedi CARATTERI_PER_STRINGA);
  *   - il fatto che una catena non costa «il suo primo provider»: i gratuiti in
- *     testa (HY-MT, Ollama, Groq…) coprono quello che riescono, e si paga solo
- *     quando si arriva al primo a pagamento. Quello è il CASO PEGGIORE, ed è
- *     quello che si riporta, nominando il provider;
+ *     testa (HY-MT, TranslateGemma, Ollama…) coprono quello che riescono, e si
+ *     paga solo quando si arriva al primo a pagamento. Quello è il CASO
+ *     PEGGIORE, ed è quello che si riporta, nominando il provider;
  *   - la Translation Memory abbatte le chiamate reali, e qui non è contata:
  *     il preventivo vero di un gioco lo fa estimateBatchCost sulle sue stringhe.
+ *
+ * ⛔ IL DIFETTO DEL 24/08/2026, perché la riga sopra era una promessa e non un
+ * fatto: «i gratuiti in testa» non venivano contati NEMMENO UNA VOLTA. Il ciclo
+ * chiedeva il prezzo con getProviderPrice1k, che per un provider fuori catalogo
+ * non risponde «non lo so» ma 0.002 — quindi `!(per1k > 0)` era sempre falso,
+ * `gratuitiPrima` sempre 0, e ogni preset veniva preventivato come il suo PRIMO
+ * provider, qualunque cosa fosse. Misurato su 10.000 stringhe, prima e dopo:
+ * OTTO preset su dieci mostravano la stessa identica cifra, ~$0,60 — il picker
+ * sembrava un listino ed era una costante. «🆓 Gratis», che parte da HY-MT sul
+ * PC dell'utente, diceva ~$0,60 (ora: fino a $0,45 dal primo cloud della
+ * catena); «👑 Massima Qualità», che parte da Claude Opus 5, diceva ~$0,60 pure
+ * lei (ora: ~$1,5) — 2,5 volte MENO del vero, l'errore nel verso che manda una
+ * fattura più alta del preventivo.
+ * Corretto in tre pezzi, tutti dalla parte dei dati e nessuno dalla formula:
+ *   1. il catalogo prezzi ha ora le chiavi che le catene usano davvero, con i
+ *      locali/senza-chiave a per1kUsd 0 (lib/remote-config.ts, 24/08/2026);
+ *   2. getProviderPrice1kOrNull distingue «gratis» (0) da «ignoto» (null), che
+ *      è la distinzione che qui serviva e non c'era;
+ *   3. quando il provider resta fuori catalogo la cifra si mostra col '?':
+ *      si stima lo stesso, ma senza spacciare il ripiego per un listino.
  */
 
-import { getModelConfig, getProviderPrice1k } from '@/lib/remote-config';
+import { getModelConfig, getProviderPrice1kOrNull, FALLBACK_PRICE_1K } from '@/lib/remote-config';
 import type { ChainPresetInfo } from './chain-presets';
 
 /**
@@ -57,6 +77,13 @@ export interface StimaCosto {
    * il tetto farebbe sembrare caro un preset che quasi sempre costa meno.
    */
   gratuitiPrima: number;
+  /**
+   * true quando usdMax NON nasce da un prezzo di catalogo ma dal ripiego
+   * FALLBACK_PRICE_1K, perché il provider non è nel listino. Il numero resta —
+   * un ordine di grandezza serve comunque a confrontare i preset — ma va
+   * mostrato come stima e non come misura: formattaStima ci mette un '?'.
+   */
+  prezzoIgnoto: boolean;
 }
 
 export function stimaCostoPreset(
@@ -69,25 +96,32 @@ export function stimaCostoPreset(
   // lingua, genere e provider configurati: qui non c'è niente da preventivare,
   // e fingere un numero sarebbe la bugia peggiore delle tre.
   if (preset.providers.length === 0) {
-    return { gratis: false, variabile: true, provider: null, usdMax: null, gratuitiPrima: 0 };
+    return { gratis: false, variabile: true, provider: null, usdMax: null, gratuitiPrima: 0, prezzoIgnoto: false };
   }
 
   let gratuitiPrima = 0;
   for (const provider of preset.providers) {
-    const per1k = getProviderPrice1k(config, provider);
-    // Nessun prezzo in catalogo = provider gratuito o sconosciuto: non si
-    // inventa una cifra, si conta e si passa al successivo della catena.
-    if (!(per1k > 0)) {
+    const per1k = getProviderPrice1kOrNull(config, provider);
+
+    // Prezzo 0 DICHIARATO in catalogo = provider gratuito (locale o senza API
+    // key): si conta e si passa al successivo della catena. Questo ramo, fino
+    // al 24/08/2026, non scattava mai — nessuna voce del listino valeva 0,
+    // perché i provider locali non erano nel listino affatto.
+    if (per1k === 0) {
       gratuitiPrima += 1;
       continue;
     }
 
     // Stessa aritmetica di estimateBatchCost: caratteri/4 token, ×2 per l'output.
     const token = Math.ceil((stringhe * CARATTERI_PER_STRINGA) / 4) * 2;
-    return { gratis: false, variabile: false, provider, usdMax: (token / 1000) * per1k, gratuitiPrima };
+    // per1k === null = provider fuori catalogo. NON è gratuito: ha una API key
+    // e un listino che qui non conosciamo. Si stima col ripiego e si dichiara.
+    const prezzoIgnoto = per1k === null;
+    const prezzo = per1k ?? FALLBACK_PRICE_1K;
+    return { gratis: false, variabile: false, provider, usdMax: (token / 1000) * prezzo, gratuitiPrima, prezzoIgnoto };
   }
 
-  return { gratis: true, variabile: false, provider: null, usdMax: null, gratuitiPrima };
+  return { gratis: true, variabile: false, provider: null, usdMax: null, gratuitiPrima, prezzoIgnoto: false };
 }
 
 /**
@@ -101,5 +135,9 @@ export function formattaStima(s: StimaCosto): string {
   if (s.gratis || s.usdMax === null) return '$0';
   const cifra =
     s.usdMax < 0.01 ? '< $0,01' : s.usdMax < 1 ? `$${s.usdMax.toFixed(2).replace('.', ',')}` : `$${s.usdMax.toFixed(1).replace('.', ',')}`;
-  return s.gratuitiPrima > 0 ? `fino a ${cifra}` : `~${cifra}`;
+  const base = s.gratuitiPrima > 0 ? `fino a ${cifra}` : `~${cifra}`;
+  // Il '?' non è decorazione: separa le cifre che vengono dal listino da quelle
+  // che vengono dal ripiego. Senza, un preventivo inventato e uno verificato si
+  // presentano all'utente esattamente uguali.
+  return s.prezzoIgnoto ? `${base}?` : base;
 }

--- a/lib/translation/chain-presets.ts
+++ b/lib/translation/chain-presets.ts
@@ -16,11 +16,19 @@ import type { GameGenre } from '../ai/genre-prompts';
 /** Preset di chain selezionabili per costo/qualita */
 export type ChainPreset = 'free' | 'privacy' | 'economy' | 'balanced' | 'quality' | 'max_quality' | 'creative' | 'long_context' | 'voice' | 'auto';
 
+/**
+ * ⛔ QUI NON C'È UN CAMPO `cost`, e non è una dimenticanza (tolto il
+ * 24/08/2026). C'era, ed era una stringa scritta a mano («~$0.10», «~$1.00+»):
+ * invecchiava in silenzio a ogni variazione di listino — il rincaro DeepSeek
+ * del 16/08 le rese false tutte insieme senza che nessuno le toccasse. Il
+ * costo di un preset ora si CALCOLA dai prezzi veri di remote-config:
+ * lib/translation/chain-cost.ts, unica fonte per entrambi i punti che lo
+ * mostrano all'utente (il picker e /binary-patcher).
+ */
 export interface ChainPresetInfo {
   id: ChainPreset;
   name: string;
   description: string;
-  cost: string;
   quality: string;
   speed: string;
   providers: string[];
@@ -31,7 +39,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'free',
     name: '🆓 Gratis',
     description: 'Solo provider gratuiti — HY-MT + TranslateGemma locali, Groq, Cerebras, OpenRouter free',
-    cost: '$0',
     quality: '⭐⭐⭐⭐',
     speed: '🏎 Media',
     providers: ['hymt', 'translategemma', 'ollama', 'lmstudio', 'groq-gptoss', 'groq', 'cerebras', 'openrouter', 'nllb', 'mymemory', 'lingva', 'libretranslate'],
@@ -40,7 +47,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'privacy',
     name: '🔒 Privacy',
     description: 'LibreTranslate self-hosted, Ollama locale, NLLB — nessun dato lascia il tuo PC',
-    cost: '$0',
     quality: '⭐⭐⭐',
     speed: '⚡ Locale',
     providers: ['libretranslate', 'ollama', 'lmstudio', 'hymt', 'translategemma', 'nllb'],
@@ -49,7 +55,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'economy',
     name: '💰 Economica',
     description: 'HY-MT/TranslateGemma locali + Gemini 3.1 Flash-Lite (low-cost long-context) + DeepSeek + fallback',
-    cost: '~$0.10',
     quality: '⭐⭐⭐⭐',
     speed: '🚀 Veloce',
     providers: ['hymt', 'translategemma', 'gemini-3.1', 'gemini', 'groq', 'cerebras', 'deepseek', 'mistral', 'openrouter', 'nllb', 'mymemory', 'lingva'],
@@ -58,7 +63,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'balanced',
     name: '⚖️ Bilanciata',
     description: 'Miglior rapporto qualità/prezzo — HY-MT locale + tutti i provider cloud',
-    cost: '~$0.25',
     quality: '⭐⭐⭐⭐',
     speed: '🚀 Veloce',
     providers: ['hymt', 'translategemma', 'gemini-3.1', 'gemini', 'deepseek', 'deepl', 'modelwiz', 'qwen', 'mistral', 'groq-gptoss', 'groq', 'cerebras', 'together', 'fireworks', 'cohere', 'openrouter', 'openai', 'nllb', 'mymemory', 'lingva'],
@@ -67,7 +71,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'quality',
     name: '✨ Qualità',
     description: 'AI premium — Claude 3.5/4 (creative), OpenAI, Mistral come priorità',
-    cost: '~$0.50',
     quality: '⭐⭐⭐⭐⭐',
     speed: '🚀 Veloce',
     providers: ['deepl', 'modelwiz', 'anthropic-claude4', 'anthropic', 'openai', 'qwen', 'mistral', 'gemini-3.1', 'gemini', 'cohere', 'together', 'deepseek', 'fireworks', 'mymemory'],
@@ -76,7 +79,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'max_quality',
     name: '👑 Massima Qualità',
     description: 'Tutti i provider inclusi Claude Opus 4.8 (premium) e Voice API — mai senza traduzione',
-    cost: '~$1.00+',
     quality: '⭐⭐⭐⭐⭐',
     speed: '🚀 Veloce',
     providers: ['anthropic-premium', 'deepl', 'deepl-voice', 'modelwiz', 'anthropic-claude4', 'anthropic', 'openai', 'qwen', 'translategemma', 'ollama', 'lmstudio', 'mistral', 'gemini-3.1', 'gemini', 'cohere', 'together', 'deepseek', 'fireworks', 'groq-gptoss', 'groq', 'cerebras', 'openrouter', 'hymt', 'nllb', 'mymemory', 'lingva'],
@@ -85,7 +87,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'creative',
     name: '🎭 Creative/Narrative',
     description: 'Claude Opus 4.8 (premium) + Sonnet 4.6 + Gemini 3.5 Flash per traduzioni creative, narrative, sfumature emotive',
-    cost: '~$0.60',
     quality: '⭐⭐⭐⭐⭐',
     speed: '🚀 Adattiva',
     providers: ['anthropic-premium', 'anthropic-claude4', 'anthropic', 'openai', 'gemini-3.1', 'gemini', 'deepl', 'modelwiz'],
@@ -94,7 +95,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'long_context',
     name: '📚 Long Context',
     description: 'Gemini 3.1 Flash-Lite (low-cost) + Gemini 3.5 Flash (65k output) per documenti lunghi, script interi, multi-file',
-    cost: '~$0.30',
     quality: '⭐⭐⭐⭐⭐',
     speed: '🚀 Veloce',
     providers: ['gemini-3.1', 'gemini', 'anthropic-claude4', 'openai', 'deepseek', 'qwen'],
@@ -103,7 +103,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'voice',
     name: '🎤 Voice Translation',
     description: 'DeepL Voice API per traduzione vocale real-time con TTS',
-    cost: '~$0.40',
     quality: '⭐⭐⭐⭐⭐',
     speed: '⚡ Real-time',
     providers: ['deepl-voice', 'deepl', 'gemini-3.1', 'anthropic-claude4', 'openai'],
@@ -112,7 +111,6 @@ export const CHAIN_PRESETS: ChainPresetInfo[] = [
     id: 'auto',
     name: '🧠 Auto-Select',
     description: 'Seleziona automaticamente i migliori provider per lingua target e genere gioco',
-    cost: 'Variabile',
     quality: '⭐⭐⭐⭐⭐',
     speed: '🚀 Adattiva',
     providers: [], // Calcolato dinamicamente da getAutoProviderChain()


### PR DESCRIPTION
The preset picker was showing **one number for eight of the ten presets** — `~$0.60` on 10,000 strings — whether the chain started with a model running on the user's own PC or with Claude Opus 5.

## The defect

`stimaCostoPreset` counts the free providers at the head of a chain and charges only the first paid one. It asked `getProviderPrice1k`, which returns `0.002` for any provider missing from the catalog instead of "I don't know" — so `!(per1k > 0)` was never true, `gratuitiPrima` stayed at 0, and every preset was estimated as its first provider at an invented rate. The catalog was keyed by vendor (`claude`, `gemini`), the chains by dispatch id (`anthropic-premium`, `hymt`, `gemini-3.1`): almost nothing matched.

Measured by running the code, before and after, on 10,000 strings:

| preset | before | after |
|---|---|---|
| free | ~$0.60 (hymt) | up to $0.60**?** (groq-gptoss, 4 free first) |
| privacy | ~$0.60 (libretranslate) | **$0** |
| economy / balanced | ~$0.60 (hymt) | up to $0.45 (gemini-3.1) |
| max_quality / creative | ~$0.60 (anthropic-premium) | ~$1.50 (Opus 5 — 2.5x the old figure) |
| long_context | ~$0.60 | ~$0.45 |
| voice | ~$0.60 | ~$6.00 (deepl-voice) |
| quality | ~$6.00 | unchanged |

The `max_quality` row is the one that mattered: the estimate was 2.5x **below** the truth, the direction that sends a bill higher than the quote.

## The fix, on the data side

1. The bundled catalog carries the keys the chains actually use: nine local/keyless providers at `per1kUsd: 0` (a fact, not an estimate — no API key, Ollama or localhost or a free public endpoint), the three Claude keys at figures already verified on 2026-08-23, and `gemini-3.1` / `deepl-voice` at their base entry's price as a ceiling. Every row dated, with where it came from.
2. `getProviderPrice1kOrNull` tells *free* (0) from *unknown* (null) — the distinction chain-cost needed and did not have. `getProviderPrice1k` is unchanged, so `estimateBatchCost` keeps its behaviour.
3. A provider still outside the catalog is estimated from the fallback and **says so**: `prezzoIgnoto`, rendered as a `?` after the figure.

`groq`, `groq-gptoss`, `cerebras`, `qwen`, `cohere`, `together`, `fireworks` stay unpriced on purpose — inventing a list price is the defect this PR removes. A test fails if a chain starts using a provider that is neither priced nor knowingly unpriced.

## Second picker

`/binary-patcher` was still rendering the hand-written `cost` strings (`'~$0.10'`, `'~$1.00+'`) that the 08-18 picker was built to stop showing. It now reads the same computed estimate, so the field has no readers left and is gone from `ChainPresetInfo`.

## Verification

- 14 new tests for `chain-cost.ts` (it had none) + 2 for the new getter
- full suite: 935 passed, 0 failed · `typecheck`, `eslint`, `i18n:check` clean
- the before/after table above was produced by running the code, not by reading it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
