### PR TITLE
Point the exported patch READMEs at the repository that exists

### DIFF
--- a/lib/patch-exporter.ts
+++ b/lib/patch-exporter.ts
@@ -408,7 +408,7 @@ NOTES
 ${metadata.notes || 'No additional notes.'}
 
 This translation was created using GameStringer.
-Report issues or contribute at: https://github.com/your-repo/gamestringer
+Report issues or contribute at: https://github.com/rouges78/GameStringer
 
 ================================================================================
 `.trim();
@@ -483,6 +483,7 @@ NOTE
 ${metadata.notes || 'Nessuna nota aggiuntiva.'}
 
 Questa traduzione è stata creata usando GameStringer.
+Segnala problemi o contribuisci su: https://github.com/rouges78/GameStringer
 
 ================================================================================
 `.trim();


### PR DESCRIPTION
Every translation patch GameStringer exports bundles a `README.txt`, and its last line sent people to `https://github.com/your-repo/gamestringer` — a placeholder nobody ever replaced. Anyone who received a patch and wanted to report a problem landed on a 404. Nothing on our side could notice: the text leaves the app inside a zip and fails on someone else's machine.

**Changes** (`lib/patch-exporter.ts`, two lines):

- `generateReadme` — the placeholder now points at `https://github.com/rouges78/GameStringer`.
- `generateReadmeItalian` — `LEGGIMI.txt` ships in the same zip (`patch-exporter.ts:114-116`) but never had the line at all. It gets the matching one, *«Segnala problemi o contribuisci su: …»*, so a reader of either file finds the same way back. Added after checking with the maintainer, not silently.

**Checked:**

- The same placeholder shape (`your-repo`, `your-org`, `username`) across `.ts`, `.tsx` and `.md`, excluding `node_modules` and agent worktrees: no other occurrence.
- `npm run typecheck`: clean.
- `npm run i18n:check`: at baseline (802), no new hardcoded strings.
- `npm test`: 944 passed, 37 skipped.

Found on 09/09/2026 while auditing the GitHub URLs the app references. It belongs to the family of defects in `docs/digests/2026-08-23-digest-traduzioni.md`: pointers that were never true, failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)