### PR TITLE
Price the last seven providers, so no preset is quoted at the fallback

### DIFF
--- a/__tests__/lib/translation/chain-cost.test.ts
+++ b/__tests__/lib/translation/chain-cost.test.ts
@@ -114,7 +114,12 @@ describe('stimaCostoPreset — prezzi presi dal catalogo, non inventati', () => 
   });
 
   it('un provider fuori catalogo si stima col ripiego e lo dichiara', () => {
-    const s = stimaCostoPreset(preset(['groq']));
+    // ⚠️ L'id è finto di proposito. Qui prima c'era 'groq', che il 24/08/2026 è
+    // entrato in listino: il test misurava il meccanismo usando come campione un
+    // buco destinato a chiudersi, e infatti si è chiuso. Un id inventato lega
+    // questo test a ciò che verifica — il ripiego dichiarato — e non allo stato
+    // del catalogo, che è esattamente la cosa che deve poter cambiare.
+    const s = stimaCostoPreset(preset(['provider-che-non-esiste']));
     expect(s.prezzoIgnoto).toBe(true);
     expect(s.usdMax).toBeCloseTo(usdA(FALLBACK_PRICE_1K), 6);
     expect(formattaStima(s)).toBe('~$0,60?');
@@ -156,10 +161,17 @@ describe('catalogo prezzi — nessun provider entra in silenzio', () => {
    * test non chiede che siano prezzati — chiede che l'elenco sia una DECISIONE:
    * se domani una catena usa un provider nuovo, questo test fallisce e obbliga
    * a scegliere fra «verifico il listino» e «resta una stima dichiarata».
+   *
+   * ⭐ 24/08/2026: È VUOTO, e vuoto è il punto d'arrivo, non un test disattivato.
+   * Ci stavano groq, groq-gptoss, cerebras, qwen, cohere, together e fireworks;
+   * sono stati verificati sul listino dei rispettivi vendor e sono entrati in
+   * BUNDLED_MODEL_CONFIG.pricing, quindi nessuna catena passa più dal fallback
+   * e nessun preset mostra il '?'. Con l'insieme vuoto il test diventa la
+   * regola più stretta che possa esprimere: OGNI provider di OGNI preset ha un
+   * prezzo. Il primo che ne aggiunge uno senza listino lo fa fallire, e deve
+   * scrivere qui il nome per dichiararlo — che è esattamente ciò che serve.
    */
-  const SENZA_PREZZO = new Set([
-    'groq', 'groq-gptoss', 'cerebras', 'qwen', 'cohere', 'together', 'fireworks',
-  ]);
+  const SENZA_PREZZO = new Set<string>([]);
 
   it('ogni provider dei preset è prezzato, o è nell’elenco dei noti-senza-prezzo', () => {
     const usati = new Set(CHAIN_PRESETS.flatMap((p) => p.providers));
@@ -167,6 +179,22 @@ describe('catalogo prezzi — nessun provider entra in silenzio', () => {
       (p) => BUNDLED_MODEL_CONFIG.pricing[p] === undefined && !SENZA_PREZZO.has(p)
     );
     expect(ignoti).toEqual([]);
+  });
+
+  it('i sette dietro API key hanno un listino, non il ripiego', () => {
+    // Erano l'ultimo gruppo a passare dal fallback, ed erano il motivo per cui
+    // SENZA_PREZZO esisteva. Zero non andrebbe bene come non andrebbe bene 0.002:
+    // hanno un free tier, ma questa tabella stima il caso peggiore, cioè il
+    // listino che si paga quando il free tier finisce.
+    for (const p of ['groq', 'groq-gptoss', 'cerebras', 'qwen', 'cohere', 'together', 'fireworks']) {
+      const voce = BUNDLED_MODEL_CONFIG.pricing[p];
+      expect(voce, `${p} deve stare in catalogo`).toBeDefined();
+      expect(voce.per1kUsd).toBeGreaterThan(0);
+      expect(voce.per1kUsd).not.toBe(FALLBACK_PRICE_1K);
+      // La nota vale quanto la cifra: dice a quale modello si riferisce e quando
+      // è stata guardata. Una voce senza data è un listino vecchio travestito.
+      expect(voce.note).toMatch(/verificato \d{2}\/\d{2}\/\d{4}/);
+    }
   });
 
   it('i provider locali o senza API key valgono zero, non «assente»', () => {

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -166,20 +166,56 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     'anthropic-claude4': { per1kUsd: 0.003, note: 'Claude Sonnet 4.6 ($3/1M input) · stessa fn di `anthropic` · verificato 23/08/2026' },
     'anthropic-premium': { per1kUsd: 0.005, note: 'Claude Opus 5 ($5/1M input) · variante premium di ai-translate-direct.ts:408 · verificato 23/08/2026' },
 
-    // Varianti dello stesso vendor, stessa API key, nessun listino separato in
-    // questa tabella: prendono il prezzo della voce base come TETTO. Gemini 3.1
-    // Flash-Lite costa meno di 3.7 Flash, quindi qui la stima sbaglia per
-    // eccesso — il verso giusto, lo stesso della nota `deepseek`.
-    'gemini-3.1': { per1kUsd: 0.0015, note: 'Gemini 3.1 Flash-Lite · tetto: prezzo della voce `gemini` (23/08/2026), il Lite costa meno' },
+    // ⏰ Gemini 3.1 Flash-Lite — VERIFICATO IL 24/08/2026 su ai.google.dev.
+    // Aveva un TETTO prudenziale, il prezzo della voce `gemini`, con scritto
+    // accanto «il Lite costa meno». Costa meno di 6×: $0.25/1M contro $1.50.
+    // Il tetto era onesto e faceva il suo lavoro; il listino è meglio, perché
+    // `gemini-3.1` apre le catene `economy`, `balanced` e `long_context` — è il
+    // primo provider a pagamento di tre preset su nove, quindi è la sua cifra a
+    // diventare il loro preventivo. Nessuna fascia per lunghezza di contesto,
+    // a differenza del 3.1 Pro.
+    'gemini-3.1': { per1kUsd: 0.00025, note: 'Gemini 3.1 Flash-Lite ($0.25/1M input, nessuna fascia) · ai.google.dev · verificato 24/08/2026' },
+
+    // Variante dello stesso vendor, stessa API key, nessun listino separato:
+    // prende il prezzo della voce base come TETTO. DeepL non pubblica una
+    // tariffa per la traduzione vocale real-time — né a minuto né a carattere
+    // (ricontrollato il 24/08/2026 su deepl.com/pro-api e sulla pagina
+    // prodotto), e da luglio 2026 API Free/Pro non sono più acquistabili.
+    // Finché è così, il tetto dichiarato nella nota resta la scelta migliore
+    // disponibile: il preset `voice` comincia proprio da qui.
     'deepl-voice': { per1kUsd: 0.02, note: 'DeepL Voice · tetto: prezzo della voce `deepl`, nessun listino separato verificato' },
 
-    // ⚠️ RESTANO SENZA PREZZO, di proposito: groq, groq-gptoss, cerebras, qwen,
-    // cohere, together, fireworks, azure. Hanno tutti bisogno di una API key
-    // dell'utente e di un listino che nessuno ha ancora verificato: inventarne
-    // uno qui sarebbe esattamente il difetto che questo blocco corregge.
-    // Finché mancano, chain-cost.ts li stima con il fallback e lo DICHIARA
-    // (StimaCosto.prezzoIgnoto, '?' accanto alla cifra). Chi verifica un
-    // listino, aggiunga la voce qui con data e fonte e il '?' sparisce da solo.
+    // ⏰ I SETTE CHE RESTAVANO — VERIFICATI IL 24/08/2026, uno per uno, sul
+    // listino del vendor. Erano l'ultimo gruppo a prendere il fallback: tutti
+    // dietro una API key dell'utente, tutti con un free tier vero — ed è proprio
+    // il free tier ad averli tenuti fuori dal listino così a lungo, perché chi
+    // non paga non guarda il prezzo. Qui sotto sta quello che si paga quando il
+    // free tier finisce: il caso peggiore, che è ciò che questa tabella stima.
+    // Il modello di ogni voce è quello che PROVIDER_MAP chiama davvero
+    // (ai-translate-direct.ts), non il modello di punta del venditore.
+    groq: { per1kUsd: 0.00059, note: 'Llama 3.3 70B Versatile ($0.59/1M input), il modello che il codice chiama · verificato 24/08/2026' },
+    'groq-gptoss': { per1kUsd: 0.00015, note: 'GPT-OSS 120B su Groq ($0.15/1M input) · console.groq.com/docs/models · verificato 24/08/2026' },
+    cerebras: { per1kUsd: 0.00085, note: 'Llama 3.3 70B su Cerebras ($0.85/1M input) · verificato 24/08/2026 · free tier 1M token/giorno' },
+    // Qwen — attenzione all'endpoint: il codice chiama dashscope.aliyuncs.com,
+    // cioè la regione Cina, dove qwen-plus costa $0.115/1M fino a 128K. Qui sta
+    // il listino della regione internazionale (Singapore), $0.40/1M fino a 256K:
+    // è più caro, e una stima deve sbagliare per eccesso. La fascia oltre i 256K
+    // ($1.20/1M) non è raggiungibile dai batch con max_tokens 8192 di questo codice.
+    qwen: { per1kUsd: 0.0004, note: 'Qwen-Plus, listino Singapore ($0.40/1M input fino a 256K) · verificato 24/08/2026 · Pechino $0.115/1M' },
+    // Cohere — il più caro dei sette, e di parecchio: $2.50/1M, ~4× cerebras.
+    // Nelle catene sta dopo provider molto più economici, ma se quelli cadono
+    // è lui a fare il conto.
+    cohere: { per1kUsd: 0.0025, note: 'Command R+ 08-2024 ($2.50/1M input) · cohere.com/pricing · verificato 24/08/2026' },
+    // Together — la sua pagina modello dice $1.04/1M, gli aggregatori $0.88.
+    // Vince la più cara, che qui è anche quella ufficiale.
+    together: { per1kUsd: 0.00104, note: 'Llama 3.3 70B Instruct Turbo ($1.04/1M input, pagina ufficiale) · verificato 24/08/2026' },
+    // Fireworks non ha una riga per llama-v3p3-70b-instruct: prezza per taglia,
+    // e sopra i 16B di parametri sono $0.90/1M, uguali in input e output.
+    fireworks: { per1kUsd: 0.0009, note: 'Llama 3.3 70B su Fireworks, fascia >16B param ($0.90/1M) · docs.fireworks.ai · verificato 24/08/2026' },
+
+    // ⚠️ Resta senza prezzo `azure`, che però nessuna catena usa oggi: non entra
+    // in nessun preventivo e non produce nessun '?'. Chi ne verifica il listino
+    // aggiunga la voce qui con data e fonte, nella stessa forma di queste.
   },
   models: {
     openai: [


### PR DESCRIPTION
Follow-up to #164, which taught the estimate to say "I don't know": a provider missing from the catalog stops the chain and its figure carries a `?`. It left seven ids in `SENZA_PREZZO`. This looks them up.

All seven sit behind a user's API key and all seven have a real free tier — which is why they are in the chains, and also why nobody had checked the price. You don't read a bill you aren't paying.

## The seven

Verified 24/08/2026 on each vendor's own list, using the model `PROVIDER_MAP` **actually calls** rather than the vendor's flagship:

| provider id | model called | input $/1M | `per1kUsd` |
|---|---|---|---|
| `groq` | `llama-3.3-70b-versatile` | 0.59 | `0.00059` |
| `groq-gptoss` | `openai/gpt-oss-120b` | 0.15 | `0.00015` |
| `cerebras` | `llama-3.3-70b` | 0.85 | `0.00085` |
| `qwen` | `qwen-plus` | 0.40 | `0.0004` |
| `cohere` | `command-r-plus-08-2024` | 2.50 | `0.0025` |
| `together` | `Llama-3.3-70B-Instruct-Turbo` | 1.04 | `0.00104` |
| `fireworks` | `llama-v3p3-70b-instruct` | 0.90 | `0.0009` |

Where sources disagreed the dearer one won — the same rule the `deepseek` note already follows:

- **together** — its own model page says $1.04 while aggregators still say $0.88.
- **qwen** — carries the Singapore list price, not the Beijing one its endpoint actually hits. $0.40 overstates $0.115, and the >256K tier at $1.20 is unreachable from batches capped at `max_tokens: 8192`.
- **fireworks** — publishes no line for that model at all. It prices by size, and >16B parameters is $0.90, input and output alike.

## `gemini-3.1`: from ceiling to list price

It carried the `gemini` figure with *"il Lite costa meno"* written beside it. It costs less by more than 6×: **$0.25/1M against $1.50**.

The ceiling was honest and did its job, but `gemini-3.1` opens `economy`, `balanced` and `long_context` — it is the first paid provider of three presets out of nine, so its figure *is* their quote.

## Measured, 10,000 strings

| preset | on main | here |
|---|---|---|
| free | `~$0,60?` | **`fino a $0,04`** |
| economy / balanced | `fino a $0,45` | **`fino a $0,07`** |
| long_context | `~$0,45` | **`~$0,07`** |

No preset shows a `?` any more.

## `SENZA_PREZZO` is now empty

Empty is the destination, not a disabled test. With no exemptions the rule reads *every provider of every preset has a price*, and the first one added without a list price fails it and has to be declared by name.

Two test repairs follow:

- The unpriced-provider case used `preset(['groq'])` — it was measuring the mechanism with a hole that was always going to be filled. It now uses an invented id, so it is tied to the fallback it verifies rather than to the state of the catalog.
- A new case asserts the seven are priced above zero, are not sitting on `FALLBACK_PRICE_1K` by coincidence, and carry a dated note. A figure without a date is an old list in disguise.

## Left alone on purpose

- **`deepl-voice`** keeps the ceiling #164 gave it. DeepL still publishes no rate for real-time voice, per minute or per character — rechecked 24/08/2026 on `deepl.com/pro-api` and the product page — and since July 2026 API Free/Pro cannot be bought at all.
- **`azure`** stays unpriced, but no chain uses it, so it produces no quote and no `?`.
- **`openrouter`** is priced at `0.001` while the code calls a model whose id ends in `:free`. Same defect as the seven above, invisible to the guard because the key exists. Worth its own change.
- **`quality` (~$6,0) costs more than `max_quality` (~$1,5)**, because DeepL at $5.49/1M characters is roughly $22/1M tokens — four times Opus 5. The hardcoded `cost` labels claim the opposite. Which one is wrong is a product decision, not a pricing fix.

## Verification

- `npx vitest run __tests__/lib/remote-config.test.ts __tests__/lib/translation/` → **76 passed**
- `npx tsc --noEmit` clean on the touched files, `eslint` clean
- `npm run i18n:check` → `802 = baseline`

> Rebased onto main after #164 landed. The branch originally carried an independent implementation of the same `prezzoIgnoto` mechanism, written from a base predating that merge; it was dropped in favour of #164's, and only the genuinely additive part kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
