### PR TITLE
Find out why the community backend is down, and fix the one thing that was ours

### DIFF
--- a/docs/maintenance/2026-08-27-supabase-522-origin-irraggiungibile.md
+++ b/docs/maintenance/2026-08-27-supabase-522-origin-irraggiungibile.md
@@ -1,0 +1,141 @@
+# Il progetto Supabase risponde 522 a quasi tutto, da 24 ore
+
+**Data:** 27/08/2026 · **Stato:** **aperto** — non risolvibile dal codice, serve
+azione sulla dashboard · **Progetto:** `gamestringer-community`
+(`relbkjoxdnbqizgomzhs`, `eu-west-1`, Postgres 17.6.1)
+
+## Il fatto
+
+Il gateway del progetto restituisce **522** (Cloudflare non riesce ad aprire la
+connessione TCP verso l'origin) a praticamente tutto il traffico. Misurato sui
+log `edge_logs`, finestra 26/08 08:00 → 27/08 08:00 UTC:
+
+| Esito | Richieste |
+|---|---|
+| **522** | **~3.470** |
+| 504 / 524 | 44 |
+| **2xx** | **~50** |
+
+Non è un picco: è ogni singola ora della finestra. L'unica eccezione è la
+finestra **05:00–05:59 UTC del 27/08** (07:00–08:00 ora italiana), in cui il
+progetto ha funzionato: 17 risposte 2xx, zero 522. Poi è tornato giù alle 06:00
+e alle 08:03 UTC, ultima misura, era ancora giù.
+
+Colpite tutte le rotte, non una: `/auth/v1/token` (2.444 richieste, tutte 522),
+`/rest/v1/compat_game_summary`, `/rest/v1/forum_threads`,
+`/rest/v1/user_profiles`, `/rest/v1/notifications`, `/rest/v1/translation_packs`,
+`/rest/v1/community_presence`, l'RPC `update_user_presence`, `/auth/v1/signup`.
+
+Nel frattempo l'API di stato del progetto riporta `ACTIVE_HEALTHY`. **Non lo è.**
+Lo stato dichiarato non è una prova di salute e non va usato come tale.
+
+## Cosa NON sono gli errori che si notano per primi
+
+Questa è la parte che fa perdere tempo. I due tipi di errore più visibili nella
+dashboard sono entrambi conseguenze, non cause.
+
+**Storage — `ABORTED REQ` su `/tenants/relbkjoxdnbqizgomzhs/health`.** Il
+chiamante è `@supabase-infra/mgmt-api`: sono le sonde di salute interne di
+Supabase, non traffico dell'app. Non c'è niente da correggere nel nostro codice.
+
+**Postgres — `57014 canceling statement due to statement timeout`,** 93 nelle 24
+ore, più 47 `canceling statement due to user request`. Sembrano query lente
+dell'app. Non lo sono. Estraendo `parsed.query` dai log, sono **tutte** di
+`postgrest`/`authenticator` e sono gli statement di apertura di una connessione
+nuova:
+
+```
+SET client_encoding = 'UTF8'; SET client_min_messages TO WARNING;
+SELECT current_setting('server_version_num')::integer, ...
+BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY
+<la query di refresh dello schema cache di PostgREST>
+```
+
+`SET client_encoding` che va in timeout non è una query lenta: è PostgREST che
+apre una connessione, si pianta sul primo statement e riprova. Ritmo costante di
+4–11/ora **per 24 ore, notte compresa**, quando nessuno usa l'app. È lo stesso
+guasto visto dal lato database.
+
+## Cosa non prova cosa
+
+Tre tentativi di eseguire SQL via management API (MCP) sono finiti in
+`Connection terminated due to connection timeout`. **Questo da solo non prova
+niente sull'outage:** l'host diretto `db.<ref>.supabase.co` può fallire anche
+per ragioni di rete indipendenti (è IPv6-only, il pooler è un'altra cosa). La
+prova che conta sono i 522 sull'edge, che è il percorso che usano davvero gli
+utenti.
+
+## Cosa fare (dashboard, non codice)
+
+1. Settings → General → **Restart project**.
+2. Guardare i grafici **CPU / RAM / Disk IO** nella finestra 26/08 08:00 in poi:
+   se l'istanza è satura o ha esaurito i crediti di burst IO, il 522 si spiega.
+3. Se dopo il riavvio torna 522: ticket al supporto con ref
+   `relbkjoxdnbqizgomzhs`, regione `eu-west-1`, e i numeri di questa pagina.
+
+## Due cose nostre, emerse per strada
+
+**1. `user_profiles.user_id` non esiste.** Nell'unica ora in cui il database ha
+risposto sono comparsi 7 errori `42703: column user_profiles.user_id does not
+exist`. La query è quella di `lib/social/presence.ts` (`fetchProfilesMap`):
+interroga `user_id`, ma la chiave primaria di `user_profiles` è `id`
+(`docs/supabase-schema.sql:9`). Peggio: il fallback "riprova per `id`" che sta
+poche righe sotto **era codice morto**, perché il ramo `if (error)` fa
+`return map` prima di arrivarci. Conseguenza: `fetchProfilesMap` non ha mai
+risolto un solo username o avatar da Supabase — la presence mostrava sempre il
+ripiego locale, e nessuno se n'era accorto perché l'errore veniva inghiottito.
+Corretto il 27/08 interrogando `id`.
+
+### La radice: due `user_profiles` diversi nel repo
+
+Il bug sopra non e' una svista isolata. Nel repo esistono **due definizioni
+incompatibili della stessa tabella**, e il codice e' stato scritto ora contro
+l'una ora contro l'altra:
+
+| | `docs/supabase-schema.sql:8` | `supabase/forum-schema.sql:156` |
+|---|---|---|
+| chiave | `id UUID PK REFERENCES auth.users(id)` | `id UUID PK DEFAULT gen_random_uuid()` |
+| `user_id` | **non esiste** | `TEXT UNIQUE NOT NULL` |
+| `display_name` | **non esiste** | `TEXT` |
+
+Quella **deployata e' la prima** — lo dimostra l'errore 42703 su `user_id`.
+`forum-schema.sql` non e' mai stato applicato a questo progetto.
+
+Da qui discendono i due dialetti che convivono nel codice:
+`community-hub-backend.ts` filtra con `.eq('id', userId)` (corretto), mentre
+`presence.ts` filtrava con `.eq('user_id', ...)` (rotto, ora corretto).
+
+**Sospetto ancora aperto, non corretto:** `lib/social/social.ts:495` e `:523`
+selezionano `user:user_profiles!user_id(id, username, display_name, avatar_url)`.
+`display_name` non esiste sulla tabella viva, quindi quelle due query dovrebbero
+fallire con 42703 — e falliscono in silenzio (`if (error) return []`), lasciando
+il feed attivita' vuoto per sempre. Non compare nei log del 27/08 perche' in
+quella finestra nessuno ha aperto il feed: **e' un sospetto motivato, non una
+misura**. Da verificare quando il database torna raggiungibile, con una query
+sola:
+`select column_name from information_schema.columns where table_name='user_profiles'`.
+
+**2. Ritempesta di token.** 2.444 richieste a `/auth/v1/token` in 24 ore, tutte
+522, in coppie distanziate 20s con pause di ~90s: è il refresh di GoTrue che
+ritenta contro un origin morto. Non è la causa dell'outage, ma genera traffico
+inutile e brucia la quota dei log. Un backoff va messo — **dopo** aver risolto
+il 522, altrimenti non si distingue il fix dal database che torna su.
+
+## Come rifare le misure
+
+Query ClickHouse sui log unificati (MCP Supabase, `query_logs`), finestra max 24h:
+
+```sql
+-- Distribuzione esiti per ora
+select toStartOfHour(timestamp) as ora,
+       countIf(log_attributes['response.status_code']='522') as c522,
+       countIf(log_attributes['response.status_code'] like '2%') as ok2xx,
+       count(*) as tot
+from logs where source='edge_logs' group by ora order by ora;
+
+-- Il testo vero delle query che vanno in timeout
+select timestamp, log_attributes['parsed.query'] as q
+from logs where source='postgres_logs'
+  and log_attributes['parsed.sql_state_code']='57014'
+order by timestamp desc;
+```

--- a/docs/maintenance/2026-08-27-supabase-522-origin-irraggiungibile.md
+++ b/docs/maintenance/2026-08-27-supabase-522-origin-irraggiungibile.md
@@ -1,8 +1,8 @@
 # Il progetto Supabase risponde 522 a quasi tutto, da 24 ore
 
-**Data:** 27/08/2026 · **Stato:** **aperto** — non risolvibile dal codice, serve
-azione sulla dashboard · **Progetto:** `gamestringer-community`
-(`relbkjoxdnbqizgomzhs`, `eu-west-1`, Postgres 17.6.1)
+**Data:** 27/08/2026 · **Stato:** **aperto a monte** — causa identificata, e' un
+incidente Supabase in corso, non il nostro progetto · **Progetto:**
+`gamestringer-community` (`relbkjoxdnbqizgomzhs`, `eu-west-1`, Postgres 17.6.1)
 
 ## Il fatto
 
@@ -65,13 +65,59 @@ per ragioni di rete indipendenti (è IPv6-only, il pooler è un'altra cosa). La
 prova che conta sono i 522 sull'edge, che è il percorso che usano davvero gli
 utenti.
 
-## Cosa fare (dashboard, non codice)
+*Nota del senno di poi:* con l'incidente pgBouncer alla mano quei timeout
+tornano coerenti col resto, ma restavano comunque non-prove nel momento in cui
+li ho osservati. Una coincidenza spiegata a posteriori non retrodata la propria
+forza probatoria.
 
-1. Settings → General → **Restart project**.
-2. Guardare i grafici **CPU / RAM / Disk IO** nella finestra 26/08 08:00 in poi:
-   se l'istanza è satura o ha esaurito i crediti di burst IO, il 522 si spiega.
-3. Se dopo il riavvio torna 522: ticket al supporto con ref
-   `relbkjoxdnbqizgomzhs`, regione `eu-west-1`, e i numeri di questa pagina.
+## La causa: un incidente Supabase, non il nostro progetto
+
+Letta su `status.supabase.com` il 27/08/2026 verso le 08:20 UTC:
+
+> **pgBouncer issues on some older projects** — 26-27 agosto 2026, **non
+> risolto**. Corretto in `eu-central-2` e `ap-south-1`, in rollout sulle altre
+> regioni.
+
+`eu-west-1` non e' ancora coperta. La finestra dell'incidente combacia con i
+nostri log: i 522 iniziano il 26/08 alle 08:00 UTC. Un connection pooler rotto
+produce esattamente questo — Cloudflare non riesce ad aprire la connessione
+verso l'origin — e spiega anche perche' lo stato del progetto resta
+`ACTIVE_HEALTHY`: **il database sta su, e' il davanti che non risponde.**
+
+Sulla stessa pagina, gli altri due pezzi del quadro:
+
+- **Storage: Partial Outage** → sono gli `ABORTED REQ` sulle sonde `/health`.
+- **API Gateway: Degraded Performance**.
+
+Cioe' tutti e tre i sintomi che si vedono in dashboard hanno la stessa origine,
+e nessuno dei tre e' nostro.
+
+### L'ipotesi sbagliata, registrata apposta
+
+La prima stesura di questa pagina diceva di riavviare il progetto e di guardare
+i grafici CPU/RAM/Disk IO per cercare un'istanza satura. **Era la pista
+sbagliata**, ed e' quella che viene istintiva quando un progetto e' giu: cercare
+la colpa nella propria infrastruttura. Riavviare non sistema un pgBouncer rotto
+a monte, e i grafici di saturazione non avrebbero mostrato niente, facendo
+perdere tempo e lasciando il sospetto che il problema fosse nascosto altrove.
+
+Lezione: **prima di misurare la propria macchina, leggere la status page del
+fornitore.** Costa trenta secondi ed e' l'unico controllo che puo' chiudere il
+caso invece di aprirne altri.
+
+## Cosa fare
+
+1. Aspettare il rollout del fix su `eu-west-1`, seguendo l'incidente su
+   `status.supabase.com`.
+2. Se resta giu': ticket al supporto citando **quell'incidente**, il ref
+   `relbkjoxdnbqizgomzhs` e la regione, per chiedere che `eu-west-1` venga
+   prioritizzata. Non aprire un ticket generico "il mio progetto e' giu'": si
+   finisce nella coda sbagliata.
+3. **Non** riavviare il progetto e **non** metterlo in pausa sperando che si
+   sblocchi: non tocca il componente guasto e la pausa e' l'unica di queste
+   mosse che puo' peggiorare le cose.
+4. Quando torna su, rifare le misure con le query in fondo e verificare lo
+   schema di `user_profiles` (vedi sotto).
 
 ## Due cose nostre, emerse per strada
 

--- a/lib/social/presence.ts
+++ b/lib/social/presence.ts
@@ -332,17 +332,21 @@ async function fetchProfilesMap(userIds: string[]): Promise<Map<string, { userna
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) return map;
 
-    // Try user_profiles with user_id column
+    // La PK di `user_profiles` e' `id` (docs/supabase-schema.sql:9). Fino al
+    // 27/08/2026 qui si interrogava `user_id`, colonna che non esiste: ogni
+    // chiamata finiva in 42703 e il ripiego per `id` che stava sotto non veniva
+    // mai raggiunto, perche' il ramo d'errore ritorna prima. Risultato: questa
+    // funzione non ha mai risolto un username o un avatar da Supabase.
     const query = supabase
       .from('user_profiles')
-      .select('user_id, username, avatar_url');
-    
+      .select('id, username, avatar_url');
+
     if (userIds.length === 1) {
-      query.eq('user_id', userIds[0]);
+      query.eq('id', userIds[0]);
     } else {
-      query.in('user_id', userIds);
+      query.in('id', userIds);
     }
-    
+
     const { data, error } = await query;
 
     if (error) {
@@ -357,28 +361,7 @@ async function fetchProfilesMap(userIds: string[]): Promise<Map<string, { userna
 
     if (data) {
       for (const p of data) {
-        if (p.user_id) map.set(p.user_id as string, { username: p.username as string || 'Utente', avatar_url: p.avatar_url as string | null });
-      }
-    }
-
-    // Also try by id column (some tables use id instead of user_id)
-    if (map.size === 0) {
-      const query2 = supabase
-        .from('user_profiles')
-        .select('id, username, avatar_url');
-      
-      if (userIds.length === 1) {
-        query2.eq('id', userIds[0]);
-      } else {
-        query2.in('id', userIds);
-      }
-      
-      const { data: data2 } = await query2;
-
-      if (data2) {
-        for (const p of data2) {
-          if (p.id) map.set(p.id as string, { username: p.username as string || 'Utente', avatar_url: p.avatar_url as string | null });
-        }
+        if (p.id) map.set(p.id as string, { username: p.username as string || 'Utente', avatar_url: p.avatar_url as string | null });
       }
     }
   } catch { /* silent */ }


### PR DESCRIPTION
The community project has been answering **522** to almost all traffic for 24 hours. Measured on the unified logs, 26/08 08:00 → 27/08 08:00 UTC: **~3470 responses with status 522 against ~50 in the 2xx range**, every hour of the window, every route. Still down at the last check, while the project status API reports `ACTIVE_HEALTHY`.

**The cause is upstream.** `status.supabase.com` carries an unresolved incident, *"pgBouncer issues on some older projects"* (26-27 August), fixed in `eu-central-2` and `ap-south-1` and still rolling out elsewhere. `eu-west-1` is not covered yet, and the incident window matches our logs to the hour. A broken pooler produces exactly a 522, and it explains why the project still reports healthy: the database is up, the front of it is not. The same page has Storage at partial outage and the API gateway degraded, which accounts for the other two symptoms visible in the dashboard.

So there is nothing to fix here for the outage itself. What this PR adds is the note that keeps the next person from re-deriving it, and one bug it turned up.

### The note

`docs/maintenance/2026-08-27-supabase-522-origin-irraggiungibile.md`, following the convention of that directory. Most of its length goes on what the visible errors are *not*: the storage `ABORTED REQ` entries are Supabase's own health probes, and the Postgres `57014` timeouts are PostgREST's connection bootstrap (`SET client_encoding`, `BEGIN`, schema cache reload), not app queries. It also says plainly that the management-API timeouts prove nothing on their own — the 522s on the edge are the evidence that counts, because that is the path users take.

It keeps the wrong trail on the page too. The first draft said to restart the project and go read the CPU and disk IO graphs looking for a saturated instance. That is the instinct when something is down — look for the fault in your own infrastructure — and it would have found nothing.

### The bug it turned up

In the one hour the database was reachable, 7 errors: `42703: column user_profiles.user_id does not exist`. `fetchProfilesMap` in `lib/social/presence.ts` asked for `user_id`; the deployed table's primary key is `id`. The `id` fallback sitting right below was dead code, because the error branch returns first. Presence has therefore never resolved a single username or avatar from Supabase — it silently fell back to the local profile.

The mismatch has a root: two incompatible definitions of `user_profiles` live in the repo. `docs/supabase-schema.sql` (deployed, keyed on `auth.users`) and `supabase/forum-schema.sql` (never applied, has `user_id` and `display_name`). The code was written against one or the other depending on the file.

### Verification

Typecheck clean. The fix is verified against the schema and against the 42703 the database itself emitted; **it is not verified end to end**, and cannot be until the pooler is back.

One suspect is left open and labelled as a suspect in the note, not fixed here: `lib/social/social.ts:495` and `:523` select `display_name`, which the live table does not have, and swallow the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
