### PR TITLE
Send people to gdsdecomp where it lives now

### DIFF
--- a/components/tools/unity-patcher.tsx
+++ b/components/tools/unity-patcher.tsx
@@ -644,7 +644,7 @@ export function UnityPatcher() {
                           ) : isUnreal ? (
                             <a href="https://github.com/akintos/UnrealLocres/releases" target="_blank" rel="noopener" className="text-amber-400 hover:text-amber-300 underline">⚠ UnrealLocres</a>
                           ) : selectedGame.engine?.toLowerCase() === 'godot' ? (
-                            <a href="https://github.com/bruvzg/gdsdecomp/releases" target="_blank" rel="noopener" className="text-amber-400 hover:text-amber-300 underline">⚠ gdsdecomp</a>
+                            <a href="https://github.com/GDRETools/gdsdecomp/releases" target="_blank" rel="noopener" className="text-amber-400 hover:text-amber-300 underline">⚠ gdsdecomp</a>
                           ) : (
                             <span className="text-amber-400">⚠ {t('gamePatcher.externalTools')}</span>
                           )}

--- a/src-tauri/src/commands/unity_patcher.rs
+++ b/src-tauri/src/commands/unity_patcher.rs
@@ -1370,14 +1370,14 @@ pub async fn check_game_engine(game_path: String) -> Result<GameEngineCheck, Str
         
         alternative_tools.push(AlternativeTool {
             name: "Godot RE Tools (gdsdecomp)".to_string(),
-            url: "https://github.com/bruvzg/gdsdecomp".to_string(),
+            url: "https://github.com/GDRETools/gdsdecomp".to_string(),
             description: "Decompila e modifica progetti Godot 3.x/4.x".to_string(),
             compatible: true,
         });
         if is_godot4 {
             alternative_tools.push(AlternativeTool {
                 name: "gdre_tools".to_string(),
-                url: "https://github.com/bruvzg/gdsdecomp/releases".to_string(),
+                url: "https://github.com/GDRETools/gdsdecomp/releases".to_string(),
                 description: "Supporto specifico Godot 4.x".to_string(),
                 compatible: true,
             });

--- a/src-tauri/src/commands/universal_injector.rs
+++ b/src-tauri/src/commands/universal_injector.rs
@@ -332,7 +332,7 @@ fn detect_godot(game_dir: &Path) -> Option<EngineDetectionResult> {
         tools_required: vec![
             InjectionTool {
                 name: "Godot RE Tools".to_string(),
-                url: "https://github.com/bruvzg/gdsdecomp".to_string(),
+                url: "https://github.com/GDRETools/gdsdecomp".to_string(),
                 description: "Decompila progetti Godot".to_string(),
                 auto_install: false,
             },


### PR DESCRIPTION
`gdsdecomp` moved from `bruvzg` to the **GDRETools** organization. The old URL still answers, but only because GitHub redirects it: the canonical repository is [`GDRETools/gdsdecomp`](https://github.com/GDRETools/gdsdecomp) — latest release v2.6.4 (12/08/2026), not archived. A link that works by courtesy of a redirect is one rename away from a 404, and a provenance check that compares owners reads the old one as a mismatch.

**Four links updated**, all shown to the user when the app meets a Godot game. None of them parses owner or repo out of the string:

| File | What |
|---|---|
| `components/tools/unity-patcher.tsx` | the "⚠ gdsdecomp" link for Godot games |
| `src-tauri/src/commands/unity_patcher.rs` | both `AlternativeTool` entries (the tool, and its `/releases` page for Godot 4) |
| `src-tauri/src/commands/universal_injector.rs` | the Godot `InjectionTool` |

**Left alone on purpose:** `docs/i18n/audit-untranslated-2026-07-04.md` quotes the string as it read on 04/07. It is a dated record; rewriting it would make it say something that was not true that day.

**Checked:** no `bruvzg` left in `components/`, `lib/`, `app/`, `src-tauri/src/` or `docs/sito/` · `npm run typecheck` clean · `npm run i18n:check` at baseline (802) · `npm test` 944 passed, 37 skipped. The Rust edits are string literals only; `cargo check` runs in CI (`check-windows`, `check-linux`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)