### PR TITLE
Put the chain aliases in the site catalog, next to the vendors they shadow

### DIFF
--- a/docs/sito/config/models.json
+++ b/docs/sito/config/models.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "updatedAt": "2026-08-27",
   "_comment": "Catalogo modelli/prezzi remoto di GameStringer. Modifica questo file e ridistribuisci il sito per aggiornare modelli, prezzi e raccomandazioni SENZA rilasciare l'app. L'app fa fail-open sui default bundled se il file non e' raggiungibile. Prezzi in USD per 1K token (stima input). ATTENZIONE: nel merge il remoto VINCE sul bundled, per chiave di provider e per intero array modelli. Un file stantio qui non e' inerte: sovrascrive i valori corretti di lib/remote-config.ts su TUTTE le installazioni. Tenere questo file allineato a BUNDLED_MODEL_CONFIG.",
   "pricing": {
@@ -7,6 +7,9 @@
     "gpt5": { "per1kUsd": 0.0025, "note": "GPT-4o ($2.50/1M input) · VERIFICATO 23/08/2026. La chiave si chiama gpt5 per ragioni storiche, il modello e GPT-4o." },
     "gemini": { "per1kUsd": 0.0015, "note": "Gemini 3.7 Flash, il default del codice · VERIFICATO 23/08/2026 su ai.google.dev. Costa $0.75/1M fino al 31/12/2026 e $1.50/1M dal 01/01/2027: qui sta il prezzo pieno, cosi' la stima sbaglia per eccesso invece di dover rincorrere il rialzo a Capodanno." },
     "claude": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input), il default del codice · VERIFICATO 23/08/2026. Claude Opus 5 costa $5/1M: chi sceglie il premium spende ~1.7x questa stima." },
+    "anthropic": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input) · ALIAS DI CATENA: stessa fn e stesso prezzo di 'claude' qui sopra. Se cambi 'claude', cambia anche queste tre righe: sono lo stesso vendor, e lasciarle indietro lo prezza in due modi diversi nella stessa esecuzione." },
+    "anthropic-claude4": { "per1kUsd": 0.003, "note": "Claude Sonnet 4.6 ($3/1M input) · ALIAS DI CATENA: stessa fn di 'anthropic'. Muovere insieme a 'claude'." },
+    "anthropic-premium": { "per1kUsd": 0.005, "note": "Claude Opus 5 ($5/1M input) · ALIAS DI CATENA: la variante premium, il preset 'Massima Qualita'' parte da qui. NON e' il prezzo di 'claude': Opus costa ~1.7x Sonnet, quindi questa riga si muove con 'claude' ma non copia la sua cifra." },
     "deepseek": { "per1kUsd": 0.00044, "note": "DeepSeek V4 Flash, tariffa di PICCO ($0.44/1M input cache-miss) · RIVERIFICATO 23/08/2026 su api-docs.deepseek.com · fuori picco costa la meta'" },
     "mistral": { "per1kUsd": 0.00015, "note": "Mistral Small 4 ($0.15/1M input), il modello che il codice chiama davvero · VERIFICATO 23/08/2026 su mistral.ai/pricing/api. Catalogo e tendina allineati al codice il 23/08: prima dicevano Large 3 e 'Large 2'." },
     "qwen": { "per1kUsd": 0.000115, "note": "Qwen Plus (= qwen-plus-2025-12-01) via endpoint Pechino, scaglione 0-128K ($0.115/1M input) · VERIFICATO 24/08/2026 su alibabacloud.com/help/en/model-studio/billing-for-model-studio. Prima del 24/08 qwen non aveva una voce qui e cadeva sul fallback 0.002: 17x il prezzo vero. Il prezzo vale finche' i batch restano da 20 stringhe (~1-3K token): oltre i 128K per richiesta lo scaglione triplica." },
@@ -18,6 +21,7 @@
     "fireworks": { "per1kUsd": 0.0009, "note": "Llama 3.3 70B su Fireworks, fascia >16B parametri ($0.90/1M) · VERIFICATO 24/08/2026 su docs.fireworks.ai" },
     "openrouter": { "per1kUsd": 0.001, "note": "Varia per modello" },
     "deepl": { "per1kUsd": 0.02, "note": "DeepL Pro" },
+    "deepl-voice": { "per1kUsd": 0.02, "note": "DeepL Voice · ALIAS DI CATENA: tetto prudenziale, cioe' il prezzo della voce 'deepl', perche' un listino separato non e' mai stato verificato. Muovere insieme a 'deepl'." },
     "google": { "per1kUsd": 0.00002, "note": "Google Translate" }
   },
   "models": {


### PR DESCRIPTION
Follow-up to #169, which closed the site catalog's gap for six providers and left this one open as a decision rather than settling it.

### The gap

`docs/sito/config/models.json` overrides the bundled config **per key**. It carried `claude` and `deepl` but none of the chain aliases that resolve to the same functions, so the file could reprice `claude` while `anthropic`, `anthropic-claude4` and `anthropic-premium` kept the bundled number. Same vendor, two prices, inside a single run. `deepl` and `deepl-voice` had the same gap.

Nothing is broken today — the numbers happen to agree — but the file exists precisely so prices can be changed without shipping the app, and the next person to use it that way would have split them without noticing.

### What this adds

The four keys, placed where the coupling is visible rather than appended at the end: the three `anthropic*` aliases directly under `claude`, `deepl-voice` directly under `deepl`.

| Key | Price | |
|---|---|---|
| `anthropic` | 0.003 | same fn and price as `claude` |
| `anthropic-claude4` | 0.003 | same fn as `anthropic` |
| `anthropic-premium` | **0.005** | Opus 5, not Sonnet |
| `deepl-voice` | 0.02 | prudential ceiling, no separate list price ever verified |

Their notes say they move together with the vendor above them. `anthropic-premium`'s note says the thing that is easy to get wrong while applying that rule: it follows `claude` but **does not copy its figure**. Opus is ~1.7x Sonnet, and that is the entry the "Massima Qualità" preset starts from — the one quoted at 2.5x under the truth before #165 priced it at all.

The file goes to `version: 5` and now holds twenty keys, every one equal to its bundled counterpart, checked key by key.

The nine local and free providers stay out, for the reason given in #169: their price is structurally zero, so a remote override buys nothing and only adds another value to keep in sync.

### Verification

Typecheck clean. `remote-config`, `remote-config-sito` and `chain-cost` suites green, 56 tests.

The guard added in #169 already covers this change: all four keys pass the "no provider the app does not know" check because each exists in `BUNDLED_MODEL_CONFIG`. A typo in any of the four names would have turned that test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
