### PR TITLE
Record how Fran Bow stores its languages, and give Unity a registry section

### DIFF
--- a/docs/METODI-DI-TRADUZIONE.md
+++ b/docs/METODI-DI-TRADUZIONE.md
@@ -274,6 +274,103 @@ per un difetto suo: per una condizione a monte che non poteva essere vera.
 Prima di credere che un percorso funzioni, va provato con un input che lo
 imbocchi davvero — qui è bastato installare un gioco.
 
+## Unity
+
+### Fran Bow: sei lingue fisse per frase in `resources.assets`, e i font sono già pronti per l'italiano
+
+**Il fatto.** In Fran Bow (Unity 2021.3.16f1, Mono) ogni frase del gioco è un
+array di 6 stringhe, una per lingua, dentro `resources.assets`: è l'unico file
+con testo non inglese, i 145 file di scena `levelN` contengono solo inglese. Le
+colonne sono fisse, nell'ordine **pt · fr · de · ru · es · en**. L'italiano non
+c'è, e aggiungerlo come settima lingua vuol dire toccare il codice del gioco. Le
+tabelle font TextMeshPro invece hanno già tutte le accentate italiane: per
+l'italiano non serve nessun override di font.
+
+**Misura.** Fran Bow, Steam app 362680, build 11189293, 12/09/2026:
+
+```bash
+node scripts/unity-loc-probe.js "C:/Program Files (x86)/Steam/steamapps/common/Fran Bow/Fran Bow_Data"
+```
+
+| Cosa | Risultato |
+|---|---|
+| Tabelle font TMP | 3 (due in `resources.assets` da 250 caratteri, una in `sharedassets0.assets` da 235): a nessuna manca `à è é ì ò ù À È É Ì Ò Ù ’` |
+| File con testo non inglese | 1 su 146: `resources.assets` |
+| Righe di localizzazione | 8.325, su 8.340 array di 6 stringhe (i 15 scartati sono keyword shader come `UNITY_UI_ALPHACLIP`) |
+| Inglese | 300.563 caratteri, 58.186 parole · lunghezza mediana 35, 95° percentile 73, massimo 98 |
+| Formattazione | 0 tag rich text, 0 segnaposto `{…}` o `%s` · 11 «a capo» e 8 azioni tra asterischi (`*hic*`) da preservare |
+| Spazio a schermo | francese/inglese: mediana 1,16, 95° percentile 1,50 — l'italiano sta in questa fascia, e il gioco la mostra già |
+
+Le stringhe sono nel formato Unity standard (int32 lunghezza + UTF-8, allineate a
+4 byte), non Odin, anche se `Sirenix.Serialization.dll` è tra le assembly del
+gioco. Le lingue ufficiali, dall'API di Steam:
+
+```bash
+curl -s "https://store.steampowered.com/api/appdetails?appids=362680&l=english" \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s)['362680'].data.supported_languages.replace(/<[^>]+>/g,'')))"
+```
+
+→ `English, German, Spanish - Spain, Russian, French, Portuguese - Brazil`. E
+nei dati del gioco la parola `Italiano` compare zero volte.
+
+**Cosa ne segue per il metodo.** Due strade, **nessuna ancora provata in gioco**:
+
+- **XUnity via BepInEx (la più sicura).** GameStringer riconosce il gioco come
+  Mono (`MonoBleedingEdge` presente, `GameAssembly.dll` assente), e fra i
+  pacchetti di `unity_patcher.rs` c'è BepInEx 5.4.23.5 x64 per Mono, adatto a
+  Unity 2021.3. `needs_font_override("it")` è falso, ed è giusto così: i glifi
+  ci sono. Non si tocca `resources.assets`.
+- **File-based, sovrascrivendo una colonna.** Due ostacoli misurati. Il testo
+  italiano è più lungo, quindi `resources.assets` va riserializzato, non
+  patchato in-place: in GameStringer lo fa `tools/unity_inject.py` tramite
+  `unity_asset_injector.rs`, parte non coperta dalla CI. E lo scan euristico di
+  `unity_assets.rs` **scarterebbe 1.057 righe inglesi su 8.324** («Eww!»,
+  «No... Um.», «A door!», «Jump...»), perché `looks_like_game_text` vuole almeno
+  uno spazio e più di 5 lettere. Prima dell'euristica, `scan_assets_for_text`
+  prova a estrarre i TextAsset, mentre queste frasi stanno in campi di script:
+  quale dei due rami parta su questo file **non è stato verificato**.
+
+*Sospetto, non misurato:* nei file di scena compaiono chiavi come
+`Mr. Midnight.: Use`, e tra le righe ci sono pezzi di frase. Se il gioco compone
+le battute a runtime, un italiano tradotto a pezzi rischia accordi sbagliati con
+le preposizioni articolate (a + la → «alla»), mentre XUnity vede la frase già
+composta.
+
+**Nel codice.**
+
+- `scripts/unity-loc-probe.js` — la sonda di questa voce, sola lettura.
+- `src-tauri/src/commands/unity_patcher.rs` — `BEPINEX5_X64_URL`, rilevamento
+  Mono/IL2CPP (`is_il2cpp`), `needs_font_override`.
+- `src-tauri/src/commands/unity_assets.rs` — `scan_assets_for_text`,
+  `looks_like_game_text`.
+- `src-tauri/src/commands/unity_asset_injector.rs` → `tools/unity_inject.py`.
+- `src-tauri/src/commands/gamemaker_patcher.rs` — `find_data_win` (vedi trappola 5).
+
+**Trappole.**
+
+1. **La ricerca web ha detto che l'italiano c'è.** Era un riassunto automatico
+   sbagliato. La pagina Steam sta dietro la verifica dell'età e un fetch non la
+   legge; l'API `appdetails` sì. Le lingue ufficiali si leggono lì, e si
+   confermano nei file.
+2. **«Mr. Midnight» nei `levelN` sembrava dialogo.** Lì ci sono solo inglese e
+   chiavi. Si contano parole-spia per lingua e per file, invece di fidarsi della
+   prima occorrenza.
+3. **La prima firma di record prendeva il menu, non i dialoghi.** Ancorata ai
+   campi che precedono l'array (`-1`, `0`, ID, …, `9`, `6`) trovava 48 righe con
+   ID 8726–8773: i nomi delle lingue. Le frasi hanno un'intestazione diversa;
+   l'unica cosa comune a tutte è l'array di 6 stringhe.
+4. **Un array di 6 stringhe non è per forza una frase.** Anche 15 liste di
+   keyword shader hanno quella forma, e gonfiavano ogni conteggio. Il filtro che
+   le separa si ricava dai dati: colonna russa in cirillico, oppure uguale
+   all'inglese.
+5. **La cartella `Fran Bow GameMaker` non confonde nessuno.** Contiene il
+   `data.win` della versione originale del 2015. `detect_gamemaker` guarda solo
+   la radice, e `find_data_win` pure: il suo ramo commentato «Subdirectories»
+   itera la radice e tiene solo i file, quindi nelle sottocartelle non scende.
+6. **Ambiente.** In Git Bash non c'è `strings`, e Python sulla console Windows
+   (cp1252) si ferma stampando caratteri come `ő`. Per questo la sonda è in
+   Node, come le altre in `scripts/`.
+
 ## Traduzione in tempo reale (IPC)
 
 ### Stato della catena — aggiornato al 21/08/2026

