### PR TITLE
Price Qwen at the endpoint the code calls, and put a net under the site catalog

### DIFF
--- a/__tests__/lib/remote-config-sito.test.ts
+++ b/__tests__/lib/remote-config-sito.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Il file del sito è l'unico pezzo di questa configurazione senza una rete.
+ *
+ * `docs/sito/config/models.json` viene ridistribuito con il sito e, nel merge,
+ * VINCE sul bundled: per chiave di provider e per intero array di modelli. Non
+ * è un'aggiunta, è una sovrascrittura su TUTTE le installazioni. Ad agosto 2026
+ * un file fermo a luglio ha rimesso in circolo prezzi che il repo aveva già
+ * corretto, e nessun test poteva accorgersene perché i test coprivano il merge,
+ * non il contenuto del file (docs/maintenance/2026-08-23-il-sito-sovrascrive-i-prezzi.md).
+ *
+ * Questi test coprono il contenuto. Attenzione a cosa NON possono fare:
+ *
+ * - Non pretendono che i valori del sito coincidano col bundled: il file esiste
+ *   apposta per divergere, è il suo mestiere.
+ * - Vedono la copia nel repo, non quella deployata. Ad agosto erano la stessa
+ *   cosa ed è bastato, ma se un domani qualcuno modifica il file sul server
+ *   senza passare di qui, questi test resteranno verdi.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { BUNDLED_MODEL_CONFIG, validateModelConfig } from '@/lib/remote-config';
+
+const PERCORSO = resolve(process.cwd(), 'docs/sito/config/models.json');
+const GREZZO = readFileSync(PERCORSO, 'utf-8');
+
+/** Oltre questo, i listini vanno riguardati: non è un bug del codice, è una scadenza. */
+const GIORNI_PRIMA_DI_RIGUARDARLO = 180;
+
+describe('docs/sito/config/models.json', () => {
+  it('è JSON valido con la forma che l\'app si aspetta', () => {
+    const cfg = JSON.parse(GREZZO);
+    expect(typeof cfg.version).toBe('number');
+    expect(cfg.pricing).toBeTypeOf('object');
+    expect(cfg.models).toBeTypeOf('object');
+  });
+
+  it('passa il validatore dell\'app senza perdere voci per strada', () => {
+    // Il controllo vero non è «è JSON»: è «sopravvive a validateModelConfig».
+    // Quel validatore scarta in silenzio le voci malformate e tiene le altre,
+    // quindi un prezzo scritto male non fa fallire niente — sparisce e basta,
+    // lasciando vincere il bundled senza che nessuno lo sappia. Qui pretendiamo
+    // che il conto delle chiavi entrate sia il conto delle chiavi uscite.
+    const grezzo = JSON.parse(GREZZO);
+    const validato = validateModelConfig(grezzo);
+    expect(validato).not.toBeNull();
+    expect(Object.keys(validato!.pricing).sort()).toEqual(Object.keys(grezzo.pricing).sort());
+    expect(Object.keys(validato!.models).sort()).toEqual(Object.keys(grezzo.models).sort());
+  });
+
+  it('non contiene provider che l\'app non conosce', () => {
+    // Una chiave che nel bundled non esiste è peso morto nel migliore dei casi
+    // e un refuso nel peggiore: `deepsek: 0.0001` non sovrascrive niente, e il
+    // prezzo che credevi di aver corretto resta quello di prima.
+    const cfg = JSON.parse(GREZZO);
+    const orfaniPrezzi = Object.keys(cfg.pricing).filter((k) => !(k in BUNDLED_MODEL_CONFIG.pricing));
+    const orfaniModelli = Object.keys(cfg.models).filter((k) => !(k in BUNDLED_MODEL_CONFIG.models));
+    expect(orfaniPrezzi, 'prezzi per provider che il bundled non ha').toEqual([]);
+    expect(orfaniModelli, 'modelli per provider che il bundled non ha').toEqual([]);
+  });
+
+  it('dichiara quando è stato guardato, e non è passato troppo tempo', () => {
+    // Se questo fallisce non c'è niente da riparare nel codice: vuol dire che i
+    // listini hanno più di sei mesi e vanno riverificati sul sito dei vendor,
+    // aggiornando `updatedAt`. È la scadenza sul latte, non un allarme antifurto.
+    const cfg = JSON.parse(GREZZO);
+    expect(cfg.updatedAt, 'manca updatedAt: un listino senza data è un listino vecchio travestito').toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const giorni = (Date.now() - Date.parse(cfg.updatedAt)) / 86_400_000;
+    expect(giorni, `models.json fermo da ${Math.round(giorni)} giorni: riguardare i listini`).toBeLessThan(GIORNI_PRIMA_DI_RIGUARDARLO);
+  });
+});

