### PR TITLE
Wire the last silent engine into the compatibility database

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -224,9 +224,22 @@
 
 ## Se dovessi scegliere solo tre cose
 
-1. **Database di compatibilità automatico** (P0)
-2. **Discord** (P1 community)
-3. **Font auto-patching** (P1 qualità)
-
 Le prime due creano il volano community-dati che nessun tool amatoriale può
 replicare; la terza elimina il fallimento più visibile per l'utente finale.
+
+1. ~~**Database di compatibilità automatico** (P0)~~ — FATTO 13/07/2026 (vedi P0
+   sopra). Completato il 24/08/2026 anche l'ultimo motore che non segnalava:
+   il ramo Visionaire Studio apriva la sua operazione di progresso a mano e
+   saltava `startHeroTracking`, quindi ogni sua run restava fuori dai dati.
+   Ora passa dal tracker come gli altri cinque, e
+   `__tests__/lib/compat-telemetry-coverage.test.ts` impedisce che un motore
+   nuovo torni a essere muto.
+2. **Discord** (P1 community) — l'unica delle tre ancora aperta (riga 167).
+3. ~~**Font auto-patching** (P1 qualità)~~ — v1 FATTA 13/07/2026 (riga 109).
+
+⚠️ Questo blocco è rimasto invariato dal 13/07 al 24/08/2026 mentre due delle
+tre voci venivano completate e spuntate PIÙ SOPRA, nello stesso file. Chi lo
+leggeva vedeva tre P0/P1 aperti che aperti non erano — ed è stato letto, e ha
+mandato qualcuno a rifare una cosa fatta. Un riassunto che non si aggiorna
+insieme a ciò che riassume è peggio di nessun riassunto: va spuntato QUI ogni
+volta che si spunta una voce sopra.