--- a/scripts/unity-loc-probe.js
+++ b/scripts/unity-loc-probe.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * unity-loc-probe.js — sonda SOLA LETTURA della localizzazione di un gioco Unity.
+ *
+ * Nata il 12/09/2026 su Fran Bow (Unity 2021.3.16f1, Mono, app Steam 362680),
+ * per rispondere PRIMA di tradurre alle domande che decidono il metodo:
+ *
+ *  1. I font TextMeshPro del gioco hanno le lettere della lingua di arrivo?
+ *     Un atlante SDF contiene solo i glifi scelti al momento del build: se manca
+ *     «ì», in gioco si vede un quadrato e nessuna traduzione lo aggiusta.
+ *  2. Dove stanno le traduzioni esistenti, e com'è fatto il testo?
+ *
+ * Non modifica nulla e non deserializza: cerca pattern di byte.
+ *  - Tabelle font TMP: voci TMP_Character consecutive da 16 byte
+ *    (m_ElementType=1 · m_Unicode · m_GlyphIndex · m_Scale=1.0f).
+ *  - Array di lingue: int32 = 6 seguito da 6 stringhe Unity (int32 lunghezza +
+ *    UTF-8, allineate a 4 byte).
+ * L'ordine delle colonne NON viene assunto: si ricava contando in ogni colonna
+ * parole tipiche di ciascuna lingua.
+ *
+ * Limite noto: un font con atlante dinamico può avere la tabella vuota nel file,
+ * e allora qui non compare. Su Fran Bow il russo si vede in gioco ma nessuna
+ * tabella trovata contiene cirillico: i font elencati non sono per forza tutti.
+ *
+ * Uso: node scripts/unity-loc-probe.js "<gioco>/<Nome>_Data" ["glifi da cercare"]
+ *      (glifi di default: le accentate italiane e l'apostrofo tipografico)
+ */
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = process.argv[2];
+if (!dataDir || !fs.existsSync(path.join(dataDir, 'globalgamemanagers'))) {
+  console.error('Uso: node scripts/unity-loc-probe.js "<gioco>/<Nome>_Data" ["glifi"]');
+  process.exit(2);
+}
+const glyphs = [...(process.argv[3] || 'àèéìòùÀÈÉÌÒÙ’')];
+
+// File serializzati: *.assets e i file di scena levelN (senza estensione).
+// .resS e .resource sono texture e audio: niente testo né tabelle font.
+const serialized = fs.readdirSync(dataDir)
+  .filter(f => f.endsWith('.assets') || /^level\d+$/.test(f))
+  .sort((a, b) => a.localeCompare(b, 'en', { numeric: true }));
+
+const ggm = fs.readFileSync(path.join(dataDir, 'globalgamemanagers'));
+const version = ggm.toString('latin1').match(/20\d\d\.\d+\.\d+[abfp]\d+/);
+console.log(`Unity ${version ? version[0] : '(versione non trovata)'} · ${serialized.length} file serializzati`);
+
+// Parole che compaiono quasi solo nella lingua indicata: servono a riconoscere
+// le colonne e a capire quali file contengono testo non inglese.
+const MARKERS = { en: ' you ', fr: ' vous ', de: ' nicht ', es: ' pero ', pt: 'você', ru: ' не ' };
+
+function countOf(buf, needle) {
+  let n = 0;
+  for (let p = buf.indexOf(needle); p !== -1; p = buf.indexOf(needle, p + needle.length)) n++;
+  return n;
+}
+
+// ── Tabelle font TMP ────────────────────────────────────────────────────────
+const FLOAT_ONE = Buffer.from([0x00, 0x00, 0x80, 0x3f]);
+function fontTables(buf) {
+  const tables = [];
+  let run = [], prev = -1, runStart = -1;
+  const close = () => { if (run.length >= 60) tables.push({ offset: runStart, chars: new Set(run) }); };
+  for (let p = buf.indexOf(FLOAT_ONE); p !== -1; p = buf.indexOf(FLOAT_ONE, p + 1)) {
+    const s = p - 12;
+    if (s < 0 || buf.readUInt32LE(s) !== 1) continue;
+    const u = buf.readUInt32LE(s + 4);
+    if (u > 0x2ffff) continue;
+    if (s === prev + 16) run.push(u);
+    else { close(); run = [u]; runStart = s; }
+    prev = s;
+  }
+  close();
+  // Una tabella vera contiene quasi tutto l'ASCII stampabile; il resto è rumore
+  // (1.0f come scala di un transform capita ovunque).
+  return tables.filter(t => {
+    t.ascii = 0;
+    for (let c = 0x20; c < 0x7f; c++) if (t.chars.has(c)) t.ascii++;
+    return t.ascii >= 80;
+  });
+}
+
+console.log(`\n== 1. Tabelle font TextMeshPro · glifi cercati: ${glyphs.join(' ')} ==`);
+let tableCount = 0;
+const textFiles = [];
+for (const f of serialized) {
+  const buf = fs.readFileSync(path.join(dataDir, f));
+  for (const t of fontTables(buf)) {
+    tableCount++;
+    const missing = glyphs.filter(g => !t.chars.has(g.codePointAt(0)));
+    const has = ch => (t.chars.has(ch.codePointAt(0)) ? 'sì' : 'no');
+    console.log(`${f} @0x${t.offset.toString(16)}: ${t.chars.size} caratteri (ASCII ${t.ascii}/95)` +
+      ` · mancanti: ${missing.join(' ') || 'nessuno'} · ñ=${has('ñ')} ő=${has('ő')} Ж=${has('Ж')}`);
+  }
+  const counts = {};
+  for (const [lang, word] of Object.entries(MARKERS)) counts[lang] = countOf(buf, Buffer.from(word));
+  if (Object.values(counts).some(Boolean)) textFiles.push({ f, counts });
+}
+console.log(`tabelle trovate: ${tableCount}`);
+
+// ── Dove sta il testo ───────────────────────────────────────────────────────
+console.log('\n== 2. File con testo, per lingua (occorrenze delle parole-spia) ==');
+const nonEnglish = textFiles.filter(t => Object.entries(t.counts).some(([l, n]) => l !== 'en' && n > 0));
+for (const t of nonEnglish) console.log(`${t.f}: ${Object.entries(t.counts).map(([l, n]) => `${l}=${n}`).join(' ')}`);
+console.log(`file con testo non inglese: ${nonEnglish.length} · file con solo inglese: ${textFiles.length - nonEnglish.length}`);
+
+// ── Array di lingue in resources.assets ─────────────────────────────────────
+const resPath = path.join(dataDir, 'resources.assets');
+if (!fs.existsSync(resPath)) { console.log('\nresources.assets assente: sezione 3 saltata'); process.exit(0); }
+const res = fs.readFileSync(resPath);
+const dec = new TextDecoder('utf-8', { fatal: true });
+
+function unityString(buf, p) {
+  if (p + 4 > buf.length) return null;
+  const len = buf.readUInt32LE(p);
+  if (len > 20000 || p + 4 + len > buf.length) return null;
+  const bytes = buf.subarray(p + 4, p + 4 + len);
+  if (bytes.includes(0)) return null;
+  let text;
+  try { text = dec.decode(bytes); } catch { return null; }
+  const end = p + 4 + len;
+  return { text, next: end + ((4 - (end % 4)) % 4) };
+}
+
+const SIX = Buffer.from([6, 0, 0, 0]);
+const arrays = [];
+for (let p = res.indexOf(SIX); p !== -1; p = res.indexOf(SIX, p + 1)) {
+  if (p % 4) continue;
+  const vals = [];
+  let q = p + 4;
+  for (let i = 0; i < 6; i++) {
+    const s = unityString(res, q);
+    if (!s) break;
+    vals.push(s.text);
+    q = s.next;
+  }
+  // Almeno 4 valori pieni e 3 diversi: scarta liste di sei stringhe uguali.
+  if (vals.length === 6 && vals.filter(Boolean).length >= 4 && new Set(vals).size >= 3) arrays.push(vals);
+}
+console.log('\n== 3. resources.assets: array di 6 stringhe (una per lingua) ==');
+console.log(`array trovati: ${arrays.length}`);
+if (!arrays.length) process.exit(0);
+
+const matrix = Array.from({ length: 6 }, () => ({}));
+for (const vals of arrays) {
+  vals.forEach((v, i) => {
+    for (const [lang, word] of Object.entries(MARKERS)) if (v.includes(word)) matrix[i][lang] = (matrix[i][lang] || 0) + 1;
+  });
+}
+const slotOf = lang => matrix.reduce((best, row, i) => ((row[lang] || 0) > (matrix[best][lang] || 0) ? i : best), 0);
+matrix.forEach((row, i) => console.log(`colonna ${i}: ${Object.keys(MARKERS).map(l => `${l}=${row[l] || 0}`).join(' ')}`));
+const order = Object.keys(MARKERS).map(l => [slotOf(l), l]).sort((a, b) => a[0] - b[0]).map(([i, l]) => `${i}=${l}`);
+console.log(`ordine ricavato: ${order.join(' · ')}`);
+
+const EN = slotOf('en'), FR = slotOf('fr'), RU = slotOf('ru');
+// Non ogni array di 6 stringhe è una frase: passano anche liste di keyword shader
+// (UNITY_UI_ALPHACLIP…). Una riga di localizzazione vera ha cirillico nella colonna
+// russa, oppure la stessa stringa dell'inglese (nomi propri, numeri).
+const hasRussian = (matrix[RU].ru || 0) > 0;
+const rows = hasRussian ? arrays.filter(v => /\p{Script=Cyrillic}/u.test(v[RU]) || v[RU] === v[EN]) : arrays;
+const kept = new Set(rows);
+const noise = arrays.filter(v => !kept.has(v));
+console.log(hasRussian
+  ? `righe di localizzazione: ${rows.length} · scartati come non-frasi: ${noise.length}  es: ${noise.slice(0, 4).map(v => JSON.stringify(v[EN])).join(' ')}`
+  : `righe di localizzazione: ${rows.length} (nessuna colonna russa riconosciuta: nessun filtro)`);
+
+const en = rows.map(v => v[EN]).filter(Boolean);
+const chars = en.reduce((n, s) => n + [...s].length, 0);
+const words = en.reduce((n, s) => n + s.split(/\s+/).filter(Boolean).length, 0);
+const lens = en.map(s => [...s].length).sort((a, b) => a - b);
+const at = (xs, q) => xs[Math.floor(xs.length * q)];
+console.log(`\ninglese: ${chars} caratteri, ${words} parole (stima grezza ~${Math.floor(chars / 4)} token)`);
+console.log(`lunghezza: mediana ${at(lens, 0.5)} · 95° percentile ${at(lens, 0.95)} · massimo ${lens[lens.length - 1]}`);
+
+const FEATURES = {
+  'tag rich text <…>': /<[a-zA-Z/][^>]*>/, 'segnaposto {…}': /\{[^}]*\}/, 'printf %s %d': /%[sdif0-9]/,
+  'a capo': /\n/, 'tra quadre […]': /\[[^\]]*\]/, 'tra asterischi *…*': /\*[^*]+\*/,
+};
+for (const [name, rx] of Object.entries(FEATURES)) {
+  const hits = en.filter(s => rx.test(s));
+  console.log(`  ${name}: ${hits.length}${hits.length ? `  es: ${JSON.stringify(hits[0].slice(0, 90))}` : ''}`);
+}
+const ratios = rows
+  .filter(v => [...v[EN]].length >= 20)
+  .map(v => [...v[FR]].length / [...v[EN]].length)
+  .sort((a, b) => a - b);
+console.log(`francese/inglese (stringhe da 20 caratteri in su): mediana ${at(ratios, 0.5).toFixed(2)} · 95° percentile ${at(ratios, 0.95).toFixed(2)}`);
+
+// Stessa regola di looks_like_game_text in src-tauri/src/commands/unity_assets.rs,
+// il filtro dello scan euristico: più di 5 lettere, almeno uno spazio, e meno del
+// 40% di simboli sul numero di BYTE (text.len() in Rust conta byte UTF-8).
+const SAFE_PUNCT = new Set([...'.,!?:;\'-"()[]{}']);
+const looksLikeGameText = s => {
+  const alpha = [...s].filter(c => /\p{Alphabetic}/u.test(c)).length;
+  const symbols = [...s].filter(c => !/[\p{Alphabetic}\p{N}\p{White_Space}]/u.test(c) && !SAFE_PUNCT.has(c)).length;
+  return alpha > 5 && s.includes(' ') && symbols / Buffer.byteLength(s) < 0.4;
+};
+const dropped = en.filter(s => !looksLikeGameText(s));
+console.log(`valori inglesi che looks_like_game_text (unity_assets.rs) scarterebbe: ${dropped.length} su ${en.length}` +
+  `  es: ${dropped.slice(0, 6).map(s => JSON.stringify(s)).join(' ')}`);