--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -1,6 +1,6 @@
 {
-  "version": 3,
-  "updatedAt": "2026-08-24",
+  "version": 4,
+  "updatedAt": "2026-08-27",
   "_comment": "Catalogo modelli/prezzi remoto di GameStringer. Modifica questo file e ridistribuisci il sito per aggiornare modelli, prezzi e raccomandazioni SENZA rilasciare l'app. L'app fa fail-open sui default bundled se il file non e' raggiungibile. Prezzi in USD per 1K token (stima input). ATTENZIONE: nel merge il remoto VINCE sul bundled, per chiave di provider e per intero array modelli. Un file stantio qui non e' inerte: sovrascrive i valori corretti di lib/remote-config.ts su TUTTE le installazioni. Tenere questo file allineato a BUNDLED_MODEL_CONFIG.",
   "pricing": {
     "openai": { "per1kUsd": 0.00015, "note": "GPT-4o mini ($0.15/1M input) · VERIFICATO 23/08/2026 su developers.openai.com" },
@@ -10,6 +10,12 @@
     "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
     "mistral": { "per1kUsd": 0.00015, "note": "Mistral Small 4 ($0.15/1M input), il modello che il codice chiama davvero · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Catalogo e tendina allineati al codice il 23/08: prima dicevano Large 3 e 'Large 2'." },
     "qwen": { "per1kUsd": 0.000115, "note": "Qwen Plus (= qwen-plus-2025-12-01) via endpoint Pechino, scaglione 0-128K ($0.115/1M input) · VERIFICATO 24/08/2026 su alibabacloud.com/help/en/model-studio/billing-for-model-studio. Prima del 24/08 qwen non aveva una voce qui e cadeva sul fallback 0.002: 17x il prezzo vero. Il prezzo vale finche' i batch restano da 20 stringhe (~1-3K token): oltre i 128K per richiesta lo scaglione triplica." },
+    "groq": { "per1kUsd": 0.00059, "note": "Llama 3.3 70B Versatile ($0.59/1M input), il modello che il codice chiama · VERIFICATO 24/08/2026. Ha un free tier: qui sta il listino che si paga quando finisce." },
+    "groq-gptoss": { "per1kUsd": 0.00015, "note": "GPT-OSS 120B su Groq ($0.15/1M input) · VERIFICATO 24/08/2026 su console.groq.com/docs/models" },
+    "cerebras": { "per1kUsd": 0.00085, "note": "Llama 3.3 70B su Cerebras ($0.85/1M input) · VERIFICATO 24/08/2026 · free tier 1M token/giorno" },
+    "cohere": { "per1kUsd": 0.0025, "note": "Command R+ 08-2024 ($2.50/1M input) · VERIFICATO 24/08/2026 su cohere.com/pricing. Il piu' caro dei sette dietro API key, ~4x cerebras." },
+    "together": { "per1kUsd": 0.00104, "note": "Llama 3.3 70B Instruct Turbo ($1.04/1M input, pagina ufficiale) · VERIFICATO 24/08/2026. Gli aggregatori dicono $0.88: vince la piu' cara, che qui e' anche quella ufficiale." },
+    "fireworks": { "per1kUsd": 0.0009, "note": "Llama 3.3 70B su Fireworks, fascia >16B parametri ($0.90/1M) · VERIFICATO 24/08/2026 su docs.fireworks.ai" },
     "openrouter": { "per1kUsd": 0.001, "note": "Varia per modello" },
     "deepl": { "per1kUsd": 0.02, "note": "DeepL Pro" },
     "google": { "per1kUsd": 0.00002, "note": "Google Translate" }

--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -1,6 +1,6 @@
 {
-  "version": 2,
-  "updatedAt": "2026-08-23",
+  "version": 3,
+  "updatedAt": "2026-08-24",
   "_comment": "Catalogo modelli/prezzi remoto di GameStringer. Modifica questo file e ridistribuisci il sito per aggiornare modelli, prezzi e raccomandazioni SENZA rilasciare l'app. L'app fa fail-open sui default bundled se il file non e' raggiungibile. Prezzi in USD per 1K token (stima input). ATTENZIONE: nel merge il remoto VINCE sul bundled, per chiave di provider e per intero array modelli. Un file stantio qui non e' inerte: sovrascrive i valori corretti di lib/remote-config.ts su TUTTE le installazioni. Tenere questo file allineato a BUNDLED_MODEL_CONFIG.",
   "pricing": {
     "openai": { "per1kUsd": 0.00015, "note": "GPT-4o mini ($0.15/1M input) · VERIFICATO 23/08/2026 su developers.openai.com" },
@@ -9,6 +9,7 @@
     "claude": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input), il default del codice · VERIFICATO 23/08/2026. Claude Opus 5 costa $5/1M: chi sceglie il premium spende ~1.7x questa stima." },
     "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
     "mistral": { "per1kUsd": 0.00015, "note": "Mistral Small 4 ($0.15/1M input), il modello che il codice chiama davvero · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Catalogo e tendina allineati al codice il 23/08: prima dicevano Large 3 e 'Large 2'." },
+    "qwen": { "per1kUsd": 0.000115, "note": "Qwen Plus (= qwen-plus-2025-12-01) via endpoint Pechino, scaglione 0-128K ($0.115/1M input) · VERIFICATO 24/08/2026 su alibabacloud.com/help/en/model-studio/billing-for-model-studio. Prima del 24/08 qwen non aveva una voce qui e cadeva sul fallback 0.002: 17x il prezzo vero. Il prezzo vale finche' i batch restano da 20 stringhe (~1-3K token): oltre i 128K per richiesta lo scaglione triplica." },
     "openrouter": { "per1kUsd": 0.001, "note": "Varia per modello" },
     "deepl": { "per1kUsd": 0.02, "note": "DeepL Pro" },
     "google": { "per1kUsd": 0.00002, "note": "Google Translate" }
@@ -34,6 +35,9 @@
     ],
     "mistral": [
       { "id": "mistral-small-latest", "label": "Mistral Small 4" }
+    ],
+    "qwen": [
+      { "id": "qwen-plus", "label": "Qwen Plus (2025-12-01)", "recommended": true }
     ]
   },
   "recommendations": {

--- a/lib/ai/ai-translate-direct.ts
+++ b/lib/ai/ai-translate-direct.ts
@@ -622,7 +622,25 @@ async function translateWithCerebras(apiKey: string, opts: TranslateOptions): Pr
   );
 }
 
