### PR TITLE
Stop the test suite from running the agent worktrees' copy of itself

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '**/dist/**',
+      // I worktree degli agenti sotto .claude/ sono checkout completi del repo:
+      // senza questa riga la suite raccoglie ANCHE i loro __tests__, gira ogni
+      // file due volte e valuta una copia potenzialmente vecchia del codice
+      // come se fosse questa. Nota: dichiarare `exclude` sostituisce l'elenco
+      // di default di vitest, non lo estende — per questo node_modules e dist
+      // sono riscritti a mano qui sopra, e per questo un percorso che manca qui
+      // non e' escluso da nessun'altra parte.
+      '**/.claude/**',
       '**/e2e/**',
       '**/tests/e2e/**',
       '**/.next/**',


### PR DESCRIPTION
`.claude/worktrees/` holds full checkouts of the repo, so their `__tests__` were being collected alongside the real ones.

**73 duplicate test files against 75 real ones.** The suite has been running at nearly twice its size, and half of what it graded was a copy of the code from whenever that worktree was made, not the code in this tree. A passing run said less than it appeared to.

### The fix

One line in `vitest.config.ts`:

```ts
'**/.claude/**',
```

The exclude list already spelled out `node_modules` and `dist` by hand, which is the tell: declaring `exclude` **replaces** vitest's default list rather than extending it, so a path missing there is not excluded anywhere else. The comment now says so, because it is both the reason this entry had to exist and the reason the next omission will be just as silent.

### Verification

Collection measured before and after, not just a green run:

| | before | after |
|---|---|---|
| files collected | 148 | **75** |
| of those, from `.claude/` | 73 | **0** |

All 75 real files are still collected — nothing legitimate was excluded, only the duplicates removed. On a three-file sample, `Test Files` went from 4 to 2 with the same tests inside.

### It does not make CI faster

An earlier version of this description predicted the test jobs would get shorter. This PR's own run says otherwise:

| Job | #168 | #169 | #171 (with the fix) |
|---|---|---|---|
| check-windows | 13m 01s | 12m 13s | **14m 24s** |
| check-linux | 2m 24s | 2m 06s | **2m 10s** |
| frontend-checks | 5m 55s | 5m 48s | **5m 10s** |

All inside the noise, with Windows the slowest of the three. The likely reason was already visible in local runs: the cost is dominated by jsdom environment setup, not by executing the tests — 40 seconds of `environment` for 4 files. Halving a count of cheap files does not move it.

The value here is correctness, not speed: the suite stops grading a stale copy of the code as though it were this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
