### PR TITLE
Write down the date whisper-1 stops answering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,6 +207,17 @@
 
 - [ ] **Bundle e avvio**: continuare lo slimming delle route pesanti (~700 kB),
   misurare il cold-start.
+- [ ] **`whisper-1` esce dall'API OpenAI il 26/02/2027** — scadenza dura, non
+  un consiglio: dal 26/02/2027 il modello non risponde piu' e i due punti che lo
+  chiamano smettono di trascrivere. Sono `components/audio-translation.tsx` e
+  `components/voice/voice-translator.tsx`, entrambi verso
+  `POST /v1/audio/transcriptions` con `model: 'whisper-1'`; la tendina STT di
+  `app/dubbing/page.tsx` offre lo stesso percorso come "OpenAI Whisper".
+  Sostituti indicati da OpenAI: **`gpt-transcribe`** e **`gpt-live-transcribe`**.
+  Attenzione a dove si migra: nello stesso annuncio (26/08/2026) sono deprecati
+  anche `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` e `gpt-4o-transcribe-diarize`,
+  quindi puntare li' significherebbe rifare il lavoro. Il ramo Groq
+  (`groq_whisper`) non e' toccato: e' un altro fornitore.
 - [x] **Fix alla radice del bug `ship` su Windows** — fatto 13/07/2026:
   `confirm()` ora usa readline (una riga alla volta, funziona su Windows)
   invece di `fs.readFileSync(0)` che attendeva EOF. `--yes` resta per CI.

--- a/components/audio-translation.tsx
+++ b/components/audio-translation.tsx
@@ -173,6 +173,9 @@ const AudioTranslation: React.FC<AudioTranslationProps> = ({
     setProgress(20);
     const formData = new FormData();
     formData.append('file', audioBlob, 'audio.webm');
+    // ⏰ whisper-1 esce dall'API OpenAI il 26/02/2027 (annuncio 26/08/2026).
+    // Sostituti: gpt-transcribe / gpt-live-transcribe. NON gpt-4o-transcribe:
+    // e' deprecato nello stesso annuncio. Vedi ROADMAP.md, P2.
     formData.append('model', 'whisper-1');
     formData.append('response_format', 'verbose_json');
 

--- a/components/voice/voice-translator.tsx
+++ b/components/voice/voice-translator.tsx
@@ -253,6 +253,9 @@ export function VoiceTranslator() {
       // Crea FormData per Whisper API (richiede file, non base64)
       const formData = new FormData();
       formData.append('file', state.audioBlob, 'audio.webm');
+      // ⏰ whisper-1 esce dall'API OpenAI il 26/02/2027 (annuncio 26/08/2026).
+      // Sostituti: gpt-transcribe / gpt-live-transcribe. NON gpt-4o-transcribe:
+      // e' deprecato nello stesso annuncio. Vedi ROADMAP.md, P2.
       formData.append('model', 'whisper-1');
       formData.append('response_format', 'verbose_json');
       if (state.sourceLanguage !== 'auto') {


### PR DESCRIPTION
OpenAI's 26/08/2026 notice removes `whisper-1` from the API on **26/02/2027**, and this app calls it:

- `components/audio-translation.tsx` and `components/voice/voice-translator.tsx` both POST `/v1/audio/transcriptions` with `model: 'whisper-1'`
- the STT dropdown in `app/dubbing/page.tsx` offers that same path as "OpenAI Whisper"

On that date transcription stops, and nothing in the code checks that the model still exists — so the date goes where someone will actually meet it: a dated item in `ROADMAP.md` under P2, and three comment lines at each call site.

The comment carries the part that is easy to get wrong: the replacements are **`gpt-transcribe`** and **`gpt-live-transcribe`**, and `gpt-4o-transcribe` is *not* one of them — it was deprecated in the same notice along with `gpt-4o-mini-transcribe` and `gpt-4o-transcribe-diarize`. Migrating there would buy the same work twice.

The Groq branch (`groq_whisper`) is untouched: different vendor, different lifecycle.

No behaviour changes — comments and a roadmap line. `npm run typecheck` and `npm run i18n:check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)