-/** Qwen3 (Alibaba) — via DashScope API, OpenAI-compatible, top multilingue, 1M token gratis/mese */
+/**
+ * Qwen (Alibaba) — via DashScope, OpenAI-compatible, top multilingue.
+ *
+ * `qwen-plus` è un alias vivo e oggi equivale a `qwen-plus-2025-12-01`
+ * (verificato 24/08/2026 sul listino Model Studio).
+ *
+ * ⚠️ L'endpoint qui sotto è quello CINA/PECHINO. Le chiavi DashScope sono
+ * legate alla regione e NON sono portabili: una chiave creata sulla console
+ * internazionale (Singapore) riceve 401 da questo URL, e viceversa. I due link
+ * che diamo all'utente per prendere la chiave — lib/translation/language-mappings.ts:177
+ * e app/settings/page.tsx:1533 — puntano entrambi alla console di Pechino,
+ * quindi endpoint e console sono coerenti. Restano coerenti solo finché si
+ * cambiano insieme: sono tre punti, non due.
+ *
+ * Non c'è "1M token gratis al mese", come diceva questa riga fino al
+ * 24/08/2026: la quota gratuita è di 1M token una tantum, valida 90 giorni
+ * dall'attivazione, ed esiste SOLO sulla regione Singapore. Su Pechino,
+ * che è quella che questo codice chiama, non c'è nessuna quota gratuita.
+ */
 async function translateWithQwen(apiKey: string, opts: TranslateOptions): Promise<string[]> {
   return translateWithOpenAICompatible(apiKey, opts,
     'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions',

--- a/lib/remote-config.ts
+++ b/lib/remote-config.ts
@@ -196,12 +196,46 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     groq: { per1kUsd: 0.00059, note: 'Llama 3.3 70B Versatile ($0.59/1M input), il modello che il codice chiama · verificato 24/08/2026' },
     'groq-gptoss': { per1kUsd: 0.00015, note: 'GPT-OSS 120B su Groq ($0.15/1M input) · console.groq.com/docs/models · verificato 24/08/2026' },
     cerebras: { per1kUsd: 0.00085, note: 'Llama 3.3 70B su Cerebras ($0.85/1M input) · verificato 24/08/2026 · free tier 1M token/giorno' },
-    // Qwen — attenzione all'endpoint: il codice chiama dashscope.aliyuncs.com,
-    // cioè la regione Cina, dove qwen-plus costa $0.115/1M fino a 128K. Qui sta
-    // il listino della regione internazionale (Singapore), $0.40/1M fino a 256K:
-    // è più caro, e una stima deve sbagliare per eccesso. La fascia oltre i 256K
-    // ($1.20/1M) non è raggiungibile dai batch con max_tokens 8192 di questo codice.
-    qwen: { per1kUsd: 0.0004, note: 'Qwen-Plus, listino Singapore ($0.40/1M input fino a 256K) · verificato 24/08/2026 · Pechino $0.115/1M' },
+    // ⏰ Qwen — verificato il 24/08/2026 su
+    // alibabacloud.com/help/en/model-studio/billing-for-model-studio, e
+    // RICONCILIATO IL 27/08/2026: questa voce era stata scritta due volte, con
+    // due prezzi diversi, in due punti dello stesso oggetto. In un object
+    // literal vince l'ultima, in silenzio. Ora è una sola.
+    //
+    // Il codice chiama `dashscope.aliyuncs.com` (ai-translate-direct.ts:645),
+    // cioè l'endpoint CINA/PECHINO, e manda l'utente a prendere la chiave sulla
+    // console di Pechino in due punti: lib/translation/language-mappings.ts:177
+    // e app/settings/page.tsx:1533. Le chiavi DashScope sono legate alla regione
+    // e non sono portabili: una chiave creata sulla console internazionale
+    // (Singapore) riceve 401 da questo URL. Quindi il listino di Singapore
+    // ($0.40/1M fino a 256K) non è per noi il caso peggiore: è un caso
+    // IRRAGGIUNGIBILE. Stimare su un prezzo che nessuno può pagare non è
+    // prudenza — è un numero sbagliato di 3,5×, nella direzione che fa sembrare
+    // il provider più economico del lotto uno di fascia media, mentre lo
+    // raccomandiamo per IT, ZH e JA (lib/translation/language-mappings.ts:55,75,76).
+    // Vale la regola dichiarata in cima a questo blocco: il prezzo è quello di
+    // ciò che il codice chiama davvero, esattamente come il modello.
+    //
+    // Scaglioni Pechino, PER DIMENSIONE DELLA RICHIESTA:
+    //   0-128K token input : $0.115/1M   ← l'unico che questo codice tocca
+    //   128K-256K          : $0.345/1M
+    //   256K-1M            : $0.689/1M
+    // (per riferimento, Singapore: $0.40/1M fino a 256K, $1.20/1M oltre.)
+    //
+    // ⚠️ QUESTO PREZZO DIPENDE DA UN INVARIANTE DEL CODICE, non solo dal listino:
+    // l'app manda batch da 20 stringhe (ai-translate-direct.ts:2236) con
+    // max_tokens 8192, cioè ~1-3K token per chiamata. Sta nel primo scaglione con
+    // tre ordini di grandezza di margine. Se qualcuno alza `maxBatch` fino a
+    // superare i 128K token per richiesta, questo numero diventa falso di 3×.
+    // Qui non serve il margine prudenziale della voce deepseek: là lo scaglione
+    // dipende dall'ora del giorno, che non controlliamo; qui dipende da una
+    // costante che scriviamo noi.
+    //
+    // ❓ NON RIVERIFICATO: che una chiave Singapore prenda davvero 401 su
+    // dashscope.aliyuncs.com. È il perno di tutto il ragionamento qui sopra,
+    // misurato il 24/08 e mai più da allora. Se Alibaba passasse a fatturare per
+    // regione dell'account invece che per host, il numero giusto tornerebbe 0.0004.
+    qwen: { per1kUsd: 0.000115, note: 'Qwen Plus (= qwen-plus-2025-12-01) via endpoint Pechino, scaglione 0-128K ($0.115/1M input) · verificato 24/08/2026 · valido finché i batch restano da 20 stringhe' },
     // Cohere — il più caro dei sette, e di parecchio: $2.50/1M, ~4× cerebras.
     // Nelle catene sta dopo provider molto più economici, ma se quelli cadono
     // è lui a fare il conto.
@@ -235,6 +269,11 @@ export const BUNDLED_MODEL_CONFIG: RemoteModelConfig = {
     ],
     deepseek: [{ id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', recommended: true }],
     mistral: [{ id: 'mistral-small-latest', label: 'Mistral Small 4' }],
+    // Un solo modello, perché è l'unico che il codice chiama davvero
+    // (ai-translate-direct.ts:629). Qwen3.7-Plus e Qwen3.8-Max esistono e costano
+    // meno a scaglione pieno, ma cambiarli è una scelta di comportamento, non una
+    // correzione: vale la regola scritta sopra, entrano quando passano un benchmark.
+    qwen: [{ id: 'qwen-plus', label: 'Qwen Plus (2025-12-01)', recommended: true }],
   },
   recommendations: {
     creative: 'claude',


### PR DESCRIPTION
Three commits on the model price catalog. The first fixes a number that was silently wrong, the second closes an asymmetry that #165 left open, the third adds the guard that would have caught both.

### Qwen was priced twice, and the wrong one won

The `qwen` entry existed **twice in the same object literal**: `0.000115` and, from #165, `0.0004`. In an object literal the last one wins, silently, so the shipped estimate was the Singapore list price. No test could see it: the suite checks that the entry exists, is greater than zero, is not the fallback and carries a date — all of which `0.0004` satisfies.

Both versions agreed on the fact and differed on the policy. #165's own comment says the code calls `dashscope.aliyuncs.com`, the China region, where `qwen-plus` is $0.115/1M — and then stores the Singapore $0.40/1M on the grounds that an estimate should err high.

That rule is right where the worse case is *reachable*, which is why `deepseek` carries the peak-hour rate. It is not reachable here. DashScope keys are region-bound: a Singapore key gets 401 from this URL, and both places where the app sends the user for a key (`lib/translation/language-mappings.ts:177`, `app/settings/page.tsx:1533`) point at the Beijing console. Erring toward a price nobody can be charged is not caution — it is a number wrong by 3.5x, in the direction that makes the cheapest provider in the table look mid-priced, while we recommend it for IT, ZH and JA.

The same block already states the rule this follows: each entry is priced at what `PROVIDER_MAP` actually calls. #165 applied that to the model and broke it on the region.

The comment now carries the Beijing tiers, Singapore for reference, the batch invariant the first tier depends on, and **one thing marked as not re-verified**: that a Singapore key really does 401 against this endpoint. That claim is the hinge of the whole argument and was last measured on 24/08. The docstring also drops "1M token gratis/mese", which was never true for the region this code calls.

### The site catalog was missing six providers

#165 priced seven providers the chain presets use, but only in `BUNDLED_MODEL_CONFIG`. `docs/sito/config/models.json` — which overrides the bundled config on every installation — knew none of them except `qwen`. Not harmful on its own, since a key absent from the remote file leaves the bundled value standing, but it is the same asymmetry that put stale July prices back into circulation in August.

Adds `groq`, `groq-gptoss`, `cerebras`, `cohere`, `together`, `fireworks`, values copied from the bundled entries. Checked key by key: all sixteen prices in the site file now equal their bundled counterpart.

Thirteen keys are still missing, on purpose, and the commit message says why. Nine are local or free providers whose price is structurally zero, where a remote override buys nothing and adds one more value to keep in sync. The other four are chain aliases (`anthropic*`, `deepl-voice`) that mirror vendors already in the file — those have a real argument for being added, since the file can otherwise reprice `claude` while `anthropic` keeps the bundled number. Left as a decision, not settled here.

### A net under the file that had none

`models.json` was the one piece of this configuration with nothing watching it. Four guards, each one **checked by breaking the file on purpose** and confirming the suite goes red: an orphan provider key (the `deepsek: 0.0001` typo that overrides nothing), an entry the app's own validator would silently drop, a missing or stale `updatedAt`, and a file that does not parse.

A fifth test is deliberately absent. It asserted that merging the real file leaves every bundled provider with at least one model; every way I could find to break it was caught by the validator test first, and the ways it would not catch are exactly what the file is allowed to do. A test that cannot be made to fail is decoration, not protection.

The header says out loud what these cannot do: they do not require the site values to equal the bundled ones, since diverging is the whole point of the file, and they see the copy in the repo, not the one on the server.

### Verification

Typecheck clean. `remote-config`, `remote-config-sito` and `chain-cost` suites green (56 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