### PR DESCRIPTION
`docs/METODI-DI-TRADUZIONE.md` had sections for Unreal, RPG Maker and the runtime IPC chain, and **nothing for Unity**. This adds the section with one measured entry — what stands between Fran Bow and an Italian translation — plus the read-only probe that produced the numbers.

## What was measured

Fran Bow, Steam app 362680, build 11189293, 12/09/2026, with `node scripts/unity-loc-probe.js "<game>/Fran Bow_Data"`:

| | |
|---|---|
| Where the translations live | `resources.assets` only: 1 of 146 files with text; the 145 `levelN` scene files are English-only |
| Layout | each line is an array of 6 strings, fixed order **pt · fr · de · ru · es · en** (order derived from the data, not assumed) |
| Italian | not among the official languages (Steam `appdetails` API), zero occurrences of `Italiano` in the data |
| Fonts | 3 TextMeshPro tables, none missing `à è é ì ò ù À È É Ì Ò Ù ’` |
| Volume | 8,325 localization rows · 300,563 English characters · 58,186 words |
| Formatting | 0 rich-text tags, 0 placeholders · 11 newlines and 8 `*asterisk*` actions to preserve |
| Length | French / English: median 1.16, p95 1.50 |
| GameStringer scanner | `looks_like_game_text` (`unity_assets.rs`) would drop **1,057 of 8,324** English lines, e.g. "Eww!", "A door!" |

## What the entry concludes

Two routes, **neither tried in-game yet** — the entry says so explicitly:

- **XUnity via BepInEx** is the safer one: the game is detected as Mono, BepInEx 5.4.23.5 x64 fits Unity 2021.3, and `needs_font_override("it")` being false is correct here since the glyphs exist.
- **File-based** has two measured obstacles: longer Italian text means reserializing `resources.assets` (done by `tools/unity_inject.py`, not covered by CI), and the heuristic scan drop above. Which branch of `scan_assets_for_text` runs on this file is marked as not verified.

It also records the wrong turns, per the registry format: a web summary claiming Italian was supported, scene strings that looked like dialogue, a record signature that only matched the language menu (48 rows), six-string arrays that are shader keyword lists, and a GameMaker `data.win` in a subfolder that confuses no detector.

## The probe

`scripts/unity-loc-probe.js` — Node, read-only, no deserialization; same style as the other `scripts/*-probe.js`. Runs in about half a second on Fran Bow. Not covered by `tsc` or `next lint` (scripts are outside both scopes), like the existing probes.

**Checked:** the Steam command in the entry runs verbatim · `npm run i18n:check` at baseline (802) · code fences in the registry balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)