--- a/__tests__/lib/compat-telemetry-coverage.test.ts
+++ b/__tests__/lib/compat-telemetry-coverage.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Guardia sulla copertura del database di compatibilità.
+ *
+ * ⛔ IL DIFETTO CHE LA MOTIVA (24/08/2026). La telemetria di compatibilità è
+ * completa dal 13/07/2026: sender con coda offline, opt-in, anti-abuso lato
+ * server, badge, pagina pubblica. Ma un motore non ci arrivava. Il ramo
+ * Visionaire Studio di `startAutoTranslate` si apriva l'operazione di progresso
+ * a mano con `progress.startOperation`, con guardia anti-duplicato e badge tray
+ * propri, invece di passare da `startHeroTracking`. Tutto funzionava — tranne
+ * l'unica cosa che solo il tracker fa: `reportCompatStep`. Ogni traduzione
+ * Visionaire finiva fuori dai dati, e il «funziona nell'N% delle run» di quel
+ * motore sarebbe rimasto per sempre su zero run.
+ *
+ * Il punto è che non se ne accorgeva nessuno: il ramo non era rotto, era muto.
+ * Un motore aggiunto domani, copiando quel ramo, sarebbe stato muto uguale.
+ *
+ * REGOLA. Nessun file di `app/` o `components/` apre un'operazione di progresso
+ * da sé: i job di traduzione passano da `startHeroTracking`, che è il posto in
+ * cui la run viene raccontata al database. L'unica eccezione è il provider che
+ * quell'API la implementa.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const RADICE = join(__dirname, '..', '..');
+
+/**
+ * Chi può chiamare `startOperation`: solo l'implementazione dell'API.
+ * ⚠️ Aggiungere una voce qui è quasi sempre la risposta sbagliata. Se un motore
+ * nuovo ha bisogno di un'operazione di progresso, ha bisogno del tracker: da lì
+ * ottiene gratis guardia anti-duplicato, badge tray, pagina Progetti, advisor di
+ * ritmo E il report di compatibilità. A mano si riottiene tutto tranne l'ultimo,
+ * che è esattamente quello che non si vede mancare.
+ */
+const PUO_APRIRE_OPERAZIONI = ['components/progress/progress-provider.tsx'];
+
+function sorgenti(dir: string): string[] {
+  const out: string[] = [];
+  for (const voce of readdirSync(dir)) {
+    if (voce === 'node_modules' || voce.startsWith('.')) continue;
+    const p = join(dir, voce);
+    if (statSync(p).isDirectory()) out.push(...sorgenti(p));
+    else if (/\.tsx?$/.test(voce)) out.push(p);
+  }
+  return out;
+}
+
+describe('database di compatibilità — nessun motore resta muto', () => {
+  it('nessuna pagina o componente apre unoperazione di progresso da sé', () => {
+    const colpevoli: string[] = [];
+    for (const dir of ['app', 'components']) {
+      for (const file of sorgenti(join(RADICE, dir))) {
+        const rel = relative(RADICE, file).split(sep).join('/');
+        if (PUO_APRIRE_OPERAZIONI.includes(rel)) continue;
+        // `.startOperation(` con un punto davanti: la chiamata sull'oggetto
+        // progress. Le menzioni nei commenti non hanno la parentesi.
+        if (/\.startOperation\(/.test(readFileSync(file, 'utf8'))) colpevoli.push(rel);
+      }
+    }
+
+    expect(colpevoli).toEqual([]);
+  });
+});
+
+// ── Semantica dello stop utente ─────────────────────────────────────────────
+
+const reportCompatStep = vi.fn();
+const setPendingBootCheck = vi.fn();
+const maybeOfferCompatOptIn = vi.fn(() => false);
+
+vi.mock('@/lib/compat-telemetry', () => ({
+  reportCompatStep: (...a: unknown[]) => reportCompatStep(...a),
+  newCompatRunId: () => 'run-test',
+  compatGameKey: (_id: string | undefined, name: string) => `g:${name}`,
+  setPendingBootCheck: (...a: unknown[]) => setPendingBootCheck(...a),
+  classifyCompatError: () => 'unknown',
+  maybeOfferCompatOptIn: (...a: unknown[]) => maybeOfferCompatOptIn(...a),
+}));
+vi.mock('@/lib/services/translation-projects', () => ({
+  projectService: {
+    createOrGetProject: vi.fn(async () => ({ id: 'p1' })),
+    getAllProjects: vi.fn(async () => []),
+    saveProject: vi.fn(async () => {}),
+    updateProgress: vi.fn(async () => {}),
+  },
+}));
+vi.mock('@/lib/crash-reporter', () => ({ reportCrash: vi.fn() }));
+vi.mock('@/lib/feedback-invite', () => ({ maybeInviteFeedbackAfterRun: vi.fn() }));
+vi.mock('@/lib/i18n/t-static', () => ({ tStatic: (k: string) => k }));
+vi.mock('@/lib/notifications/tray-notifications', () => ({
+  incrementActiveTranslations: vi.fn(async () => {}),
+  decrementActiveTranslations: vi.fn(async () => {}),
+  notifyTranslationCompleted: vi.fn(async () => {}),
+  notifyTranslationFailed: vi.fn(async () => {}),
+}));
+
+import { startHeroTracking } from '@/lib/hero-job-tracking';
+import type { ProgressState } from '@/lib/types/progress';
+
+const progressFinto = () => ({
+  startOperation: vi.fn(),
+  updateProgress: vi.fn(),
+  completeOperation: vi.fn(),
+  failOperation: vi.fn(),
+}) as unknown as ProgressState;
+
+/** Un gioco diverso per test: la guardia anti-duplicato è globale al processo. */
+let n = 0;
+const avvia = (progress: ProgressState) =>
+  startHeroTracking(progress, {
+    engineId: 'visionaire', engineLabel: 'Visionaire Studio',
+    gamePath: `C:/giochi/test-${n++}`, gameName: 'Test', targetLang: 'it',
+  })!;
+
+describe('stop dellutente — non è né successo né errore', () => {
+  beforeEach(() => {
+    reportCompatStep.mockClear();
+    setPendingBootCheck.mockClear();
+    maybeOfferCompatOptIn.mockClear();
+  });
+
+  it('una run annullata non finisce nel database di compatibilità', async () => {
+    // ⭐ Il cuore della cosa: chi annulla ha cambiato idea, non ha trovato un
+    // gioco incompatibile. Contarlo come 'partial' abbasserebbe la percentuale
+    // di un motore per un motivo che col motore non c'entra.
+    const progress = progressFinto();
+    await avvia(progress).stopped(120, 400);
+
+    expect(reportCompatStep).not.toHaveBeenCalled();
+    // Nemmeno il boot check o la proposta di opt-in: la run non è arrivata in
+    // fondo, non c'è nessun esito da chiedere all'utente.
+    expect(setPendingBootCheck).not.toHaveBeenCalled();
+    expect(maybeOfferCompatOptIn).not.toHaveBeenCalled();
+    // L'operazione però si chiude, e dichiara PERCHÉ: senza `stopped` il widget
+    // di progresso resterebbe a girare per sempre.
+    expect(progress.completeOperation).toHaveBeenCalledWith(
+      expect.any(String), { translated: 120, total: 400, stopped: true }
+    );
+  });
+
+  it('una run finita invece lo dichiara, con lesito', async () => {
+    await avvia(progressFinto()).done(400, 400);
+
+    expect(reportCompatStep).toHaveBeenCalledTimes(1);
+    expect(reportCompatStep.mock.calls[0][0]).toMatchObject({
+      engine: 'visionaire', step: 'patch', result: 'success',
+    });
+  });
+
+  it('una run fallita lo dichiara come fallimento, sullo step raggiunto', async () => {
+    const tracker = avvia(progressFinto());
+    tracker.setStage('extract');
+    await tracker.fail(new Error('boom'));
+
+    expect(reportCompatStep).toHaveBeenCalledTimes(1);
+    expect(reportCompatStep.mock.calls[0][0]).toMatchObject({
+      engine: 'visionaire', step: 'extract', result: 'failure',
+    });
+  });
+});

--- a/components/game-detail-client.tsx
+++ b/components/game-detail-client.tsx
@@ -2426,19 +2426,8 @@ export default function GameDetailPage() {
       if (engV.includes('visionaire')) {
         const tgt = (targetLang || language || 'it').toLowerCase();
         const t0 = Date.now();
-        // Guardia anti-duplicato GLOBALE (sopravvive a navigazione/smontaggio): se la
-        // traduzione di questo gioco è già in corso in background, non rilanciarla.
-        const _vg = globalThis as unknown as { __gsVisRunning?: Set<string> };
-        if (!_vg.__gsVisRunning) _vg.__gsVisRunning = new Set<string>();
-        const VIS_RUNNING = _vg.__gsVisRunning;
-        if (VIS_RUNNING.has(game.installPath)) {
-          toast.info(t('heroJob.alreadyRunning'));
-          setAutoTranslateBusy(false);
-          autoTranslateRunningRef.current = false;
-          return;
-        }
-        VIS_RUNNING.add(game.installPath);
-        const visOpId = `visionaire-${game.installPath}`;
+        // catturata come const: il narrowing del guard non entra nelle closure
+        const vPath: string = game.installPath;
         // ⛔ PRIMA: «cloud se esiste una API key, altrimenti Ollama» — dedotto,
         //    mai chiesto. Avere una chiave configurata NON vuol dire volerla
         //    spendere su questo gioco, e l'utente non poteva forzare il locale
@@ -2453,33 +2442,41 @@ export default function GameDetailPage() {
         ];
         const vStep = (idx: number, status: 'running' | 'done' | 'error', detail?: string) =>
           setAutoTranslateSteps(prev => prev.map((s, i) => i === idx ? { ...s, status, detail } : i < idx ? { ...s, status: 'done' } : s));
-        setAutoTranslateError(null);
-        setAutoTranslateResult(null);
-        setAutoTranslateSteps([...vSteps]);
-        setAutoTranslateActive(true);
-        // Operazione GLOBALE: gli aggiornamenti vanno al ProgressProvider montato nel
-        // layout, quindi restano visibili e continuano anche cambiando pagina.
-        progress.startOperation(visOpId, {
-          title: t('heroJob.jobTitle').replace('{name}', game.name || game.title || 'Visionaire'),
-          description: t('heroJob.jobDescBg').replace('{engine}', `Visionaire Studio · ${visBackend === 'cloud' ? 'Cloud' : 'Ollama'}`),
-          isBackground: true,
-          canMinimize: true,
+        // ⭐ Tracking trasversale, come ogni altro motore hero. Fino al
+        // 24/08/2026 questo ramo si apriva l'operazione di progresso a mano,
+        // con guardia e badge tray propri — era l'unico `progress.startOperation`
+        // diretto del file. Funzionava, ma saltava l'unica cosa che il tracker
+        // fa e che a mano nessuno rifaceva: il report al database di
+        // compatibilità. Ogni traduzione Visionaire finiva fuori dai dati, e il
+        // «funziona nel N% delle run» di questo motore restava fermo a zero run.
+        // Il tracker era già stato scritto per accoglierlo: `canCancel`/`onCancel`
+        // esistono in HeroTrackMeta proprio per assorbire lo stop di Visionaire
+        // (vedi il commento lì), ma il ramo non era mai stato spostato.
+        const visTracker = startHeroTracking(progress, {
+          engineId: 'visionaire', engineLabel: 'Visionaire Studio', gamePath: vPath,
+          gameId: game.id || game.appid?.toString() || gameId, gameName: game.name || game.title,
+          gameImage: game.headerImage || game.coverUrl, targetLang: tgt,
+          opTitle: t('heroJob.jobTitle').replace('{name}', game.name || game.title || 'Visionaire'),
+          opDesc: t('heroJob.jobDescBg').replace('{engine}', `Visionaire Studio · ${visBackend === 'cloud' ? 'Cloud' : 'Ollama'}`),
           // Il pulsante Annulla del widget ferma il job TRA un blocco e
           // l'altro: checkpoint salvato (disco+idb) e patch parziale
           // applicata. Fino al 03/08/2026 l'unico stop era chiudere la app.
           canCancel: true,
           onCancel: () => {
-            // installPath è string|undefined e il narrowing non entra nelle
-            // closure: si rilegge e si controlla QUI, al momento del click.
-            const p = game.installPath;
-            if (!p) return;
             import('@/lib/visionaire-translate')
-              .then(m => m.requestVisionaireStop(p))
+              .then(m => m.requestVisionaireStop(vPath))
               .catch(() => {});
           },
         });
-        // Badge tray: +1 traduzione in corso
-        import('@/lib/notifications/tray-notifications').then(m => m.incrementActiveTranslations()).catch(() => {});
+        if (!visTracker) {
+          toast.info(t('heroJob.alreadyRunning'));
+          setAutoTranslateBusy(false); autoTranslateRunningRef.current = false;
+          return;
+        }
+        setAutoTranslateError(null);
+        setAutoTranslateResult(null);
+        setAutoTranslateSteps([...vSteps]);
+        setAutoTranslateActive(true);
         try {
           const { runVisionaireTranslation } = await import('@/lib/visionaire-translate');
           const r = await runVisionaireTranslation({
@@ -2490,14 +2487,18 @@ export default function GameDetailPage() {
             gameName: game.name || game.title,
             gameImage: game.headerImage || game.coverUrl,
             onProgress: (p) => {
-              if (p.phase === 'scan') vStep(0, 'running');
-              else if (p.phase === 'extract') { vStep(0, 'done'); vStep(1, 'running'); }
+              // setStage dice al tracker a che punto della pipeline siamo: se la
+              // run fallisce, il database riceve lo step VERO invece della stima
+              // ('extract' → 'translate' al primo progresso). Qui le fasi sono
+              // note, quindi non c'è ragione di farlo indovinare.
+              if (p.phase === 'scan') { visTracker.setStage('scan'); vStep(0, 'running'); }
+              else if (p.phase === 'extract') { visTracker.setStage('extract'); vStep(0, 'done'); vStep(1, 'running'); }
               else if (p.phase === 'translate') {
                 vStep(1, 'done');
                 vStep(2, 'running', `${p.done}/${p.total}`);
                 setAutoTranslateProgress(p.total ? `${p.done}/${p.total}` : '');
-                progress.updateProgress(visOpId, p.total ? (p.done / p.total) * 100 : 0, `${p.done}/${p.total}`);
-              } else if (p.phase === 'apply') { vStep(2, 'done'); vStep(3, 'running'); progress.updateProgress(visOpId, 99, 'Applicazione patch...'); }
+                visTracker.onProgress(p.done, p.total);
+              } else if (p.phase === 'apply') { visTracker.setStage('patch'); vStep(2, 'done'); vStep(3, 'running'); }
               else if (p.phase === 'done') vStep(3, 'done');
             },
           });
@@ -2506,11 +2507,7 @@ export default function GameDetailPage() {
             // successo da wizard né un errore — il lavoro è nel checkpoint
             // e la patch parziale è applicata. Si chiude sobri.
             vStep(2, 'done', `${r.translated}/${r.total} — ${t('heroJob.stoppedByUser')}`);
-            progress.completeOperation(visOpId, { translated: r.translated, total: r.total, stopped: true });
-            try {
-              const tray = await import('@/lib/notifications/tray-notifications');
-              await tray.decrementActiveTranslations();
-            } catch { /* tray non disponibile */ }
+            await visTracker.stopped(r.translated, r.total);
             toast.info(t('heroJob.stoppedToast').replace('{n}', String(r.translated)).replace('{total}', String(r.total)));
             return;
           }
@@ -2530,13 +2527,7 @@ export default function GameDetailPage() {
               stringsWritten: r.translated, runtimeOnly: false,
             },
           });
-          progress.completeOperation(visOpId, { translated: r.translated, total: r.total });
-          // Notifica tray (anche con finestra ridotta a icona) + aggiorna badge attivi
-          try {
-            const tray = await import('@/lib/notifications/tray-notifications');
-            await tray.decrementActiveTranslations();
-            await tray.notifyTranslationCompleted(game.name || game.title || 'Gioco', r.translated);
-          } catch { /* tray non disponibile */ }
+          await visTracker.done(r.translated, r.total);
           toast.success(t('heroJob.visDone').replace('{n}', String(r.translated)).replace('{total}', String(r.total)));
         } catch (e) {
           vStep(2, 'error', String(e));
@@ -2545,16 +2536,10 @@ export default function GameDetailPage() {
           const _full = `${t('heroJob.visError').replace('{hint}', hint)}${_detail ? ' — ' + _detail : ''}`;
           clientLogger.error('[Visionaire] traduzione fallita:', e);
           setAutoTranslateError(_full);
-          progress.failOperation(visOpId, new Error(_full));
-          try {
-            const tray = await import('@/lib/notifications/tray-notifications');
-            await tray.decrementActiveTranslations();
-            await tray.notifyTranslationFailed(game.name || game.title || 'Gioco', String(e));
-          } catch { /* tray non disponibile */ }
+          await visTracker.fail(new Error(_full));
           toast.error(t('heroJob.visError').replace('{hint}', hint), { description: String(e) });
           void tryRuntimeFallback('failure', {}, 'run-failed');
         } finally {
-          VIS_RUNNING.delete(game.installPath);
           setAutoTranslateBusy(false);
           setAutoTranslateProgress('');
           autoTranslateRunningRef.current = false;

--- a/lib/hero-job-tracking.ts
+++ b/lib/hero-job-tracking.ts
@@ -54,6 +54,23 @@ export interface HeroTracker {
   done: (translated: number, total: number) => Promise<void>;
   fail: (err: unknown) => Promise<void>;
   /**
+   * Run fermata DALL'UTENTE col pulsante Annulla del widget globale.
+   *
+   * ⛔ Non è né `done` né `fail`, e schiacciarla su uno dei due mente in un
+   * modo che si vede: `done` la manderebbe nel database di compatibilità come
+   * 'success' (o 'partial'), abbassando la percentuale di un motore per un
+   * motivo che col motore non c'entra — chi annulla ha cambiato idea, non ha
+   * trovato un gioco incompatibile. `fail` direbbe che qualcosa si è rotto,
+   * quando invece il checkpoint è salvo e la patch parziale è applicata.
+   *
+   * Quindi qui NON si segnala nessuno step: si chiude l'operazione dichiarando
+   * `stopped`, si rilasciano guardia e badge, e si aggiorna il progetto con il
+   * lavoro davvero fatto (che è recuperabile). Niente boot check e niente
+   * proposta di opt-in: la run non è arrivata in fondo, non c'è esito da
+   * chiedere. Il silenzio, qui, è il dato più onesto che possiamo produrre.
+   */
+  stopped: (translated: number, total: number) => Promise<void>;
+  /**
    * Facoltativo: comunica lo step di pipeline corrente al tracker (per la
    * telemetria di compatibilità). Se mai chiamato, la stima è: 'extract'
    * all'avvio → 'translate' al primo progress → 'patch' su done().
@@ -246,6 +263,11 @@ export function startHeroTracking(progress: ProgressState, meta: HeroTrackMeta):
         const tray = await import('@/lib/notifications/tray-notifications');
         await tray.notifyTranslationCompleted(meta.gameName || 'Gioco', translated);
       } catch { /* ignore */ }
+    },
+    stopped: async (translated: number, total: number) => {
+      progress.completeOperation(opId, { translated, total, stopped: true });
+      if (projectId) await projectService.updateProgress(projectId, translated).catch(() => {});
+      await releaseGuardAndBadge();
     },
     fail: async (err: unknown) => {
       progress.failOperation(opId, err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
The compatibility telemetry has been complete since 13/07/2026 — sender with offline queue, opt-in, server-side anti-abuse, badges, public page. One engine never reached it.

The **Visionaire Studio** branch of `startAutoTranslate` opened its own progress operation by hand, with its own duplicate guard and its own tray badge, instead of going through `startHeroTracking`. It was the only direct `progress.startOperation` call in the file.

Nothing was broken — and that is the whole problem. The branch was **mute, not failing**. Everything it did by hand it did correctly, except the one thing only the tracker does: `reportCompatStep`. Every Visionaire run stayed out of the data, and *"works in N% of runs"* for that engine would have read zero runs forever. An engine added tomorrow by copying that branch would have been mute too.

## The tracker had been written to receive it

`HeroTrackMeta.canCancel` / `onCancel` exist precisely to absorb Visionaire's hand-rolled stop, and the comment there says so:

> Visionaire lo fa così dal 03/08/2026 chiamando `progress.startOperation` a mano; qui la stessa cosa passa dal tracker, così ogni motore la ottiene gratis.

The hook was added. The branch was never moved onto it.

## What moving it does

**−15 net lines** in the component: the `__gsVisRunning` global guard, the operation setup, the tray increment and its four scattered decrements, three hand-managed notifications.

Two things nobody set out to add come along for free, because they live in the tracker: Visionaire now appears in the **Projects** page and gets the **pace advisor**. It had neither.

`setStage` is wired to the phases the orchestrator already reports (`scan` / `extract` / `patch`), so a failed run records the step it actually reached instead of the tracker's fallback guess.

## `HeroTracker.stopped()` — the one thing the tracker could not express

Visionaire is the only engine with a user Stop, and that outcome is neither `done` nor `fail`:

- `done` would file it as `success` or `partial`, lowering an engine's percentage for a reason that has nothing to do with the engine. Someone who cancels changed their mind; they did not hit an incompatible game.
- `fail` would claim something broke, when the checkpoint is safe and the partial patch is applied.

So `stopped` reports **nothing at all**. It closes the operation declaring `stopped`, releases guard and badge, records the work actually done. No boot check, no opt-in prompt — the run never finished, so there is no outcome to ask the user about.

## The guard test

One rule: *no file under `app/` or `components/` opens a progress operation of its own*, with a single allowlist entry for the provider that implements the API.

It was checked against the **real defect**, not an invented mutant — restoring the file as it stood at `HEAD` makes it fail, naming `components/game-detail-client.tsx`. Three more cases pin the new semantics: cancelled reports nothing but still closes the operation, finished reports `patch`/`success`, failed reports `failure` on the stage reached.

## ROADMAP

The *"if you could pick only three things"* block listed three open items while two of them had been completed and ticked higher up in the same file. It had been stale since 13/07 — and it was read: it sent someone to redo finished work. Corrected, with a note that a summary which does not age with what it summarises is worse than no summary.

## Verification

- `npx vitest run` → **940 passed**, 37 skipped (pre-existing)
- `npx tsc --noEmit` clean; `eslint` clean on the touched files (4 pre-existing warnings elsewhere in the component)
- `npm run i18n:check` → `802 = baseline`

**Not verified end to end against a real Visionaire run.** The `gamestringer-community` Supabase is refusing Postgres connections: the HTTP gateway answers `401` in 0.15s while every authenticated query times out at 25s — on `compat_reports`, `compat_game_summary` and the unrelated `patch_hub_entries` alike — and `select 1` times out over the SQL connection too. Still reproducing at the time of writing, across a session restart. That outage is not caused by this change, affects badges / public page / Patch Hub for everyone, and is worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
